### PR TITLE
Fix docs generation with Clang

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright 2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-FileCopyrightText: Copyright 2024-2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -90,7 +90,7 @@ WARN_IF_DOC_ERROR      = YES
 WARN_NO_PARAMDOC       = NO
 WARN_FORMAT            = "$file:$line: $text"
 WARN_LOGFILE           =
-INPUT                  =
+INPUT                  = @PROJECT_SOURCE_DIR@/graph @PROJECT_SOURCE_DIR@/tensor
 INPUT_ENCODING         = UTF-8
 FILE_PATTERNS          = *.c \
                          *.cpp \


### PR DESCRIPTION
Build process would crash when docs were generated using Clang

Change-Id: I35040c8ed5df90ca168fa039c421569f2c41c442