### PR TITLE
Fix tensor array handling

### DIFF
--- a/tensor/spirv_glsl_tensor_buffer.hpp
+++ b/tensor/spirv_glsl_tensor_buffer.hpp
@@ -17,7 +17,7 @@ namespace mlsdk::el::layer {
 class CompilerTensorAsBuffer : public spirv_cross::CompilerGLSL {
   public:
     explicit CompilerTensorAsBuffer(std::vector<uint32_t> spirv_);
-    bool hasTensors() const { return !tensorVariables.empty(); }
+    bool hasTensors() const { return !tensorVariables.empty() || !tensorArrayVariables.empty(); }
     bool isCompute() const { return get_execution_model() == spv::ExecutionModelGLCompute; }
 
   protected:
@@ -33,6 +33,7 @@ class CompilerTensorAsBuffer : public spirv_cross::CompilerGLSL {
     static const std::string tensorDefines;
     // Used to keep track of SPIRV-Cross variables across `CompilerGLSL` function calls
     std::vector<std::tuple<uint32_t, uint32_t>> tensorVariables;
+    std::vector<uint32_t> tensorArrayVariables;
 
     // Tensor structs use uint64_t to store dimension info (rank, shape and stride)
     // To create the tensor struct SPIRType, we therefore need SPIRTypes for uint64_t and uint64_t arrays

--- a/tests/shader/tensor.comp
+++ b/tests/shader/tensor.comp
@@ -11,6 +11,10 @@ layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 layout(set = 0, binding = 0) uniform tensorARM<int8_t, 4> intensor;
 layout(set = 0, binding = 1) uniform tensorARM<int8_t, 4> outtensor;
 
+uint size_dim3(tensorARM<int8_t, 4> tensor) {
+    return tensorSizeARM(tensor, 3);
+}
+
 int8_t read(tensorARM<int8_t, 4> tensor, uint coords[4]) {
     int8_t value;
     tensorReadARM(tensor, coords, value);
@@ -26,7 +30,8 @@ void main() {
     uint ox = gl_GlobalInvocationID.x;
     uint oc = gl_GlobalInvocationID.z;
 
-    if (oy >= tensorSizeARM(intensor, 1) || ox >= tensorSizeARM(intensor, 2) || oc >= tensorSizeARM(intensor, 3)) {
+    // Both direct usage of tensorSizeARM and a helper function
+    if (oy >= tensorSizeARM(intensor, 1) || ox >= tensorSizeARM(intensor, 2) || oc >= size_dim3(intensor)) {
         return;
     }
     uint coords[4] = uint[](0u, oy, ox, oc);

--- a/tests/shader/tensor_array.comp
+++ b/tests/shader/tensor_array.comp
@@ -1,0 +1,60 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#version 460 core
+
+#extension GL_ARM_tensors : enable
+#extension GL_EXT_shader_explicit_arithmetic_types : enable
+
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+// Array of tensors
+const uint NUM_TENSORS = 4;
+layout(set = 0, binding = 0) uniform tensorARM<int8_t, 1> itain[NUM_TENSORS];
+layout(set = 0, binding = 1) uniform tensorARM<int8_t, 1> itaout[NUM_TENSORS];
+
+// Example of helper function having a tensor argument
+// Note: The standard does not allow tensor arrays as arguments.
+uint size_dim0(tensorARM<int8_t, 1> tensor) {
+    return tensorSizeARM(tensor, 0);
+}
+
+int8_t read(tensorARM<int8_t, 1> tensor, uint coords[1]) {
+    int8_t value;
+    tensorReadARM(tensor, coords, value);
+    return value;
+}
+
+void write(tensorARM<int8_t, 1> tensor, uint coords[1], int8_t value) {
+    tensorWriteARM(tensor, coords, value);
+}
+
+void main() {
+    uint global_id = gl_GlobalInvocationID.x;
+    uint tensor_index = global_id / NUM_TENSORS;
+    uint element_index = global_id % NUM_TENSORS;
+
+    if (tensor_index >= itain.length()) {
+        return;
+    }
+
+    // Use tensorSizeARM to query runtime size and validate element index
+    uint length = tensorSizeARM(itain[tensor_index], 0);
+
+    // Early exit if element index is out of bounds (should not happen if dispatch is correct)
+    if (element_index >= length) {
+        return;
+    }
+
+    uint coords[] = {element_index};
+
+    int8_t value = int8_t(0x55);
+    tensorReadARM(itain[tensor_index], coords, value);
+    tensorWriteARM(itaout[tensor_index], coords, value);
+
+    // Use helper functions to validate tensor transformation
+    uint length2 = size_dim0(itain[tensor_index]);
+    value = read(itain[tensor_index], coords);
+    write(itaout[tensor_index], coords, value);
+}


### PR DESCRIPTION
Make sure that tensorARM is lowered correct for arrays. The tensor array access is transformed to point to the descriptor member.

Change-Id: I18eefd60011443924d0633c5a4b6f27e5fbfd5f8