### PR TITLE
Add cache mutex

### DIFF
--- a/tensor/descriptor_binding.hpp
+++ b/tensor/descriptor_binding.hpp
@@ -55,8 +55,8 @@ substituteTensorWriteDescriptorSet(const Device &dev, uint32_t descriptorWriteCo
 
     // Loop over write descriptors and replace tensor bindings with uniform buffer for tensor description
     for (uint32_t i = 0; i < descriptorWriteCount; i++) {
-        if (!hasTensor(pDescriptorWrites[i])) {
-            const auto &write = pDescriptorWrites[i];
+        const auto &write = pDescriptorWrites[i];
+        if (!hasTensor(write)) {
             if (!write.pImageInfo || write.pImageInfo->imageLayout != VK_IMAGE_LAYOUT_TENSOR_ALIASING_ARM) {
                 writes.emplace_back(write);
                 continue;
@@ -73,8 +73,8 @@ substituteTensorWriteDescriptorSet(const Device &dev, uint32_t descriptorWriteCo
             continue;
         }
 
-        const auto tensorInfo = findType<VkWriteDescriptorSetTensorARM>(
-            pDescriptorWrites[i].pNext, VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET_TENSOR_ARM);
+        const auto tensorInfo =
+            findType<VkWriteDescriptorSetTensorARM>(write.pNext, VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET_TENSOR_ARM);
         if (tensorInfo == nullptr) {
             throw std::runtime_error("Write descriptor is missing tensor descriptor tensor info");
         }
@@ -89,16 +89,16 @@ substituteTensorWriteDescriptorSet(const Device &dev, uint32_t descriptorWriteCo
             });
 
             writes.emplace_back(VkWriteDescriptorSet{
-                VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,   // sType
-                nullptr,                                  // pNext
-                pDescriptorWrites[i].dstSet,              // dstSet
-                pDescriptorWrites[i].dstBinding,          // dstBinding
-                pDescriptorWrites[i].dstArrayElement + j, // dstArrayElement
-                1,                                        // descriptorCount
-                VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,        // descriptorType
-                nullptr,                                  // pImageInfo
-                &bufferInfos.back(),                      // pBufferInfo
-                nullptr                                   // pTexelBufferView
+                VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, // sType
+                nullptr,                                // pNext
+                write.dstSet,                           // dstSet
+                write.dstBinding,                       // dstBinding
+                write.dstArrayElement + j,              // dstArrayElement
+                1,                                      // descriptorCount
+                VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,      // descriptorType
+                nullptr,                                // pImageInfo
+                &bufferInfos.back(),                    // pBufferInfo
+                nullptr                                 // pTexelBufferView
             });
         }
     }

--- a/tensor/tensor_arm.cpp
+++ b/tensor/tensor_arm.cpp
@@ -211,7 +211,8 @@ TensorCopyPipeline::PushConstant TensorCopyPipeline::createPushConstant(const Te
 }
 
 VkShaderModule TensorCopyPipeline::createShaderModule(const TensorARM &srcTensor) const {
-    auto srcType = makeFormat((srcTensor.getTensorInfo().format))->glslType();
+    const auto srcType = makeFormat((srcTensor.getTensorInfo().format))->glslType();
+    const auto lock = std::lock_guard(cacheMutex);
     auto &spirv = spirvCache[srcType];
     if (spirv.empty()) {
         std::string tmp = glsl;
@@ -430,8 +431,6 @@ void TensorCopyPipeline::cmdBindAndDispatchCopy(VkCommandBuffer cmd, uint32_t re
                                     nullptr);
     loader->vkCmdDispatch(cmd, divideRoundUp(regionCount, warp1D), 1, 1);
 }
-
-std::map<std::string, std::vector<uint32_t>> TensorCopyPipeline::spirvCache;
 
 const std::string TensorCopyPipeline::glsl =
 #include "shaders/copy.comp"

--- a/tensor/tensor_arm.hpp
+++ b/tensor/tensor_arm.hpp
@@ -7,6 +7,8 @@
 #pragma once
 
 #include "mlel/vulkan_layer.hpp"
+
+#include <unordered_map>
 #include <vulkan/vulkan.hpp>
 
 namespace mlsdk::el::layer {
@@ -90,7 +92,8 @@ class TensorCopyPipeline {
 
     static const uint32_t warp1D = 128;
     static const std::string glsl;
-    static std::map<std::string, std::vector<uint32_t>> spirvCache;
+    static inline std::mutex cacheMutex;
+    static inline std::unordered_map<std::string, std::vector<uint32_t>> spirvCache;
 };
 
 } // namespace mlsdk::el::layer

--- a/utilities/include/mlel/pipeline.hpp
+++ b/utilities/include/mlel/pipeline.hpp
@@ -94,7 +94,6 @@ class PipelineBase {
     std::shared_ptr<vk::raii::PipelineLayout> createPipelineLayout() const;
     vk::raii::ShaderModule createShaderModule(const std::vector<uint32_t> &code) const;
     vk::raii::CommandPool createCommandPool() const;
-    virtual vk::raii::Pipeline createPipeline() const = 0;
     void updateDescriptorSet(const vk::raii::DescriptorSets &descriptorSets, const DescriptorMap &descriptorMap) const;
 
     std::shared_ptr<Device> device;
@@ -135,7 +134,7 @@ class GraphPipeline : public PipelineBase {
         void *pointer;
     };
 
-    vk::raii::Pipeline createPipeline() const override;
+    vk::raii::Pipeline createPipeline() const;
     vk::raii::DataGraphPipelineSessionARM createGraphPipelineSession() const;
     std::map<vk::DataGraphPipelineSessionBindPointARM, vk::MemoryRequirements>
     createMemoryRequirements(const vk::raii::DataGraphPipelineSessionARM &graphPipelineSession) const;
@@ -162,7 +161,7 @@ class TensorComputePipeline : public PipelineBase {
     void dispatchSubmit(uint32_t _x, uint32_t _y, uint32_t _z);
 
   private:
-    vk::raii::Pipeline createPipeline() const override;
+    vk::raii::Pipeline createPipeline() const;
 
     vk::raii::Pipeline pipeline;
 };


### PR DESCRIPTION
Add mutex to avoid cache data races.
A bit of code polish.
Avoiding a virtual function when not needed.

Change-Id: I14a64e8caadf1a6c8205d003402f8f60cdbe2dfc