### PR TITLE
Correct variable usage on Darwin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,10 @@ if(DEFINED ANDROID_ABI)
     message(WARNING "Building for Android is currently an experimental feature.")
 endif()
 
+if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+    add_compile_definitions(MOLTEN_VK_SUPPORT)
+endif()
+
 include(CTest)
 configure_file(CTestCustom.cmake CTestCustom.cmake)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,10 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-    add_compile_definitions(MOLTEN_VK_SUPPORT)
-endif()
-
 if(ANDROID)
     set(DEVICE_TEST_DIR "/data/local/tmp/vmel")
     set(SHADER_SOURCE_DIR "${DEVICE_TEST_DIR}/shader")
@@ -57,22 +53,37 @@ function(mlel_add_test)
             PROPERTIES ${ARGS_PROPERTIES})
     endif()
 endfunction()
+if(NOT APPLE)
+    mlel_add_test(
+        TARGET mlel_unit_tests
+        SOURCES
+            vulkan.cpp
+        DEFINITIONS
+            SHADER_SOURCE_DIR=${SHADER_SOURCE_DIR}
+        LIBRARIES
+            mlelutilities
+            VkLayer_Common
+        PROPERTIES
+            ENVIRONMENT_MODIFICATION VK_LAYER_PATH=path_list_append:$<TARGET_FILE_DIR:VkLayer_Graph>
+            ENVIRONMENT_MODIFICATION LD_LIBRARY_PATH=path_list_append:$<TARGET_FILE_DIR:VkLayer_Graph>
 
-mlel_add_test(
-    TARGET mlel_unit_tests
-    SOURCES
-        vulkan.cpp
-    DEFINITIONS
-        SHADER_SOURCE_DIR=${SHADER_SOURCE_DIR}
-    LIBRARIES
-        mlelutilities
-        VkLayer_Common
-    PROPERTIES
-        ENVIRONMENT_MODIFICATION VK_LAYER_PATH=path_list_append:$<TARGET_FILE_DIR:VkLayer_Graph>
-        ENVIRONMENT_MODIFICATION LD_LIBRARY_PATH=path_list_append:$<TARGET_FILE_DIR:VkLayer_Graph>
+            ENVIRONMENT_MODIFICATION VK_LAYER_PATH=path_list_append:$<TARGET_FILE_DIR:VkLayer_Tensor>
+            ENVIRONMENT_MODIFICATION LD_LIBRARY_PATH=path_list_append:$<TARGET_FILE_DIR:VkLayer_Tensor>
 
-        ENVIRONMENT_MODIFICATION VK_LAYER_PATH=path_list_append:$<TARGET_FILE_DIR:VkLayer_Tensor>
-        ENVIRONMENT_MODIFICATION LD_LIBRARY_PATH=path_list_append:$<TARGET_FILE_DIR:VkLayer_Tensor>
-
-        ENVIRONMENT_MODIFICATION VK_LAYER_PATH=path_list_append:/usr/share/vulkan/explicit_layer.d
-)
+            ENVIRONMENT_MODIFICATION VK_LAYER_PATH=path_list_append:/usr/share/vulkan/explicit_layer.d
+    )
+else()
+    mlel_add_test(
+        TARGET mlel_unit_tests
+        SOURCES
+            vulkan.cpp
+        DEFINITIONS
+            SHADER_SOURCE_DIR=${SHADER_SOURCE_DIR}
+        LIBRARIES
+            mlelutilities
+            VkLayer_Common
+        PROPERTIES
+            ENVIRONMENT_MODIFICATION VK_LAYER_PATH=path_list_append:$ENV{VK_LAYER_PATH}
+            ENVIRONMENT_MODIFICATION DYLD_LIBRARY_PATH=path_list_append:$ENV{DYLD_LIBRARY_PATH}
+    )
+endif()

--- a/utilities/device.cpp
+++ b/utilities/device.cpp
@@ -35,14 +35,19 @@ vk::raii::Instance Instance::createInstance(const std::vector<const char *> &lay
         VK_MAKE_VERSION(1, 3, 0), // engine version
         VK_MAKE_VERSION(1, 3, 0), // api version
     };
-
+    std::vector<const char *> exts = extensions;
+    vk::InstanceCreateFlags flags;
+#ifdef MOLTEN_VK_SUPPORT
+    exts.push_back(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME);
+    flags = vk::InstanceCreateFlagBits::eEnumeratePortabilityKHR;
+#endif
     const vk::InstanceCreateInfo instanceCreateInfo{
-        {},                                       // flags
-        &applicationInfo,                         // application info
-        static_cast<uint32_t>(layers.size()),     // enabled layer count
-        layers.data(),                            // enabled layers
-        static_cast<uint32_t>(extensions.size()), // enabled extension count
-        extensions.data(),                        // enabled extensions
+        flags,                                // flags
+        &applicationInfo,                     // application info
+        static_cast<uint32_t>(layers.size()), // enabled layer count
+        layers.data(),                        // enabled layers
+        static_cast<uint32_t>(exts.size()),   // enabled extension count
+        exts.data(),                          // enabled extensions
     };
 
     vk::raii::Instance instance(*context, instanceCreateInfo);
@@ -250,15 +255,18 @@ Device::allocateDeviceMemory(const vk::DeviceSize size, const vk::MemoryProperty
 vk::raii::Device Device::createDevice(const std::vector<const char *> &layers,
                                       const std::vector<const char *> &extensions, const void *deviceFeatures) const {
     auto queueCreateInfo = physicalDevice->getQueueCreateInfo(vk::QueueFlagBits::eCompute);
-
+    std::vector<const char *> exts = extensions;
+#ifdef MOLTEN_VK_SUPPORT
+    exts.push_back("VK_KHR_portability_subset");
+#endif
     const vk::DeviceCreateInfo deviceCreateInfo{
         {},                                            // flags
         static_cast<uint32_t>(queueCreateInfo.size()), // queue create info count
         queueCreateInfo.data(),                        // queue create infos
         static_cast<uint32_t>(layers.size()),          // enabled layer count
         layers.data(),                                 // enabled layers
-        static_cast<uint32_t>(extensions.size()),      // enabled extension count
-        extensions.data(),                             // enabled extensions
+        static_cast<uint32_t>(exts.size()),            // enabled extension count
+        exts.data(),                                   // enabled extensions
         nullptr,                                       // Don't set pEnabledFeatures here!
         deviceFeatures                                 // Attach deviceFeatures via pNext
     };


### PR DESCRIPTION
Use correct env vars on Darwin when running tests, extended the extension variable fix to outside of the test dir, since some test utilize the affected code

Change-Id: I3516574be19ce57b20cf63f38a9c490b7a9a896f