### PR TITLE
Temporarily disable GetExternalTensorProperties test on Windows

### DIFF
--- a/tests/vulkan.cpp
+++ b/tests/vulkan.cpp
@@ -1918,6 +1918,8 @@ TEST_F(MLEmulationLayerForVulkan, GetQueueFamilyDataGraphPropertiesARM) {
     ASSERT_FALSE(result.empty());
 }
 
+#if !(_WIN32)
+// FIXME: Temporarily disabled on Windows due to segfault
 TEST_F(MLEmulationLayerForVulkan, GetExternalTensorProperties) {
     vk::raii::Context ctx{};
     auto instance = createInstance(ctx, {"VK_LAYER_ML_Tensor_Emulation"});
@@ -1948,3 +1950,4 @@ TEST_F(MLEmulationLayerForVulkan, GetExternalTensorProperties) {
 
     ASSERT_EQ(properties.externalMemoryProperties, bufferProperties.externalMemoryProperties);
 }
+#endif


### PR DESCRIPTION
Change-Id: I07094b40c217a2452220c980892acd1a8a6d2bb0