### PR TITLE
Fix VkMemoryAllocateFlagsInfo modification

### DIFF
--- a/common/include/mlel/vulkan_layer.hpp
+++ b/common/include/mlel/vulkan_layer.hpp
@@ -117,7 +117,7 @@ template <typename T, class U> static LinkedType<T> findAndRemoveType(U *ptr, co
     if (node.current == nullptr) {
         return {};
     }
-    node.parent->pNext = reinterpret_cast<VkBaseOutStructure *>(node.current->pNext);
+    node.parent->pNext = reinterpret_cast<VkBaseOutStructure *>(const_cast<void *>(node.current->pNext));
     return node;
 }
 


### PR DESCRIPTION
Previously VkMemoryAllocateFlagsInfo was always assumed to be first struct in the pNext chain, the VkMemoryAllocateInfo.pNext was set to it.  However if it wasn't, you effectively 'skip' the earlier structs.

Signed-off-by: Camden Mannett <camden.mannett@arm.com>

Change-Id: Icb020ec6a545faf9dcc1dc3f066410b1d87dd228