### PR TITLE
Add missing dependency in tooling file

### DIFF
--- a/tooling-requirements.txt
+++ b/tooling-requirements.txt
@@ -10,3 +10,4 @@ myst_parser
 pre-commit
 sphinx
 sphinx_rtd_theme
+sphinxcontrib.plantuml


### PR DESCRIPTION
Dependency required to build docs was missing in tooling-requirements.


Change-Id: I24d8f36f511fc104b36bed401d904e4c516c8f7a