### PR TITLE
Expose VK_ARM_data_graph_instruction_set_tosa in the EL

### DIFF
--- a/graph/graph_layer.cpp
+++ b/graph/graph_layer.cpp
@@ -21,6 +21,7 @@
 #include "spirv_pass_tosaspv_v100.hpp"
 
 #include <chrono>
+#include <cstdlib>
 #include <optional>
 #include <regex>
 
@@ -253,8 +254,10 @@ std::optional<std::string> tryGetExtInstVersion(const uint32_t *spirvCode, const
 
 } // namespace
 
-constexpr std::array<const VkExtensionProperties, 1> extensions{
+constexpr std::array<const VkExtensionProperties, 2> extensions{
     VkExtensionProperties{VK_ARM_DATA_GRAPH_EXTENSION_NAME, VK_ARM_DATA_GRAPH_SPEC_VERSION},
+    VkExtensionProperties{VK_ARM_DATA_GRAPH_INSTRUCTION_SET_TOSA_EXTENSION_NAME,
+                          VK_ARM_DATA_GRAPH_INSTRUCTION_SET_TOSA_SPEC_VERSION},
 };
 
 constexpr std::array<const VkExtensionProperties, 2> requiredExtensions = {
@@ -281,6 +284,8 @@ class GraphLayer : public VulkanLayerImpl {
             {"vk_layerGetPhysicalDeviceProcAddr", PFN_vkVoidFunction(vk_layerGetPhysicalDeviceProcAddr)},
 
             // PhysicalDevice functions
+            {"vkGetPhysicalDeviceQueueFamilyDataGraphEngineOperationPropertiesARM",
+             PFN_vkVoidFunction(vkGetPhysicalDeviceQueueFamilyDataGraphEngineOperationPropertiesARM)},
             {"vkGetPhysicalDeviceQueueFamilyDataGraphProcessingEnginePropertiesARM",
              PFN_vkVoidFunction(vkGetPhysicalDeviceQueueFamilyDataGraphProcessingEnginePropertiesARM)},
             {"vkGetPhysicalDeviceQueueFamilyDataGraphPropertiesARM",
@@ -356,6 +361,8 @@ class GraphLayer : public VulkanLayerImpl {
         static const vTable vtable = {
             {"vk_layerGetPhysicalDeviceProcAddr", PFN_vkVoidFunction(vk_layerGetPhysicalDeviceProcAddr)},
             // PhysicalDevice functions
+            {"vkGetPhysicalDeviceQueueFamilyDataGraphEngineOperationPropertiesARM",
+             PFN_vkVoidFunction(vkGetPhysicalDeviceQueueFamilyDataGraphEngineOperationPropertiesARM)},
             {"vkGetPhysicalDeviceQueueFamilyDataGraphProcessingEnginePropertiesARM",
              PFN_vkVoidFunction(vkGetPhysicalDeviceQueueFamilyDataGraphProcessingEnginePropertiesARM)},
             {"vkGetPhysicalDeviceQueueFamilyDataGraphPropertiesARM",
@@ -756,6 +763,41 @@ class GraphLayer : public VulkanLayerImpl {
             * /*pQueueFamilyDataGraphProcessingEngineInfo*/,
         VkQueueFamilyDataGraphProcessingEnginePropertiesARM * /*pQueueFamilyDataGraphProcessingEngineProperties*/) {
         // No properties available
+    }
+
+    static VkResult VKAPI_CALL vkGetPhysicalDeviceQueueFamilyDataGraphEngineOperationPropertiesARM(
+        VkPhysicalDevice physicalDevice, uint32_t queueFamilyIndex,
+        const VkQueueFamilyDataGraphPropertiesARM *pQueueFamilyDataGraphProperties, VkBaseOutStructure *pProperties) {
+        auto handle = VulkanLayerImpl::getHandle(physicalDevice);
+        uint32_t familyCount = 0;
+        handle->loader->vkGetPhysicalDeviceQueueFamilyProperties(physicalDevice, &familyCount, nullptr);
+        if (queueFamilyIndex >= familyCount || pQueueFamilyDataGraphProperties == nullptr || pProperties == nullptr) {
+            return VK_ERROR_UNKNOWN;
+        }
+
+        if (pQueueFamilyDataGraphProperties->engine.type !=
+                VK_PHYSICAL_DEVICE_DATA_GRAPH_PROCESSING_ENGINE_TYPE_DEFAULT_ARM ||
+            pQueueFamilyDataGraphProperties->operation.operationType !=
+                VK_PHYSICAL_DEVICE_DATA_GRAPH_OPERATION_TYPE_SPIRV_EXTENDED_INSTRUCTION_SET_ARM) {
+            return VK_ERROR_UNKNOWN;
+        }
+
+        auto *tosaProperties = findTypeMutable<VkQueueFamilyDataGraphTOSAPropertiesARM>(
+            pProperties, VK_STRUCTURE_TYPE_QUEUE_FAMILY_DATA_GRAPH_TOSA_PROPERTIES_ARM);
+        if (tosaProperties == nullptr) {
+            return VK_SUCCESS;
+        }
+
+        const static VkDataGraphTOSANameQualityARM profile = {"Emulation Layer",
+                                                              VK_DATA_GRAPH_TOSA_QUALITY_CONFORMANT_ARM};
+
+        tosaProperties->profileCount = 1;
+        tosaProperties->pProfiles = &profile;
+        tosaProperties->extensionCount = 0;
+        tosaProperties->pExtensions = nullptr;
+        tosaProperties->level = VK_DATA_GRAPH_TOSA_LEVEL_8K_ARM;
+
+        return VK_SUCCESS;
     }
 
     static VkResult VKAPI_CALL vkGetPhysicalDeviceQueueFamilyDataGraphPropertiesARM(

--- a/graph/layer.d/VkLayer_Graph.json.in
+++ b/graph/layer.d/VkLayer_Graph.json.in
@@ -42,12 +42,20 @@
                     "vkGetDeviceQueue",
                     "vkGetDeviceQueue2",
                     "vkGetPhysicalDeviceFeatures2",
+                    "vkGetPhysicalDeviceQueueFamilyDataGraphEngineOperationPropertiesARM",
                     "vkGetPhysicalDeviceQueueFamilyDataGraphProcessingEnginePropertiesARM",
                     "vkGetPhysicalDeviceQueueFamilyDataGraphPropertiesARM",
                     "vkGetPhysicalDeviceQueueFamilyProperties",
                     "vkGetPhysicalDeviceToolPropertiesEXT",
                     "vkSetDebugUtilsObjectNameEXT",
                     "vkUpdateDescriptorSets"
+                ]
+            },
+            {
+                "name": "VK_ARM_data_graph_instruction_set_tosa",
+                "spec_version": "1",
+                "entrypoints": [
+                    "vkGetPhysicalDeviceQueueFamilyDataGraphEngineOperationPropertiesARM"
                 ]
             }
         ]

--- a/tests/vulkan.cpp
+++ b/tests/vulkan.cpp
@@ -2023,6 +2023,47 @@ TEST_F(MLEmulationLayerForVulkan, GetQueueFamilyDataGraphPropertiesARM_TwoCallPa
     ASSERT_EQ(retrieveCount, count);
 }
 
+TEST_F(MLEmulationLayerForVulkan, GetQueueFamilyDataGraphEngineOperationPropertiesARM_TosaProfile) {
+    const auto device = createDevice();
+    const auto &physicalDevice = device->getPhysicalDevice();
+    const auto &vkPhysicalDevice = &(*physicalDevice);
+    const uint32_t queueFamilyIndex = physicalDevice->getComputeFamilyIndex();
+
+    uint32_t count = 0;
+    const VkResult firstResult = vkPhysicalDevice.getDispatcher()->vkGetPhysicalDeviceQueueFamilyDataGraphPropertiesARM(
+        *vkPhysicalDevice, queueFamilyIndex, &count, nullptr);
+    ASSERT_EQ(firstResult, VK_SUCCESS);
+    ASSERT_GT(count, 0u);
+
+    std::vector<VkQueueFamilyDataGraphPropertiesARM> properties(count);
+    for (auto &property : properties) {
+        property = {};
+        property.sType = VK_STRUCTURE_TYPE_QUEUE_FAMILY_DATA_GRAPH_PROPERTIES_ARM;
+    }
+
+    uint32_t retrieveCount = count;
+    const VkResult secondResult =
+        vkPhysicalDevice.getDispatcher()->vkGetPhysicalDeviceQueueFamilyDataGraphPropertiesARM(
+            *vkPhysicalDevice, queueFamilyIndex, &retrieveCount, properties.data());
+    ASSERT_EQ(secondResult, VK_SUCCESS);
+    ASSERT_GT(retrieveCount, 0u);
+
+    VkQueueFamilyDataGraphTOSAPropertiesARM tosaProperties = {};
+    tosaProperties.sType = VK_STRUCTURE_TYPE_QUEUE_FAMILY_DATA_GRAPH_TOSA_PROPERTIES_ARM;
+
+    const VkResult result =
+        vkPhysicalDevice.getDispatcher()->vkGetPhysicalDeviceQueueFamilyDataGraphEngineOperationPropertiesARM(
+            *vkPhysicalDevice, queueFamilyIndex, &properties[0],
+            reinterpret_cast<VkBaseOutStructure *>(&tosaProperties));
+    ASSERT_EQ(result, VK_SUCCESS);
+    ASSERT_EQ(tosaProperties.profileCount, 1u);
+    ASSERT_NE(tosaProperties.pProfiles, nullptr);
+    ASSERT_EQ(tosaProperties.pProfiles[0].qualityFlags, VK_DATA_GRAPH_TOSA_QUALITY_CONFORMANT_ARM);
+    ASSERT_EQ(tosaProperties.extensionCount, 0u);
+    ASSERT_EQ(tosaProperties.pExtensions, nullptr);
+    ASSERT_EQ(tosaProperties.level, VK_DATA_GRAPH_TOSA_LEVEL_8K_ARM);
+}
+
 TEST_F(MLEmulationLayerForVulkan, GetDataGraphPipelineSessionBindPointRequirementsARM_TwoCallPattern) {
     auto device = createDevice();
 


### PR DESCRIPTION
 * Report a TOSA profile marked as CONFORMANT for the emulation layer.
 * Add a unit test surrounding expected behaviour of vkGetPhysicalDeviceQueueFamilyDataGraphEngineOperationPropertiesARM

Signed-off-by: Cian McGriskin <Cian.McGriskin@arm.com>
Change-Id: I038fe987cd81e8c5f4cd631759d32e92bcfa33ad
