### PR TITLE
Disable SPIRV-Cross tests when building

### DIFF
--- a/cmake/spirv-cross.cmake
+++ b/cmake/spirv-cross.cmake
@@ -7,6 +7,7 @@ set(SPIRV_CROSS_PATH "SPIRV_CROSS-NOTFOUND" CACHE PATH "Path to SPIRV-Cross")
 
 if(EXISTS ${SPIRV_CROSS_PATH}/CMakeLists.txt)
     if(NOT TARGET spirv-cross-glsl)
+        option(SPIRV_CROSS_ENABLE_TESTS "" OFF)
         add_subdirectory(${SPIRV_CROSS_PATH} spirv-cross SYSTEM EXCLUDE_FROM_ALL)
     endif()
 else()


### PR DESCRIPTION
This should silence a warning.
