### PR TITLE
Fixing bad package name when building from root

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,8 +80,8 @@ endif()
 ###############################################################################
 # Packaging
 ###############################################################################
-include(package)
 if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
+    include(cmake/package.cmake)
     mlsdk_package(PACKAGE_NAME ${ML_SDK_EL_PACKAGE_NAME}
         NAMESPACE ${ML_SDK_EL_NAMESPACE}
         LICENSES "${CMAKE_CURRENT_LIST_DIR}/LICENSES/Apache-2.0.txt")


### PR DESCRIPTION
Change-Id: I86802de73df558680ee39d3e1b1bf48f08158063