### PR TITLE
Fix build --install failure in SDK top level

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,7 @@ endif()
 ###############################################################################
 
 include(package)
-if(NOT ML_SDK_GENERATE_CPACK)
+if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
     mlsdk_package(PACKAGE_NAME ${ML_SDK_EL_PACKAGE_NAME}
         NAMESPACE ${ML_SDK_EL_NAMESPACE}
         LICENSES "${CMAKE_CURRENT_LIST_DIR}/LICENSES/Apache-2.0.txt")


### PR DESCRIPTION
When running build.py --install from top level, do not add clashing packaging/install rules. The original if condition here only applied when --package was selected, not for --install.
What we want is just to check if we are running from component level, and only in that case bother with the packaging rules.

Change-Id: I7865c2bef086ef91d107c2d93681bf894a2b183c