### PR TITLE
Add ordered sets in GraphPipeline and MemoryPlanner

### DIFF
--- a/graph/compute.cpp
+++ b/graph/compute.cpp
@@ -2248,12 +2248,17 @@ std::shared_ptr<TensorDescriptor> GraphPipeline::makeTensor(const VkFormat forma
                                                             const std::vector<int64_t> &dimensions,
                                                             const std::vector<int64_t> &strides) {
     auto tensor = std::make_shared<TensorDescriptor>(loader, physicalDevice, device, format, dimensions, strides);
-    tensorSet.insert(tensor);
+
+    auto [iterator, inserted] = tensorSet.insert(tensor);
+
+    if (inserted) {
+        tensors.push_back(tensor);
+    }
 
     return tensor;
 }
 
-const std::set<std::shared_ptr<TensorDescriptor>> &GraphPipeline::getTensorSet() const { return tensorSet; }
+const std::vector<std::shared_ptr<TensorDescriptor>> &GraphPipeline::getTensors() const { return tensors; }
 
 ComputeDescriptorSetMap GraphPipeline::makeSessionRamDescriptorSets() const {
     TensorDescriptorMap filter;

--- a/graph/compute.hpp
+++ b/graph/compute.hpp
@@ -1137,7 +1137,8 @@ class GraphPipeline {
     // Tensors allocated in session ram
     std::shared_ptr<TensorDescriptor> makeTensor(const VkFormat format, const std::vector<int64_t> &dimensions = {},
                                                  const std::vector<int64_t> &strides = {});
-    const std::set<std::shared_ptr<TensorDescriptor>> &getTensorSet() const;
+
+    const std::vector<std::shared_ptr<TensorDescriptor>> &getTensors() const;
 
     // Make descriptor sets
     ComputeDescriptorSetMap makeConstantsDescriptorSets() const;
@@ -1414,6 +1415,8 @@ class GraphPipeline {
 
     // Set of all tensors allocated in session ram
     std::set<std::shared_ptr<TensorDescriptor>> tensorSet;
+
+    std::vector<std::shared_ptr<TensorDescriptor>> tensors;
 
     // Virtual pipelines used to track input and output tensors
     ComputePipelineBase inputs{nullptr};

--- a/graph/memory_planner.hpp
+++ b/graph/memory_planner.hpp
@@ -52,6 +52,8 @@ class LinearMemoryPlanner : public MemoryPlanner {
                                         const ComputeDescriptorSetMap &descriptorSets) override;
 };
 
+using Tensors = std::vector<std::shared_ptr<TensorDescriptor>>;
+
 /*******************************************************************************
  * BestFitMemoryPlanner
  *******************************************************************************/
@@ -69,24 +71,22 @@ class BestFitMemoryPlanner : public MemoryPlanner {
 
     VkDeviceSize memorySize;
 
-    const std::vector<std::shared_ptr<TensorDescriptor>> tensors;
-    const std::map<std::shared_ptr<TensorDescriptor>, std::set<std::shared_ptr<TensorDescriptor>>> safeToReuse;
-    const std::map<std::shared_ptr<TensorDescriptor>, std::vector<std::shared_ptr<TensorDescriptor>>> allAlternatives;
+    const Tensors tensors;
+    const std::map<std::shared_ptr<TensorDescriptor>, Tensors> safeToReuse;
+    const std::map<std::shared_ptr<TensorDescriptor>, Tensors> allAlternatives;
     std::map<std::shared_ptr<TensorDescriptor>, VkDeviceSize> tensorOffsets;
 
   private:
     void allocate(const std::shared_ptr<TensorDescriptor> &tensor, VkDeviceSize memoryAddress);
     std::shared_ptr<TensorDescriptor> findAlternativeTensor(
         const std::shared_ptr<TensorDescriptor> &tensor,
-        const std::map<std::shared_ptr<TensorDescriptor>,
-                       std::shared_ptr<std::vector<std::shared_ptr<TensorDescriptor>>>> &tensorOccupation);
+        const std::map<std::shared_ptr<TensorDescriptor>, std::shared_ptr<Tensors>> &tensorOccupation);
     bool isAllocated(const std::shared_ptr<TensorDescriptor> &tensor) const;
-    bool isSafeToReuse(const std::shared_ptr<std::vector<std::shared_ptr<TensorDescriptor>>> &occupationList,
+    bool isSafeToReuse(const std::shared_ptr<Tensors> &occupationList,
                        const std::shared_ptr<TensorDescriptor> &tensor) const;
-    std::map<std::shared_ptr<TensorDescriptor>, std::set<std::shared_ptr<TensorDescriptor>>> liveTensorAnalysis() const;
-    std::vector<std::shared_ptr<TensorDescriptor>> createInitialTensorOrder() const;
-    std::map<std::shared_ptr<TensorDescriptor>, std::vector<std::shared_ptr<TensorDescriptor>>>
-    createAllAlternatives() const;
+    std::map<std::shared_ptr<TensorDescriptor>, Tensors> liveTensorAnalysis() const;
+    Tensors createInitialTensorOrder() const;
+    std::map<std::shared_ptr<TensorDescriptor>, Tensors> createAllAlternatives() const;
     std::vector<ComputePipelineBase *> getTopologicalOrder() const;
 };
 


### PR DESCRIPTION
Add an ordered set for tensors in GraphPipeline.
Add an ordered carryOn set for pipelines in MemoryPlanner and updates safeToReuse for each tensor to be ordered. This is required for getGraphPipelineSessionMemoryRequirements to be deterministic.