### PR TITLE
Enable features used in unit tests

### DIFF
--- a/tests/vulkan.cpp
+++ b/tests/vulkan.cpp
@@ -304,7 +304,16 @@ std::shared_ptr<Device> createDevice() {
         layers.emplace_back("VK_LAYER_KHRONOS_validation");
     }
 
-    return makeDevice(layers, extensions);
+    // Enable base features
+    vk::PhysicalDeviceFeatures baseFeatures = {};
+    baseFeatures.shaderInt64 = VK_TRUE;
+    baseFeatures.shaderFloat64 = VK_TRUE;
+
+    // Create the features2 wrapper
+    vk::PhysicalDeviceFeatures2 features2 = {};
+    features2.setFeatures(baseFeatures);
+
+    return makeDevice(layers, extensions, &features2);
 }
 
 } // namespace

--- a/utilities/include/mlel/device.hpp
+++ b/utilities/include/mlel/device.hpp
@@ -71,7 +71,8 @@ class PhysicalDevice {
 
 class Device {
   public:
-    Device(const std::shared_ptr<PhysicalDevice> &_physicalDevice, const std::vector<const char *> &deviceExtensions);
+    Device(const std::shared_ptr<PhysicalDevice> &_physicalDevice, const std::vector<const char *> &deviceExtensions,
+           const void *deviceFeatures);
 
     vk::raii::Device const &operator&() const;
     const std::shared_ptr<PhysicalDevice> &getPhysicalDevice() const;
@@ -80,8 +81,8 @@ class Device {
                          const uint32_t memoryTypeBits = 0xffffffff) const;
 
   private:
-    vk::raii::Device createDevice(const std::vector<const char *> &layers,
-                                  const std::vector<const char *> &extensions) const;
+    vk::raii::Device createDevice(const std::vector<const char *> &layers, const std::vector<const char *> &extensions,
+                                  const void *deviceFeatures) const;
 
     std::shared_ptr<PhysicalDevice> physicalDevice;
     vk::raii::Device device;
@@ -92,6 +93,6 @@ class Device {
  *******************************************************************************/
 
 std::shared_ptr<Device> makeDevice(const std::vector<const char *> &instanceLayers,
-                                   const std::vector<const char *> &deviceExtensions);
+                                   const std::vector<const char *> &deviceExtensions, const void *deviceFeatures);
 
 } // namespace mlsdk::el::utilities

--- a/utilities/tensor.cpp
+++ b/utilities/tensor.cpp
@@ -131,7 +131,13 @@ void Tensor::updateDescriptorSet(const vk::raii::DescriptorSet &descriptorSet, u
 }
 
 void Tensor::print() const {
-    const auto p = static_cast<const uint8_t *>(pointer);
+    const auto *p = data();
+
+    if (std::all_of(p, p + size(), [](const auto value) { return value == uint8_t(0); })) {
+        std::cout << "All zeros, size: " << size() << std::endl;
+        return;
+    }
+
     std::ios_base::fmtflags coutFlags(std::cout.flags());
 
     std::cout << std::hex << std::setfill('0');


### PR DESCRIPTION
Check tensors for all zeroes and avoid printing them.

Change-Id: Ida537040c49112c84d165922997e3258a3fcbd25