### PR TITLE
Rework toolchain files to support more platforms

### DIFF
--- a/cmake/toolchain/clang.cmake
+++ b/cmake/toolchain/clang.cmake
@@ -1,0 +1,35 @@
+#
+# SPDX-FileCopyrightText: Copyright 2023-2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set(CMAKE_CROSSCOMPILING OFF)
+
+find_program(CLANG_PATH clang)
+if(NOT CLANG_PATH)
+    message(FATAL_ERROR "clang not found")
+endif()
+
+find_program(CLANGXX_PATH clang++)
+if(NOT CLANGXX_PATH)
+    message(FATAL_ERROR "clang++ not found")
+endif()
+
+# Set the compilers
+set(CMAKE_C_COMPILER "${CLANG_PATH}" CACHE FILEPATH "C compiler")
+set(CMAKE_CXX_COMPILER "${CLANGXX_PATH}" CACHE FILEPATH "C++ compiler")
+
+set(CMAKE_CXX_FLAGS_INIT "-stdlib=libc++")
+
+# Use lld if available
+if(UNIX AND NOT APPLE)
+    find_program(LLD lld)
+    if(LLD)
+        message(STATUS "Using lld linker with Clang")
+        set(CMAKE_EXE_LINKER_FLAGS_INIT "-fuse-ld=lld")
+    else()
+        message(WARNING "lld not found, using system default linker")
+    endif()
+endif()
+
+include(${CMAKE_CURRENT_LIST_DIR}/gnu_compiler_options.cmake)

--- a/cmake/toolchain/gcc.cmake
+++ b/cmake/toolchain/gcc.cmake
@@ -1,0 +1,21 @@
+#
+# SPDX-FileCopyrightText: Copyright 2023-2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set(CMAKE_CROSSCOMPILING OFF)
+
+find_program(GCC_PATH gcc)
+if(NOT GCC_PATH)
+    message(FATAL_ERROR "gcc not found")
+endif()
+
+find_program(GPP_PATH g++)
+if(NOT GPP_PATH)
+    message(FATAL_ERROR "g++ not found")
+endif()
+
+set(CMAKE_C_COMPILER "${GCC_PATH}" CACHE FILEPATH "C compiler")
+set(CMAKE_CXX_COMPILER "${GPP_PATH}" CACHE FILEPATH "C++ compiler")
+
+include(${CMAKE_CURRENT_LIST_DIR}/gnu_compiler_options.cmake)

--- a/cmake/toolchain/linux-aarch64-gcc.cmake
+++ b/cmake/toolchain/linux-aarch64-gcc.cmake
@@ -1,0 +1,37 @@
+#
+# SPDX-FileCopyrightText: Copyright 2022-2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR aarch64)
+set(CMAKE_CROSSCOMPILING TRUE)
+
+find_program(AARCH64_GCC aarch64-linux-gnu-gcc)
+if(NOT AARCH64_GCC)
+    message(FATAL_ERROR "aarch64-linux-gnu-gcc not found — make sure the cross C compiler is installed")
+endif()
+
+find_program(AARCH64_GPP aarch64-linux-gnu-g++)
+if(NOT AARCH64_GPP)
+    message(FATAL_ERROR "aarch64-linux-gnu-g++ not found — make sure the cross C++ compiler is installed")
+endif()
+
+find_program(AARCH64_LD aarch64-linux-gnu-ld)
+if(NOT AARCH64_LD)
+    message(FATAL_ERROR "aarch64-linux-gnu-ld not found — make sure the cross linker is installed")
+endif()
+
+set(CMAKE_C_COMPILER "${AARCH64_GCC}" CACHE FILEPATH "C compiler")
+set(CMAKE_CXX_COMPILER "${AARCH64_GPP}" CACHE FILEPATH "C++ compiler")
+set(CMAKE_LINKER "${AARCH64_LD}" CACHE FILEPATH "Linker")
+
+set(CMAKE_FIND_ROOT_PATH /usr/aarch64-linux-gnu)
+
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)   # Programs are found on the host
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)    # Libraries only in the target sysroot
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)    # Includes only in the target sysroot
+set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE BOTH)    # Package files (e.g., pkg-config) in target sysroot
+
+
+include(${CMAKE_CURRENT_LIST_DIR}/gnu_compiler_options.cmake)

--- a/graph/memory_planner.hpp
+++ b/graph/memory_planner.hpp
@@ -28,6 +28,8 @@ class MemoryPlanner {
   public:
     explicit MemoryPlanner(const std::shared_ptr<GraphPipeline> &_graphPipeline);
 
+    virtual ~MemoryPlanner() = default;
+
     virtual VkMemoryRequirements getGraphPipelineSessionMemoryRequirements() const = 0;
     virtual void bindGraphPipelineSessionMemory(VkDeviceMemory memory, VkDeviceSize offset,
                                                 const ComputeDescriptorSetMap &descriptorSets) = 0;
@@ -46,6 +48,7 @@ class MemoryPlanner {
 class LinearMemoryPlanner : public MemoryPlanner {
   public:
     using MemoryPlanner::MemoryPlanner;
+    ~LinearMemoryPlanner() override = default;
 
     VkMemoryRequirements getGraphPipelineSessionMemoryRequirements() const override;
     void bindGraphPipelineSessionMemory(VkDeviceMemory memory, VkDeviceSize offset,
@@ -61,6 +64,7 @@ using Tensors = std::vector<std::shared_ptr<TensorDescriptor>>;
 class BestFitMemoryPlanner : public MemoryPlanner {
   public:
     explicit BestFitMemoryPlanner(const std::shared_ptr<GraphPipeline> &_graphPipeline);
+    ~BestFitMemoryPlanner() override = default;
 
     VkMemoryRequirements getGraphPipelineSessionMemoryRequirements() const override;
     void bindGraphPipelineSessionMemory(VkDeviceMemory memory, VkDeviceSize offset,

--- a/utilities/include/mlel/tensor.hpp
+++ b/utilities/include/mlel/tensor.hpp
@@ -105,10 +105,10 @@ class Tensor {
             auto refOffsetBytes = ref.getElementOffset(idx);
             auto srcPtr = reinterpret_cast<T *>(data() + srcOffsetBytes);
             auto refPtr = reinterpret_cast<U *>(ref.data() + refOffsetBytes);
+            const auto diff = static_cast<double>(*srcPtr) - static_cast<double>(*refPtr);
             if (!isClose(*srcPtr, *refPtr, tolerance)) {
                 std::cout << "Output mismatch at position " << std::dec << idx << std::endl;
-                std::cout << "src=" << +(*srcPtr) << ", ref=" << +(*refPtr) << ", diff=" << fabs(*srcPtr - *refPtr)
-                          << std::endl;
+                std::cout << "src=" << +(*srcPtr) << ", ref=" << +(*refPtr) << ", diff=" << std::abs(diff) << std::endl;
                 return false;
             }
         }


### PR DESCRIPTION
Toolchains clang.cmake and gcc.cmake should work on multiple hosts

clang.cmake should be default on Darwin-based systems

Cleanup the toolchain for aarch64 using gcc on Linux

Change-Id: I70fe99ab2eaabd12c461c9f6094954c305b47192