### PR TITLE
Ensure the Windows DLL exports the exact Vulkan loader entry points

### DIFF
--- a/common/include/mlel/vulkan_layer.hpp
+++ b/common/include/mlel/vulkan_layer.hpp
@@ -30,12 +30,6 @@
 
 namespace mlsdk::el::layer {
 
-#if defined(_WIN64) || defined(_WIN32)
-#    define LAYER_EXPORT _declspec(dllexport)
-#else
-#    define LAYER_EXPORT
-#endif
-
 static inline mlsdk::el::log::Log layerLog("VMEL_COMMON_SEVERITY", "Layer");
 
 template <typename T> struct LinkedType {

--- a/graph/CMakeLists.txt
+++ b/graph/CMakeLists.txt
@@ -12,6 +12,11 @@ add_library(VkLayer_Graph SHARED)
 
 add_library(${ML_SDK_EL_NAMESPACE}::VkLayer_Graph ALIAS VkLayer_Graph)
 
+if(WIN32)
+  # Ensure the Windows DLL exports the exact Vulkan loader entry points
+  target_sources(VkLayer_Graph PRIVATE VkLayer_Graph.def)
+endif()
+
 target_compile_options(VkLayer_Graph PRIVATE ${VMEL_COMPILE_OPTIONS})
 
 target_sources(VkLayer_Graph PRIVATE

--- a/graph/VkLayer_Graph.def
+++ b/graph/VkLayer_Graph.def
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright 2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+#
+
+LIBRARY VkLayer_Graph
+EXPORTS
+    vkNegotiateLoaderLayerInterfaceVersion
+    vkGetInstanceProcAddr = graphGetInstanceProcAddr
+    vkGetDeviceProcAddr   = graphGetDeviceProcAddr
+    vk_layerGetPhysicalDeviceProcAddr

--- a/graph/graph_layer.cpp
+++ b/graph/graph_layer.cpp
@@ -1080,15 +1080,15 @@ class GraphLayer : public VulkanLayerImpl {
 extern "C" {
 using namespace mlsdk::el::layer;
 
-LAYER_EXPORT PFN_vkVoidFunction VKAPI_CALL graphGetInstanceProcAddr(VkInstance instance, const char *name) {
+PFN_vkVoidFunction VKAPI_CALL graphGetInstanceProcAddr(VkInstance instance, const char *name) {
     return GraphLayer::vkGetInstanceProcAddr(instance, name);
 }
 
-LAYER_EXPORT PFN_vkVoidFunction VKAPI_CALL graphGetDeviceProcAddr(VkDevice device, const char *name) {
+PFN_vkVoidFunction VKAPI_CALL graphGetDeviceProcAddr(VkDevice device, const char *name) {
     return GraphLayer::vkGetDeviceProcAddr(device, name);
 }
 
-LAYER_EXPORT PFN_vkVoidFunction VKAPI_CALL vk_layerGetPhysicalDeviceProcAddr(VkInstance instance, const char *name) {
+PFN_vkVoidFunction VKAPI_CALL vk_layerGetPhysicalDeviceProcAddr(VkInstance instance, const char *name) {
     return GraphLayer::vk_layerGetPhysicalDeviceProcAddr(instance, name);
 }
 

--- a/tensor/CMakeLists.txt
+++ b/tensor/CMakeLists.txt
@@ -6,6 +6,11 @@ add_library(VkLayer_Tensor SHARED)
 
 add_library(${ML_SDK_EL_NAMESPACE}::VkLayer_Tensor ALIAS VkLayer_Tensor)
 
+if(WIN32)
+  # Ensure the Windows DLL exports the exact Vulkan loader entry points
+  target_sources(VkLayer_Tensor PRIVATE VkLayer_Tensor.def)
+endif()
+
 target_compile_options(VkLayer_Tensor PRIVATE ${VMEL_COMPILE_OPTIONS})
 
 target_sources(VkLayer_Tensor PRIVATE

--- a/tensor/VkLayer_Tensor.def
+++ b/tensor/VkLayer_Tensor.def
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright 2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+#
+
+LIBRARY VkLayer_Tensor
+EXPORTS
+    vkNegotiateLoaderLayerInterfaceVersion
+    vkGetInstanceProcAddr = tensorGetInstanceProcAddr
+    vkGetDeviceProcAddr   = tensorGetDeviceProcAddr
+    vk_layerGetPhysicalDeviceProcAddr

--- a/tensor/tensor_layer.cpp
+++ b/tensor/tensor_layer.cpp
@@ -890,15 +890,15 @@ class TensorLayer : public VulkanLayerImpl {
 extern "C" {
 using namespace mlsdk::el::layer;
 
-LAYER_EXPORT PFN_vkVoidFunction VKAPI_CALL tensorGetInstanceProcAddr(VkInstance instance, const char *name) {
+PFN_vkVoidFunction VKAPI_CALL tensorGetInstanceProcAddr(VkInstance instance, const char *name) {
     return TensorLayer::vkGetInstanceProcAddr(instance, name);
 }
 
-LAYER_EXPORT PFN_vkVoidFunction VKAPI_CALL tensorGetDeviceProcAddr(VkDevice device, const char *name) {
+PFN_vkVoidFunction VKAPI_CALL tensorGetDeviceProcAddr(VkDevice device, const char *name) {
     return TensorLayer::vkGetDeviceProcAddr(device, name);
 }
 
-LAYER_EXPORT PFN_vkVoidFunction VKAPI_CALL vk_layerGetPhysicalDeviceProcAddr(VkInstance instance, const char *pName) {
+PFN_vkVoidFunction VKAPI_CALL vk_layerGetPhysicalDeviceProcAddr(VkInstance instance, const char *pName) {
     return TensorLayer::vk_layerGetPhysicalDeviceProcAddr(instance, pName);
 }
 


### PR DESCRIPTION
Drop the use of LAYER_EXPORT due to MSVC errors when using vkNegotiateLoaderLayerInterfaceVersion.

Replace LAYER_EXPORT with .def files for exportation of entry points in dll library files to allow
vkNegotiateLoaderLayerInterfaceVersion to be used on windows.

Change-Id: I509ad78ee3e47ee366d435a81cb095bc25d1bb31