### PR TITLE
Destroy layer Device abstraction before destroying VkDevice

### DIFF
--- a/common/include/mlel/vulkan_layer.hpp
+++ b/common/include/mlel/vulkan_layer.hpp
@@ -827,10 +827,12 @@ class VulkanLayer {
      *******************************************************************************/
 
     static void VKAPI_CALL vkDestroyDevice(VkDevice device, const VkAllocationCallbacks *allocator) {
-        auto handle = getHandle(device);
-        handle->loader->vkDestroyDevice(device, allocator);
+        std::shared_ptr<VULKAN_HPP_NAMESPACE::detail::DispatchLoaderDynamic> loader;
 
         {
+            // declare handle here to ensure no references to DeviceImpl escape this scope
+            auto handle = getHandle(device);
+            loader = handle->loader;
             scopedMutex l(globalMutex);
 
             // Erase device map
@@ -845,6 +847,8 @@ class VulkanLayer {
                 }
             }
         }
+
+        loader->vkDestroyDevice(device, allocator);
     }
 
     /*******************************************************************************


### PR DESCRIPTION
When not using RAII, the resources are not guaranteed to be destroyed before the device. When internally destroying the devices, we need to ensure the resources are destroyed before the underlying VkDevice since they rely on the VkDevice


Change-Id: Icd1aaed7781c4b7a9a2b508cb321e3a744eb0fed