### PR TITLE
Refactor compute pipeline and add unit tests

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -5,6 +5,7 @@
 Checks: >
     -*,
     bugprone-use-after-move,
+    cppcoreguidelines-pro-type-cstyle-cast,
     cppcoreguidelines-virtual-class-destructor,
     google-build-namespaces,
     misc-definitions-in-headers,

--- a/graph/compute.cpp
+++ b/graph/compute.cpp
@@ -411,7 +411,7 @@ ComputePipeline::ComputePipeline(const std::shared_ptr<VULKAN_HPP_NAMESPACE::det
       loader{_loader}, device{_device}, pipelineCache{_pipelineCache},
       shaderModule{createShaderModule(_spirv)}, pipeline{createComputePipeline(_constants)} {
     connectPipelines();
-    setDebugUtilsObjectName(loader, device, VK_OBJECT_TYPE_PIPELINE, (uint64_t)pipeline, debugName);
+    setDebugUtilsObjectName(loader, device, VK_OBJECT_TYPE_PIPELINE, reinterpret_cast<uint64_t>(pipeline), debugName);
 }
 
 ComputePipeline::~ComputePipeline() {

--- a/graph/graph_layer.cpp
+++ b/graph/graph_layer.cpp
@@ -626,24 +626,41 @@ class GraphLayer : public VulkanLayerImpl {
         uint32_t *bindPointRequirementCount, VkDataGraphPipelineSessionBindPointRequirementARM *bindPointRequirements) {
         auto *const session = reinterpret_cast<DataGraphPipelineSessionARM *>(info->session);
 
-        *bindPointRequirementCount = 0;
+        const auto needsTransient = session->memoryPlanner->getGraphPipelineSessionMemoryRequirements().size > 0;
 
-        // Calculate how much memory pipelines hidden layers require
-        const auto memoryRequirements = session->memoryPlanner->getGraphPipelineSessionMemoryRequirements();
-        if (memoryRequirements.size > 0) {
-            (*bindPointRequirementCount)++;
-            if (bindPointRequirements != nullptr) {
-                bindPointRequirements[0] = VkDataGraphPipelineSessionBindPointRequirementARM{
-                    VK_STRUCTURE_TYPE_DATA_GRAPH_PIPELINE_SESSION_BIND_POINT_REQUIREMENT_ARM, // type
-                    nullptr,                                                                  // next
-                    VK_DATA_GRAPH_PIPELINE_SESSION_BIND_POINT_TRANSIENT_ARM,                  // bind point
-                    VK_DATA_GRAPH_PIPELINE_SESSION_BIND_POINT_TYPE_MEMORY_ARM,                // bind point type
-                    1,                                                                        // number of resources
-                };
-            }
+        uint32_t requiredCount = 0;
+        if (needsTransient) {
+            ++requiredCount;
         }
 
-        return VK_SUCCESS;
+        if (bindPointRequirements == nullptr) {
+            *bindPointRequirementCount = requiredCount;
+            return VK_SUCCESS;
+        }
+
+        const auto capacity = *bindPointRequirementCount;
+        uint32_t written = 0;
+
+        auto writeRequirement = [&](VkDataGraphPipelineSessionBindPointARM bindPoint) {
+            if (written < capacity) {
+                bindPointRequirements[written] = VkDataGraphPipelineSessionBindPointRequirementARM{
+                    VK_STRUCTURE_TYPE_DATA_GRAPH_PIPELINE_SESSION_BIND_POINT_REQUIREMENT_ARM,
+                    nullptr,
+                    bindPoint,
+                    VK_DATA_GRAPH_PIPELINE_SESSION_BIND_POINT_TYPE_MEMORY_ARM,
+                    1,
+                };
+            }
+            ++written;
+        };
+
+        if (needsTransient) {
+            writeRequirement(VK_DATA_GRAPH_PIPELINE_SESSION_BIND_POINT_TRANSIENT_ARM);
+        }
+
+        *bindPointRequirementCount = written;
+
+        return (capacity < requiredCount) ? VK_INCOMPLETE : VK_SUCCESS;
     }
 
     static void VKAPI_CALL vkGetDataGraphPipelineSessionMemoryRequirementsARM(
@@ -740,36 +757,42 @@ class GraphLayer : public VulkanLayerImpl {
             return VK_ERROR_UNKNOWN;
         }
 
-        if (!pQueueFamilyDataGraphProperties) {
-            *pQueueFamilyDataGraphPropertyCount = 1;
+        constexpr uint32_t propertyCount = 1;
+
+        if (pQueueFamilyDataGraphProperties == nullptr) {
+            *pQueueFamilyDataGraphPropertyCount = propertyCount;
             return VK_SUCCESS;
         }
 
-        if (*pQueueFamilyDataGraphPropertyCount == 0) {
-            return VK_INCOMPLETE;
-        }
+        const auto capacity = *pQueueFamilyDataGraphPropertyCount;
+        const uint32_t toWrite = std::min(capacity, propertyCount);
 
-        VkPhysicalDeviceDataGraphProcessingEngineARM processingEngine = {
+        const VkPhysicalDeviceDataGraphProcessingEngineARM processingEngine = {
             VK_PHYSICAL_DEVICE_DATA_GRAPH_PROCESSING_ENGINE_TYPE_DEFAULT_ARM,
             VK_FALSE,
         };
 
-        VkPhysicalDeviceDataGraphOperationSupportARM operationSupport = {
+        const VkPhysicalDeviceDataGraphOperationSupportARM operationSupportTOSA = {
             VK_PHYSICAL_DEVICE_DATA_GRAPH_OPERATION_TYPE_SPIRV_EXTENDED_INSTRUCTION_SET_ARM,
             "TOSA.001000.1",
             {},
         };
 
-        *pQueueFamilyDataGraphProperties = {
-            VK_STRUCTURE_TYPE_QUEUE_FAMILY_DATA_GRAPH_PROPERTIES_ARM,
-            nullptr,
-            processingEngine,
-            operationSupport,
+        const VkQueueFamilyDataGraphPropertiesARM availableProperties[propertyCount] = {
+            {
+                VK_STRUCTURE_TYPE_QUEUE_FAMILY_DATA_GRAPH_PROPERTIES_ARM,
+                nullptr,
+                processingEngine,
+                operationSupportTOSA,
+            },
         };
 
-        *pQueueFamilyDataGraphPropertyCount = 1;
+        for (uint32_t i = 0; i < toWrite; ++i) {
+            pQueueFamilyDataGraphProperties[i] = availableProperties[i];
+        }
+        *pQueueFamilyDataGraphPropertyCount = toWrite;
 
-        return VK_SUCCESS;
+        return (toWrite < propertyCount) ? VK_INCOMPLETE : VK_SUCCESS;
     }
 
     /**************************************************************************

--- a/graph/shaders/CMakeLists.txt
+++ b/graph/shaders/CMakeLists.txt
@@ -7,15 +7,15 @@
 ###############################################################################
 
 # Get a list of all shaders under graph_op/, excluding the shared common header.
-file(GLOB_RECURSE SOURCES CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/graph_op/*.comp")
-list(FILTER SOURCES EXCLUDE REGEX "/common\\.comp$")
-list(SORT SOURCES)
+file(GLOB_RECURSE SOURCES_GRAPH_OP CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/graph_op/*.comp")
+list(FILTER SOURCES_GRAPH_OP EXCLUDE REGEX "/common\\.comp$")
+list(SORT SOURCES_GRAPH_OP)
 
 # Merge common header with GLSL sources
 set(GLSL_SOURCES "")
 add_custom_target(mlel_generate_shader_comp)
-foreach(SOURCE ${SOURCES})
-    get_filename_component(NAME ${SOURCE} NAME)
+macro(mlel_add_glsl_source SOURCE)
+    get_filename_component(NAME "${SOURCE}" NAME)
     set(OUT_FILE "${CMAKE_CURRENT_BINARY_DIR}/${NAME}")
 
     add_custom_command(
@@ -26,6 +26,10 @@ foreach(SOURCE ${SOURCES})
     add_dependencies(mlel_generate_shader_comp "mlel_generate_shader_${NAME}")
 
     list(APPEND GLSL_SOURCES "${OUT_FILE}")
+endmacro()
+
+foreach(SOURCE ${SOURCES_GRAPH_OP})
+    mlel_add_glsl_source("${SOURCE}")
 endforeach()
 
 # Combine all outputs into a single target

--- a/tests/vulkan.cpp
+++ b/tests/vulkan.cpp
@@ -1996,6 +1996,126 @@ TEST_F(MLEmulationLayerForVulkan, GetQueueFamilyDataGraphPropertiesARM) {
     ASSERT_FALSE(result.empty());
 }
 
+TEST_F(MLEmulationLayerForVulkan, GetQueueFamilyDataGraphPropertiesARM_TwoCallPattern) {
+    const auto device = createDevice();
+    const auto &physicalDevice = device->getPhysicalDevice();
+    const auto &vkPhysicalDevice = &(*physicalDevice);
+    const uint32_t queueFamilyIndex = physicalDevice->getComputeFamilyIndex();
+
+    // Phase 1: query the count with nullptr properties
+    uint32_t count = 0;
+    const VkResult firstResult = vkPhysicalDevice.getDispatcher()->vkGetPhysicalDeviceQueueFamilyDataGraphPropertiesARM(
+        *vkPhysicalDevice, queueFamilyIndex, &count, nullptr);
+    ASSERT_EQ(firstResult, VK_SUCCESS);
+    ASSERT_GT(count, 0u);
+
+    // Phase 2: retrieve the indicated count of elements
+    std::vector<VkQueueFamilyDataGraphPropertiesARM> properties(count);
+    for (auto &p : properties) {
+        p = {};
+        p.sType = VK_STRUCTURE_TYPE_QUEUE_FAMILY_DATA_GRAPH_PROPERTIES_ARM;
+    }
+    uint32_t retrieveCount = count;
+    const VkResult secondResult =
+        vkPhysicalDevice.getDispatcher()->vkGetPhysicalDeviceQueueFamilyDataGraphPropertiesARM(
+            *vkPhysicalDevice, queueFamilyIndex, &retrieveCount, properties.data());
+    ASSERT_EQ(secondResult, VK_SUCCESS);
+    ASSERT_EQ(retrieveCount, count);
+}
+
+TEST_F(MLEmulationLayerForVulkan, GetDataGraphPipelineSessionBindPointRequirementsARM_TwoCallPattern) {
+    auto device = createDevice();
+
+    auto inputTensor = std::make_shared<Tensor>(device, Shape{vk::Format::eR8Sint, std::vector<int64_t>{1, 16, 16, 3}});
+    auto outputTensor = std::make_shared<Tensor>(device, Shape{vk::Format::eR8Sint, std::vector<int64_t>{1, 8, 8, 3}});
+    const GraphPipeline::DescriptorMap descriptorMap = {{
+        {0, {inputTensor, inputTensor}},
+        {1, {outputTensor}},
+    }};
+    const auto spirv = assembleSpirv(fileToString("maxpool.spvasm"));
+
+    // Build resource infos from descriptor map
+    std::vector<vk::DataGraphPipelineResourceInfoARM> resourceInfos;
+    uint32_t set = 0;
+    for (const auto &bindingMap : descriptorMap) {
+        for (const auto &[binding, tensors] : bindingMap) {
+            for (uint32_t i = 0; i < tensors.size(); i++) {
+                resourceInfos.push_back(
+                    vk::DataGraphPipelineResourceInfoARM{set, binding, i, &tensors[i]->getTensorDescription()});
+            }
+        }
+        ++set;
+    }
+
+    // Shader module
+    const vk::ShaderModuleCreateInfo shaderModuleCI{
+        {},
+        spirv.size() * sizeof(uint32_t),
+        spirv.data(),
+    };
+    vk::raii::ShaderModule shaderModule{&(*device), shaderModuleCI};
+
+    // Descriptor set layouts and pipeline layout
+    std::vector<vk::raii::DescriptorSetLayout> dsLayouts;
+    for (const auto &bindingMap : descriptorMap) {
+        std::vector<vk::DescriptorSetLayoutBinding> bindings;
+        bindings.reserve(bindingMap.size());
+        for (const auto &[binding, tensors] : bindingMap) {
+            bindings.push_back(
+                {binding, vk::DescriptorType::eTensorARM, uint32_t(tensors.size()), vk::ShaderStageFlagBits::eAll});
+        }
+        std::vector<vk::DescriptorBindingFlags> bindingFlags(bindings.size(),
+                                                             vk::DescriptorBindingFlagBits::eUpdateAfterBind);
+        const vk::DescriptorSetLayoutBindingFlagsCreateInfo bindingFlagsCI{uint32_t(bindingFlags.size()),
+                                                                           bindingFlags.data()};
+        const vk::DescriptorSetLayoutCreateInfo dsCI{vk::DescriptorSetLayoutCreateFlagBits::eUpdateAfterBindPool,
+                                                     uint32_t(bindings.size()), bindings.data(), &bindingFlagsCI};
+        dsLayouts.emplace_back(&(*device), dsCI);
+    }
+    std::vector<vk::DescriptorSetLayout> vkDSLayouts;
+    vkDSLayouts.reserve(dsLayouts.size());
+    for (const auto &l : dsLayouts) {
+        vkDSLayouts.push_back(*l);
+    }
+    const vk::PipelineLayoutCreateInfo plCI{{}, uint32_t(vkDSLayouts.size()), vkDSLayouts.data()};
+    vk::raii::PipelineLayout pipelineLayout{&(*device), plCI};
+
+    // Pipeline
+    const vk::DataGraphPipelineShaderModuleCreateInfoARM smCI{*shaderModule, "Graph Pipeline", nullptr, 0, nullptr};
+    const vk::DataGraphPipelineCreateInfoARM pipelineCI{
+        {}, *pipelineLayout, uint32_t(resourceInfos.size()), resourceInfos.data(), &smCI};
+    vk::raii::Pipeline pipeline{&(*device), nullptr, nullptr, pipelineCI};
+
+    // Session
+    const vk::DataGraphPipelineSessionCreateInfoARM sessionCI{{}, *pipeline};
+    vk::raii::DataGraphPipelineSessionARM session{&(*device), sessionCI};
+
+    const auto &vkDevice = &(*device);
+    const VkDataGraphPipelineSessionBindPointRequirementsInfoARM requirementsInfo{
+        VK_STRUCTURE_TYPE_DATA_GRAPH_PIPELINE_SESSION_BIND_POINT_REQUIREMENTS_INFO_ARM,
+        nullptr,
+        *session,
+    };
+
+    // Phase 1: query the count with nullptr requirements
+    uint32_t count = 0;
+    const VkResult firstResult = vkDevice.getDispatcher()->vkGetDataGraphPipelineSessionBindPointRequirementsARM(
+        *vkDevice, &requirementsInfo, &count, nullptr);
+    ASSERT_EQ(firstResult, VK_SUCCESS);
+
+    // Phase 2: retrieve the indicated count of requirements
+    std::vector<VkDataGraphPipelineSessionBindPointRequirementARM> requirements(count);
+    for (auto &r : requirements) {
+        r = {};
+        r.sType = VK_STRUCTURE_TYPE_DATA_GRAPH_PIPELINE_SESSION_BIND_POINT_REQUIREMENT_ARM;
+    }
+    uint32_t retrieveCount = count;
+    const VkResult secondResult = vkDevice.getDispatcher()->vkGetDataGraphPipelineSessionBindPointRequirementsARM(
+        *vkDevice, &requirementsInfo, &retrieveCount, requirements.data());
+    ASSERT_EQ(secondResult, VK_SUCCESS);
+    ASSERT_EQ(retrieveCount, count);
+}
+
 TEST_F(MLEmulationLayerForVulkan, GetExternalTensorPropertiesARM) {
     const auto device = createDevice();
     const auto &physicalDevice = device->getPhysicalDevice();


### PR DESCRIPTION
Refactor functions to make it easier to add the new functionality. Add unit tests.
Fix cast and add clang-tidy check.
Reserve memory for vectors to avoid unnecessary reallocations.

Change-Id: I905f3673fe7fc1b306a0310aa39544c238c95023