### PR TITLE
Fix shell exports for Vulkan layer setup

### DIFF
--- a/pip_package/emulation_layer/cli.py
+++ b/pip_package/emulation_layer/cli.py
@@ -38,9 +38,9 @@ def main():
         print(
             f"export DYLD_LIBRARY_PATH={paths['DYLD_LIBRARY_PATH']}:$DYLD_LIBRARY_PATH"
         )
-        print(f"$env:VK_LAYER_PATH={paths['VK_LAYER_PATH']}:$VK_LAYER_PATH")
+        print(f"export VK_LAYER_PATH={paths['VK_LAYER_PATH']}:$VK_LAYER_PATH")
         print(
-            '$env:VK_INSTANCE_LAYERS="VK_LAYER_ML_Graph_Emulation:VK_LAYER_ML_Tensor_Emulation"'
+            'export VK_INSTANCE_LAYERS="VK_LAYER_ML_Graph_Emulation:VK_LAYER_ML_Tensor_Emulation"'
         )
     else:
         print("ERROR: Unsupported platform")


### PR DESCRIPTION
Update the CLI output on non-Windows platforms to use POSIX `export` syntax for Vulkan-related environment variables.

This makes the generated setup commands usable in standard Unix shells, so `VK_LAYER_PATH` and `VK_INSTANCE_LAYERS` can be applied correctly alongside `DYLD_LIBRARY_PATH`.


Change-Id: I225a60f37e19cb1f9056bcb7accccac29f67f9a6