### PR TITLE
Support VK_ARM_data_graph_optical_flow

### DIFF
--- a/common/include/mlel/vulkan_layer.hpp
+++ b/common/include/mlel/vulkan_layer.hpp
@@ -752,9 +752,12 @@ class VulkanLayer {
         VkPhysicalDeviceVulkan13Features queryVulkan13Feature{};
         queryVulkan13Feature.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_3_FEATURES;
         queryVulkan13Feature.pNext = &queryVulkan12Feature;
+        VkPhysicalDeviceDescriptorIndexingFeatures queryVulkanIndexingFeature{};
+        queryVulkanIndexingFeature.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES;
+        queryVulkanIndexingFeature.pNext = &queryVulkan13Feature;
         VkPhysicalDeviceFeatures2 queryFeatures2{};
         queryFeatures2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
-        queryFeatures2.pNext = &queryVulkan13Feature;
+        queryFeatures2.pNext = &queryVulkanIndexingFeature;
         handle->loader->vkGetPhysicalDeviceFeatures2(physicalDevice, &queryFeatures2);
 
         // store origin deviceCreateInfo chain and modify to enable features
@@ -821,6 +824,11 @@ class VulkanLayer {
         layerVulkan12Feature.bufferDeviceAddress = queryVulkan12Feature.bufferDeviceAddress;
         layerVulkan12Feature.descriptorBindingStorageBufferUpdateAfterBind =
             queryVulkan12Feature.descriptorBindingStorageBufferUpdateAfterBind;
+        layerVulkan12Feature.descriptorBindingStorageImageUpdateAfterBind =
+            queryVulkan12Feature.descriptorBindingStorageImageUpdateAfterBind;
+        layerVulkan12Feature.descriptorBindingSampledImageUpdateAfterBind =
+            queryVulkan12Feature.descriptorBindingSampledImageUpdateAfterBind;
+        layerVulkan12Feature.descriptorBindingPartiallyBound = queryVulkan12Feature.descriptorBindingPartiallyBound;
         appendType(&newCreateInfo, &layerVulkan12Feature);
 
         const auto *pDeviceFeature13 = removeType<VkPhysicalDeviceVulkan13Features>(

--- a/graph/CMakeLists.txt
+++ b/graph/CMakeLists.txt
@@ -18,10 +18,13 @@ target_compile_options(VkLayer_Graph PRIVATE ${VMEL_COMPILE_OPTIONS})
 
 target_sources(VkLayer_Graph PRIVATE
     compute_graph_op.cpp
+    compute_optical_flow.cpp
     compute_pipeline_common.cpp
     graph_layer.cpp
     graph_log.cpp
+    image.cpp
     memory_planner.cpp
+    optical_flow.cpp
     pipeline_cache.cpp
     spirv_pass.cpp
     spirv_pass_tosaspv_v100.cpp

--- a/graph/compute_optical_flow.cpp
+++ b/graph/compute_optical_flow.cpp
@@ -1,0 +1,768 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+/*******************************************************************************
+ * Includes
+ *******************************************************************************/
+
+#include "compute_optical_flow.hpp"
+#include "compute_pipeline_common.hpp"
+
+using namespace mlsdk::el::utils;
+
+namespace mlsdk::el::compute::optical_flow {
+
+/*******************************************************************************
+ * ComputePipeline
+ *******************************************************************************/
+
+ComputePipeline::ComputePipeline(const std::shared_ptr<VULKAN_HPP_NAMESPACE::detail::DispatchLoaderDynamic> &loader,
+                                 const VkDevice device, const std::shared_ptr<PipelineCache> &pipelineCache,
+                                 const SpirvBinary &spirv, const DescriptorConfigs &descriptorConfigs,
+                                 const SpecConstants &specConstants, uint32_t pushConstantsSize,
+                                 const ScheduleHelper &schedule, const std::string &debugName)
+    : loader_(loader), device_(device), pipelineCache_(pipelineCache), spirv_(spirv),
+      descriptorConfigs_(descriptorConfigs), specConstants_(specConstants), pushConstantsSize_(pushConstantsSize),
+      scheduler_(schedule), debugName_(debugName) {}
+
+ComputePipeline::~ComputePipeline() {
+    if (device_) {
+        if (vkPipeline_) {
+            loader_->vkDestroyPipeline(device_, vkPipeline_, pAllocator_);
+        }
+        if (pipelineLayout_) {
+            loader_->vkDestroyPipelineLayout(device_, pipelineLayout_, pAllocator_);
+        }
+        if (descriptorSetLayout_) {
+            loader_->vkDestroyDescriptorSetLayout(device_, descriptorSetLayout_, pAllocator_);
+        }
+        if (descriptorPool_) {
+            loader_->vkDestroyDescriptorPool(device_, descriptorPool_, pAllocator_);
+        }
+        for (auto *sampler : samplers_) {
+            loader_->vkDestroySampler(device_, sampler, pAllocator_);
+        }
+    }
+};
+
+void ComputePipeline::makePipeline() {
+    // Shader module
+    const VkShaderModule shaderModule = common::createShaderModule(loader_, device_, spirv_, pAllocator_);
+
+    // Create descriptor pool
+    // TODO: maybe use descriptor buffers so we can use session memory instead of seperate allocations?
+    const std::vector<VkDescriptorPoolSize> poolSizes = {
+        {VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, 5}, {VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 5},
+        {VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 5}, {VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 5},
+        {VK_DESCRIPTOR_TYPE_SAMPLER, 5},
+    };
+
+    const VkDescriptorPoolCreateInfo descriptorPoolCreateInfo = {
+        VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO,
+        nullptr,
+        VK_DESCRIPTOR_POOL_CREATE_UPDATE_AFTER_BIND_BIT, // flags
+        3,                                               // maxSets
+        static_cast<uint32_t>(poolSizes.size()),
+        poolSizes.data(),
+    };
+    VkResult res = loader_->vkCreateDescriptorPool(device_, &descriptorPoolCreateInfo, pAllocator_, &descriptorPool_);
+    if (res != VK_SUCCESS) {
+        throw std::runtime_error("Failed to create descriptor pool");
+    }
+
+    // Create descriptor set layout
+    // Assuming descriptorBindingPartiallyBound from DescriptorIndexingFeatures
+    std::vector<VkDescriptorSetLayoutBinding> bindings;
+    bindings.reserve(descriptorConfigs_.size());
+    std::vector<VkDescriptorBindingFlags> bindingFlags;
+    bindingFlags.reserve(descriptorConfigs_.size());
+    for (const auto &dconf : descriptorConfigs_) {
+        bindings.emplace_back(VkDescriptorSetLayoutBinding{
+            dconf.index,
+            dconf.type,
+            /* descriptorCount */ 1,
+            VK_SHADER_STAGE_COMPUTE_BIT,
+            nullptr,
+        });
+        bindingFlags.emplace_back(dconf.flags);
+    }
+
+    const VkDescriptorSetLayoutBindingFlagsCreateInfo bindingFlagsCreateInfo{
+        VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO,
+        nullptr,
+        static_cast<uint32_t>(bindingFlags.size()),
+        bindingFlags.data(),
+    };
+
+    const VkDescriptorSetLayoutCreateInfo dsetLayoutCreateInfo = {
+        VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO,
+        &bindingFlagsCreateInfo, // pNext
+        0,                       // flags
+        static_cast<uint32_t>(bindings.size()),
+        bindings.data(),
+    };
+    res = loader_->vkCreateDescriptorSetLayout(device_, &dsetLayoutCreateInfo, pAllocator_, &descriptorSetLayout_);
+    if (res != VK_SUCCESS) {
+        throw std::runtime_error("Failed to create descriptor set layout");
+    }
+
+    // Allocate descriptor sets
+    const VkDescriptorSetAllocateInfo dsetAllocInfo = {
+        VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO, nullptr, descriptorPool_, 1, &descriptorSetLayout_,
+    };
+    res = loader_->vkAllocateDescriptorSets(device_, &dsetAllocInfo, &descriptorSet_);
+    if (res != VK_SUCCESS) {
+        throw std::runtime_error("Failed to allocate descriptor sets");
+    }
+
+    // Create pipeline layout
+    const VkPushConstantRange pushConstantRange = {
+        VK_SHADER_STAGE_COMPUTE_BIT,
+        0,
+        pushConstantsSize_,
+    };
+
+    const VkPipelineLayoutCreateInfo pipeLayoutCreateInfo = {
+        VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO,         // sType
+        nullptr,                                               // pNext
+        0,                                                     // flags
+        1,                                                     // setLayoutCount
+        &descriptorSetLayout_,                                 // pSetLayouts
+        pushConstantsSize_ > 0 ? 1u : 0u,                      // pushConstantRangeCount
+        pushConstantsSize_ > 0 ? &pushConstantRange : nullptr, // pPushConstantRanges
+    };
+    res = loader_->vkCreatePipelineLayout(device_, &pipeLayoutCreateInfo, pAllocator_, &pipelineLayout_);
+    if (res != VK_SUCCESS) {
+        throw std::runtime_error("Failed to create pipeline layout");
+    }
+
+    // Create compute pipeline
+    const auto specializationConstants =
+        common::makeSpecializationConstantsView(specConstants_.pointer, specConstants_.sizeBytes);
+    const auto *specialization = specConstants_.sizeBytes > 0 ? &specializationConstants : nullptr;
+    vkPipeline_ = common::createComputePipeline(loader_, device_, pipelineCache_->getPipelineCache(), shaderModule,
+                                                pipelineLayout_, specialization, pAllocator_);
+
+    setDebugUtilsObjectName(loader_, device_, VK_OBJECT_TYPE_PIPELINE, reinterpret_cast<uint64_t>(vkPipeline_),
+                            debugName_);
+
+    // clean up
+    loader_->vkDestroyShaderModule(device_, shaderModule, nullptr);
+}
+
+void ComputePipeline::setInputStorage(VkCommandBuffer cmdBuf, uint32_t binding, const std::shared_ptr<Image> &image,
+                                      VkSampler sampler) {
+    image->makeBarrier(cmdBuf, Image::BarrierState::ShaderRead);
+
+    if (image->isBufferLoad()) {
+        setBuffer(binding, image);
+    } else {
+        setCombinedImageSampler(binding, image, sampler);
+    }
+}
+
+void ComputePipeline::setOutputStorage(VkCommandBuffer cmdBuf, uint32_t binding, const std::shared_ptr<Image> &image) {
+    image->makeBarrier(cmdBuf, Image::BarrierState::ShaderWrite);
+
+    if (image->isBufferStore()) {
+        setBuffer(binding, image);
+    } else {
+        setOutputImage(binding, image);
+    }
+}
+
+void ComputePipeline::setCombinedImageSampler(uint32_t binding, const std::shared_ptr<Image> &image,
+                                              VkSampler sampler) {
+    setImage(binding, image, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, sampler);
+}
+
+void ComputePipeline::setOutputImage(uint32_t binding, const std::shared_ptr<Image> &image) {
+    setImage(binding, image, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, VK_NULL_HANDLE);
+}
+
+void ComputePipeline::setImage(uint32_t binding, const std::shared_ptr<Image> &image, VkDescriptorType descriptorType,
+                               VkSampler sampler) {
+    const VkDescriptorImageInfo imageInfo = {sampler, image->getImageView(), image->getImageLayout()};
+
+    const VkWriteDescriptorSet writeDescriptorSet = {
+        VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,
+        nullptr,
+        descriptorSet_,
+        binding,
+        0, // dstArrayElement
+        1, // descriptorCount
+        descriptorType,
+        &imageInfo, // pImageInfo
+        nullptr,
+        nullptr, // pTexelBufferView
+    };
+    loader_->vkUpdateDescriptorSets(device_, 1, &writeDescriptorSet, 0, nullptr);
+}
+
+void ComputePipeline::setBuffer(uint32_t binding, const std::shared_ptr<Image> &image) {
+    assert(image->isInternal());
+    const VkDescriptorBufferInfo bufferInfo = {image->getBuffer(), 0, VK_WHOLE_SIZE};
+    const VkWriteDescriptorSet writeDescriptorSet = {
+        VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,
+        nullptr,
+        descriptorSet_,
+        binding,
+        0, // dstArrayElement
+        1, // descriptorCount
+        VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
+        nullptr, // pImageInfo
+        &bufferInfo,
+        nullptr, // pTexelBufferView
+    };
+    loader_->vkUpdateDescriptorSets(device_, 1, &writeDescriptorSet, 0, nullptr);
+}
+
+VkSampler ComputePipeline::createSampler(VkFilter filter, VkSamplerAddressMode addressMode,
+                                         bool unnormalizedCoordinates = true) {
+    VkSamplerCreateInfo samplerInfo{};
+    samplerInfo.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
+    samplerInfo.minFilter = filter;
+    samplerInfo.magFilter = filter;
+    samplerInfo.addressModeU = addressMode;
+    samplerInfo.addressModeV = addressMode;
+    samplerInfo.addressModeW = addressMode;
+    samplerInfo.mipmapMode = VK_SAMPLER_MIPMAP_MODE_NEAREST;
+    samplerInfo.unnormalizedCoordinates = unnormalizedCoordinates;
+
+    VkSampler sampler;
+    VkResult res = loader_->vkCreateSampler(device_, &samplerInfo, nullptr, &sampler);
+    if (res != VK_SUCCESS) {
+        throw std::runtime_error("Failed to create sampler");
+    }
+    samplers_.push_back(sampler);
+    return sampler;
+}
+
+void ComputePipeline::bindPipeline(VkCommandBuffer cmdBuf) {
+    loader_->vkCmdBindPipeline(cmdBuf, VK_PIPELINE_BIND_POINT_COMPUTE, vkPipeline_);
+    loader_->vkCmdBindDescriptorSets(cmdBuf, VK_PIPELINE_BIND_POINT_COMPUTE, pipelineLayout_, 0, 1, &descriptorSet_, 0,
+                                     nullptr);
+}
+
+void ComputePipeline::dispatchPipeline(VkCommandBuffer cmdBuf) {
+    loader_->vkCmdDispatch(cmdBuf, scheduler_.groupCountX, scheduler_.groupCountY, scheduler_.groupCountZ);
+}
+
+/*******************************************************************************
+ * RGBToY
+ *******************************************************************************/
+
+RGBToY::RGBToY(const std::shared_ptr<VULKAN_HPP_NAMESPACE::detail::DispatchLoaderDynamic> &loader,
+               const VkDevice device, const std::shared_ptr<PipelineCache> &pipelineCache,
+               std::shared_ptr<Image> srcRGBImage, std::shared_ptr<Image> dstDownsampledImage,
+               std::shared_ptr<Image> dstFullImage, bool outputDownsample, bool outputFullRes, float downsampleScale,
+               const std::string &debugName)
+    : ComputePipeline(loader, device, pipelineCache, createSpirv(pipelineCache), descriptorConfigs_,
+                      {&specConstants_, sizeof(specConstants_)}, 0,
+                      {dstDownsampledImage->width(), dstDownsampledImage->height()}, debugName),
+      srcImage_(srcRGBImage), dstYDownsampled_(dstDownsampledImage), dstYFull_(dstFullImage),
+      outputDS_(outputDownsample), outputFull_(outputFullRes),
+      scale_(downsampleScale), specConstants_{makeSpecConstants(srcRGBImage, dstDownsampledImage, dstFullImage,
+                                                                outputDownsample, outputFullRes, scale_)},
+      linearSampler_{createSampler(VK_FILTER_LINEAR, VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE)} {}
+
+RGBToY::SpecConstants RGBToY::makeSpecConstants(const std::shared_ptr<Image> &srcRGBImage,
+                                                const std::shared_ptr<Image> &dstDownsampledImage,
+                                                const std::shared_ptr<Image> &dstFullImage, bool outputDownsample,
+                                                bool outputFullRes, float downsampleScale) const {
+    VkBool32 isLumaInput = srcRGBImage->componentCount() == 1;
+    VkBool32 isImageStore = true;
+    if (outputDownsample) {
+        isImageStore = dstDownsampledImage->isImageStore() == true;
+    } else if (outputFullRes) {
+        isImageStore = dstFullImage->isImageStore() == true;
+    }
+    assert((outputDownsample & outputFullRes) ? dstFullImage->isImageStore() == dstDownsampledImage->isImageStore()
+                                              : true);
+
+    SpecConstants specConstants = {
+        32,
+        8,
+        1,
+        1,
+        isLumaInput,
+        outputDownsample,
+        outputFullRes,
+        isImageStore,
+        downsampleScale,
+        downsampleScale,
+        outputDownsample ? dstDownsampledImage->width() : 1,
+        outputDownsample ? dstDownsampledImage->height() : 1,
+        outputDownsample ? dstDownsampledImage->stride() : 1,
+        outputFullRes ? dstFullImage->width() : 1,
+        outputFullRes ? dstFullImage->height() : 1,
+        outputFullRes ? dstFullImage->stride() : 1,
+    };
+    return specConstants;
+}
+
+SpirvBinary RGBToY::createSpirv(const std::shared_ptr<PipelineCache> &pipelineCache) {
+    return pipelineCache->lookup(shaderName, {}, {});
+}
+
+void RGBToY::setInput(std::shared_ptr<Image> src) {
+    assert(Image::isCompatible(srcImage_, src));
+    srcImage_ = std::move(src);
+}
+
+void RGBToY::bindAndDispatch(VkCommandBuffer cmdBuf) {
+    setInputStorage(cmdBuf, 0, srcImage_, linearSampler_);
+    if (outputDS_) {
+        setOutputStorage(cmdBuf, dstYDownsampled_->isImageStore() ? 1 : 2, dstYDownsampled_);
+    }
+    if (outputFull_) {
+        setOutputStorage(cmdBuf, dstYFull_->isImageStore() ? 3 : 4, dstYFull_);
+    }
+
+    bindPipeline(cmdBuf);
+    dispatchPipeline(cmdBuf);
+}
+
+/*******************************************************************************
+ * Downsample
+ *******************************************************************************/
+
+Downsample::Downsample(const std::shared_ptr<VULKAN_HPP_NAMESPACE::detail::DispatchLoaderDynamic> &loader,
+                       const VkDevice device, const std::shared_ptr<PipelineCache> &pipelineCache,
+                       std::shared_ptr<Image> src, std::shared_ptr<Image> dst, const std::string &debugName)
+    : ComputePipeline(loader, device, pipelineCache, createSpirv(pipelineCache), descriptorConfigs_,
+                      {&specConstants_, sizeof(specConstants_)}, 0, {dst->width(), dst->height()}, debugName),
+      srcImage_(src), dstImage_(dst), specConstants_{makeSpecConstants(src, dst)},
+      linearSampler_{createSampler(VK_FILTER_LINEAR, VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE)} {}
+
+Downsample::SpecConstants Downsample::makeSpecConstants(const std::shared_ptr<Image> &src,
+                                                        const std::shared_ptr<Image> &dst) const {
+    SpecConstants specConstants = {
+        32,
+        8,
+        1,
+        1,
+        dst->isImageStore(),
+        src->width() != dst->width() * 2,
+        src->height() != dst->height() * 2,
+        dst->width(),
+        dst->height(),
+        dst->stride(),
+    };
+    return specConstants;
+}
+
+SpirvBinary Downsample::createSpirv(const std::shared_ptr<PipelineCache> &pipelineCache) {
+    return pipelineCache->lookup(shaderName, {}, {});
+}
+
+void Downsample::bindAndDispatch(VkCommandBuffer cmdBuf) {
+    setInputStorage(cmdBuf, 0, srcImage_, linearSampler_);
+    setOutputStorage(cmdBuf, dstImage_->isImageStore() ? 1 : 2, dstImage_);
+
+    bindPipeline(cmdBuf);
+    dispatchPipeline(cmdBuf);
+}
+
+/*******************************************************************************
+ * MVProcessAndWarp
+ *******************************************************************************/
+
+MVProcessAndWarp::MVProcessAndWarp(const std::shared_ptr<VULKAN_HPP_NAMESPACE::detail::DispatchLoaderDynamic> &loader,
+                                   const VkDevice device, const std::shared_ptr<PipelineCache> &pipelineCache,
+                                   std::shared_ptr<Image> srcImage, std::shared_ptr<Image> srcFlow,
+                                   std::shared_ptr<Image> dstImage, std::shared_ptr<Image> dstFlow,
+                                   const std::string &debugName)
+    : ComputePipeline(loader, device, pipelineCache, createSpirv(pipelineCache), descriptorConfigs_,
+                      {&specConstants_, sizeof(specConstants_)}, 0, {dstImage->width(), dstImage->height()}, debugName),
+      srcSearch_(srcImage), srcFlow_(srcFlow), dstWarped_(dstImage),
+      dstFlow_(dstFlow), specConstants_{makeSpecConstants(dstImage, dstFlow)},
+      linearSampler_{createSampler(VK_FILTER_LINEAR, VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE)} {}
+
+MVProcessAndWarp::SpecConstants MVProcessAndWarp::makeSpecConstants(const std::shared_ptr<Image> &dstImage,
+                                                                    const std::shared_ptr<Image> &dstFlow) const {
+    SpecConstants specConstants = {
+        32,
+        8,
+        1,
+        1,
+        dstImage->isImageStore(),
+        2.0f,
+        2.0f,
+        0.5f,
+        0.5f,
+        dstFlow->width(),
+        dstFlow->height(),
+        dstImage->stride(),
+        dstFlow->stride(),
+    };
+    return specConstants;
+}
+
+SpirvBinary MVProcessAndWarp::createSpirv(const std::shared_ptr<PipelineCache> &pipelineCache) {
+    return pipelineCache->lookup(shaderName, {}, {});
+}
+
+void MVProcessAndWarp::bindAndDispatch(VkCommandBuffer cmdBuf) {
+    setInputStorage(cmdBuf, 0, srcSearch_, linearSampler_);
+    setInputStorage(cmdBuf, 1, srcFlow_, linearSampler_);
+    setOutputStorage(cmdBuf, dstWarped_->isImageStore() ? 2 : 3, dstWarped_);
+    setOutputStorage(cmdBuf, dstFlow_->isImageStore() ? 4 : 5, dstFlow_);
+
+    bindPipeline(cmdBuf);
+    dispatchPipeline(cmdBuf);
+}
+
+/*******************************************************************************
+ * DenseWarp
+ *******************************************************************************/
+
+DenseWarp::DenseWarp(const std::shared_ptr<VULKAN_HPP_NAMESPACE::detail::DispatchLoaderDynamic> &loader,
+                     const VkDevice device, const std::shared_ptr<PipelineCache> &pipelineCache,
+                     std::shared_ptr<Image> srcImage, std::shared_ptr<Image> srcFlow, std::shared_ptr<Image> dstImage,
+                     float inputFlowScale, const std::string &debugName)
+    : ComputePipeline(loader, device, pipelineCache, createSpirv(pipelineCache), descriptorConfigs_,
+                      {&specConstants_, sizeof(specConstants_)}, 0, {dstImage->width(), dstImage->height()}, debugName),
+      srcSearch_(srcImage), srcFlow_(srcFlow),
+      dstWarped_(dstImage), specConstants_{makeSpecConstants(dstImage, inputFlowScale)},
+      linearSampler_{createSampler(VK_FILTER_LINEAR, VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE)},
+      nearestSampler_{createSampler(VK_FILTER_NEAREST, VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE)} {}
+
+DenseWarp::SpecConstants DenseWarp::makeSpecConstants(const std::shared_ptr<Image> &dstImage,
+                                                      float inputFlowScale) const {
+    SpecConstants specConstants = {
+        32,
+        8,
+        1,
+        1,
+        dstImage->isImageStore(),
+        inputFlowScale,
+        dstImage->width(),
+        dstImage->height(),
+        dstImage->stride(),
+    };
+    return specConstants;
+}
+
+SpirvBinary DenseWarp::createSpirv(const std::shared_ptr<PipelineCache> &pipelineCache) {
+    return pipelineCache->lookup(shaderName, {}, {});
+}
+
+void DenseWarp::setInputFlow(std::shared_ptr<Image> srcFlow) {
+    assert(Image::isCompatible(srcFlow, srcFlow_));
+    srcFlow_ = std::move(srcFlow);
+}
+
+void DenseWarp::bindAndDispatch(VkCommandBuffer cmdBuf) {
+    setInputStorage(cmdBuf, 0, srcSearch_, linearSampler_);
+    setInputStorage(cmdBuf, 1, srcFlow_, nearestSampler_);
+    setOutputStorage(cmdBuf, dstWarped_->isImageStore() ? 2 : 3, dstWarped_);
+
+    bindPipeline(cmdBuf);
+    dispatchPipeline(cmdBuf);
+}
+
+/*******************************************************************************
+ * MedianFilter
+ *******************************************************************************/
+
+MedianFilter::MedianFilter(const std::shared_ptr<VULKAN_HPP_NAMESPACE::detail::DispatchLoaderDynamic> &loader,
+                           const VkDevice device, const std::shared_ptr<PipelineCache> &pipelineCache,
+                           std::shared_ptr<Image> srcImage, std::shared_ptr<Image> dstImage, float outputFlowScale,
+                           const std::string &debugName)
+    : ComputePipeline(loader, device, pipelineCache, createSpirv(pipelineCache), descriptorConfigs_,
+                      {&specConstants_, sizeof(specConstants_)}, 0, {dstImage->width(), dstImage->height()}, debugName),
+      srcFlow_(srcImage), dstFlow_(dstImage), specConstants_{makeSpecConstants(dstImage, outputFlowScale)},
+      nearestSampler_{createSampler(VK_FILTER_NEAREST, VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE)} {}
+
+MedianFilter::SpecConstants MedianFilter::makeSpecConstants(const std::shared_ptr<Image> &dstImage,
+                                                            float outputFlowScale) const {
+    SpecConstants specConstants = {
+        32,
+        8,
+        1,
+        1,
+        dstImage->isImageStore(),
+        outputFlowScale,
+        dstImage->width(),
+        dstImage->height(),
+        dstImage->stride(),
+    };
+    return specConstants;
+}
+
+SpirvBinary MedianFilter::createSpirv(const std::shared_ptr<PipelineCache> &pipelineCache) {
+    return pipelineCache->lookup(shaderName, {}, {});
+}
+
+void MedianFilter::setOutput(std::shared_ptr<Image> dstImage) {
+    assert(Image::isCompatible(dstFlow_, dstImage));
+    dstFlow_ = std::move(dstImage);
+}
+
+void MedianFilter::bindAndDispatch(VkCommandBuffer cmdBuf) {
+    setInputStorage(cmdBuf, 0, srcFlow_, nearestSampler_);
+    setOutputStorage(cmdBuf, dstFlow_->isImageStore() ? 1 : 2, dstFlow_);
+
+    bindPipeline(cmdBuf);
+    dispatchPipeline(cmdBuf);
+}
+
+/*******************************************************************************
+ * BilateralFilter
+ *******************************************************************************/
+
+BilateralFilter::BilateralFilter(const std::shared_ptr<VULKAN_HPP_NAMESPACE::detail::DispatchLoaderDynamic> &loader,
+                                 const VkDevice device, const std::shared_ptr<PipelineCache> &pipelineCache,
+                                 std::shared_ptr<Image> srcImage, std::shared_ptr<Image> srcFlow,
+                                 std::shared_ptr<Image> dstFlow, float outputFlowScale, const std::string &debugName)
+    : ComputePipeline(loader, device, pipelineCache, createSpirv(pipelineCache), descriptorConfigs_,
+                      {&specConstants_, sizeof(specConstants_)}, 0, {dstFlow->width(), dstFlow->height()}, debugName),
+      srcTemplate_(srcImage), srcFlow_(srcFlow),
+      dstFlow_(dstFlow), specConstants_{makeSpecConstants(dstFlow, outputFlowScale)},
+      nearestSampler_{createSampler(VK_FILTER_NEAREST, VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE)} {}
+
+BilateralFilter::SpecConstants BilateralFilter::makeSpecConstants(const std::shared_ptr<Image> &dstFlow,
+                                                                  float outputFlowScale) const {
+    SpecConstants specConstants = {
+        32, 8, 1, 1, dstFlow->isImageStore(), outputFlowScale, dstFlow->width(), dstFlow->height(), dstFlow->stride(),
+    };
+    return specConstants;
+}
+
+SpirvBinary BilateralFilter::createSpirv(const std::shared_ptr<PipelineCache> &pipelineCache) {
+    return pipelineCache->lookup(shaderName, {}, {});
+}
+
+void BilateralFilter::setOutput(std::shared_ptr<Image> dstFlow) {
+    assert(Image::isCompatible(dstFlow, dstFlow_));
+    dstFlow_ = std::move(dstFlow);
+}
+
+void BilateralFilter::bindAndDispatch(VkCommandBuffer cmdBuf) {
+    setInputStorage(cmdBuf, 0, srcTemplate_, nearestSampler_);
+    setInputStorage(cmdBuf, 1, srcFlow_, nearestSampler_);
+    setOutputStorage(cmdBuf, dstFlow_->isImageStore() ? 2 : 3, dstFlow_);
+
+    bindPipeline(cmdBuf);
+    dispatchPipeline(cmdBuf);
+}
+
+/*******************************************************************************
+ * SubpixelME
+ *******************************************************************************/
+
+SubpixelME::SubpixelME(const std::shared_ptr<VULKAN_HPP_NAMESPACE::detail::DispatchLoaderDynamic> &loader,
+                       const VkDevice device, const std::shared_ptr<PipelineCache> &pipelineCache,
+                       std::shared_ptr<Image> srcImageSearch, std::shared_ptr<Image> srcImageTemplate,
+                       std::shared_ptr<Image> srcFlow, std::shared_ptr<Image> prevLevelFlow,
+                       std::shared_ptr<Image> dstFlow, bool doAccumulate, const std::string &debugName)
+    : ComputePipeline(loader, device, pipelineCache, createSpirv(pipelineCache), descriptorConfigs_,
+                      {&specConstants_, sizeof(specConstants_)}, 0, {dstFlow->width(), dstFlow->height()}, debugName),
+      srcSearch_(srcImageSearch), srcTemplate_(srcImageTemplate), srcFlow_(srcFlow), srcPrevLevelFlow_(prevLevelFlow),
+      dstFlow_(dstFlow), specConstants_{makeSpecConstants(srcFlow, prevLevelFlow, dstFlow, doAccumulate)},
+      nearestZeroPadSampler_{createSampler(VK_FILTER_NEAREST, VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER)},
+      nearestRepeatPadSampler_{createSampler(VK_FILTER_NEAREST, VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE)} {}
+
+SubpixelME::SpecConstants SubpixelME::makeSpecConstants(const std::shared_ptr<Image> &srcFlow,
+                                                        const std::shared_ptr<Image> &prevLevelFlow,
+                                                        const std::shared_ptr<Image> &dstFlow,
+                                                        bool doAccumulate) const {
+    SpecConstants specConstants = {
+        32,
+        8,
+        1,
+        1,
+        doAccumulate,
+        doAccumulate ? prevLevelFlow->isBufferLoad() : false,
+        dstFlow->isImageStore(),
+        dstFlow->width(),
+        dstFlow->height(),
+        srcFlow->stride(),
+        doAccumulate ? prevLevelFlow->stride() : 1,
+        dstFlow->stride(),
+    };
+    return specConstants;
+}
+
+SpirvBinary SubpixelME::createSpirv(const std::shared_ptr<PipelineCache> &pipelineCache) {
+    return pipelineCache->lookup(shaderName, {}, {});
+}
+
+void SubpixelME::setOutput(std::shared_ptr<Image> dstFlow) {
+    assert(Image::isCompatible(dstFlow, dstFlow_));
+    dstFlow_ = std::move(dstFlow);
+}
+
+void SubpixelME::bindAndDispatch(VkCommandBuffer cmdBuf) {
+    setInputStorage(cmdBuf, 0, srcSearch_, nearestZeroPadSampler_);
+    setInputStorage(cmdBuf, 1, srcTemplate_, nearestRepeatPadSampler_);
+    setInputStorage(cmdBuf, 2, srcFlow_, nearestZeroPadSampler_);
+    setInputStorage(cmdBuf, srcPrevLevelFlow_->isBufferLoad() ? 4 : 3, srcPrevLevelFlow_, nearestZeroPadSampler_);
+    setOutputStorage(cmdBuf, dstFlow_->isImageStore() ? 5 : 6, dstFlow_);
+
+    bindPipeline(cmdBuf);
+    dispatchPipeline(cmdBuf);
+}
+
+/*******************************************************************************
+ * MVReplace
+ *******************************************************************************/
+
+MVReplace::MVReplace(const std::shared_ptr<VULKAN_HPP_NAMESPACE::detail::DispatchLoaderDynamic> &loader,
+                     const VkDevice device, const std::shared_ptr<PipelineCache> &pipelineCache,
+                     std::shared_ptr<Image> mvInput, std::shared_ptr<Image> flowBlockMatch,
+                     std::shared_ptr<Image> costAtInput, std::shared_ptr<Image> minCostBlockMatch,
+                     std::shared_ptr<Image> dstFlow, std::shared_ptr<Image> dstCost, bool outputCost,
+                     const std::string &debugName)
+    : ComputePipeline(loader, device, pipelineCache, createSpirv(pipelineCache), descriptorConfigs_,
+                      {&specConstants_, sizeof(specConstants_)}, 0, {dstFlow->width(), dstFlow->height()}, debugName),
+      srcInputMV_(mvInput), srcBlockMatchFlow_(flowBlockMatch), srcInputMVCost_(costAtInput),
+      srcBlockMatchCost_(minCostBlockMatch), dstFlow_(dstFlow), dstCost_(dstCost),
+      outputCost_(outputCost), specConstants_{makeSpecConstants(costAtInput, dstFlow, dstCost, outputCost)},
+      nearestSampler_{createSampler(VK_FILTER_NEAREST, VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE)} {}
+
+MVReplace::SpecConstants MVReplace::makeSpecConstants(const std::shared_ptr<Image> &costAtInput,
+                                                      const std::shared_ptr<Image> &dstFlow,
+                                                      const std::shared_ptr<Image> &dstCost, bool outputCost) const {
+    SpecConstants specConstants = {
+        32,
+        8,
+        1,
+        1,
+        outputCost,
+        costAtInput->isBufferLoad(),
+        dstFlow->isImageStore(),
+        dstFlow->width(),
+        dstFlow->height(),
+        costAtInput->stride(),
+        dstFlow->stride(),
+        outputCost ? dstCost->stride() : 1,
+    };
+    return specConstants;
+}
+
+SpirvBinary MVReplace::createSpirv(const std::shared_ptr<PipelineCache> &pipelineCache) {
+    return pipelineCache->lookup(shaderName, {}, {});
+}
+
+void MVReplace::setInputMv(std::shared_ptr<Image> srcMV) {
+    assert(Image::isCompatible(srcInputMV_, srcMV));
+    srcInputMV_ = std::move(srcMV);
+}
+
+void MVReplace::setOutputFlow(std::shared_ptr<Image> dstFlow) {
+    assert(Image::isCompatible(dstFlow, dstFlow_));
+    dstFlow_ = std::move(dstFlow);
+}
+
+void MVReplace::setOutputCost(std::shared_ptr<Image> dstCost) {
+    assert(Image::isCompatible(dstCost, dstCost_));
+    dstCost_ = std::move(dstCost);
+}
+
+void MVReplace::bindAndDispatch(VkCommandBuffer cmdBuf) {
+    setInputStorage(cmdBuf, 0, srcInputMV_, nearestSampler_);
+    setInputStorage(cmdBuf, 1, srcBlockMatchFlow_, nearestSampler_);
+    setInputStorage(cmdBuf, srcInputMVCost_->isBufferLoad() ? 3 : 2, srcInputMVCost_, nearestSampler_);
+    setInputStorage(cmdBuf, srcBlockMatchCost_->isBufferLoad() ? 5 : 4, srcBlockMatchCost_, nearestSampler_);
+    setOutputStorage(cmdBuf, dstFlow_->isImageStore() ? 6 : 7, dstFlow_);
+
+    if (outputCost_) {
+        setOutputStorage(cmdBuf, dstCost_->isImageStore() ? 8 : 9, dstCost_);
+    }
+
+    bindPipeline(cmdBuf);
+    dispatchPipeline(cmdBuf);
+}
+
+/*******************************************************************************
+ * BlockMatch
+ *******************************************************************************/
+
+BlockMatch::BlockMatch(const std::shared_ptr<VULKAN_HPP_NAMESPACE::detail::DispatchLoaderDynamic> &loader,
+                       const VkDevice device, const std::shared_ptr<PipelineCache> &pipelineCache,
+                       SearchType searchType, int32_t maxSearchRange, std::shared_ptr<Image> srcSearch,
+                       std::shared_ptr<Image> srcTemplate, std::shared_ptr<Image> dstFlow,
+                       std::shared_ptr<Image> dstCost, const std::string &debugName)
+    : ComputePipeline(loader, device, pipelineCache, createSpirv(pipelineCache), descriptorConfigs_,
+                      {&specConstants_, sizeof(specConstants_)}, sizeof(PushConstants),
+                      {srcSearch->width(), srcSearch->height()}, debugName),
+      srcSearch_(srcSearch), srcTemplate_(srcTemplate), dstFlow_(dstFlow), dstCost_(dstCost), searchType_(searchType),
+      maxSearchRange_(maxSearchRange),
+      searchRangeLimit_(maxSearchRange), specConstants_{makeSpecConstants(searchType_, maxSearchRange_, dstFlow_,
+                                                                          dstCost_)},
+      nearestSampler_{createSampler(VK_FILTER_NEAREST, VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER)} {
+    // MIN_SAD* assumes maxSearchRange > 0
+    assert(!(searchType_ != SearchType::RAW_SAD && maxSearchRange_ == 0));
+    // RAW_SAD supports only in case maxSearchRange = 0
+    assert(!(searchType_ == SearchType::RAW_SAD && maxSearchRange_ != 0));
+}
+
+BlockMatch::SpecConstants BlockMatch::makeSpecConstants(SearchType searchType, int32_t maxSearchRange,
+                                                        const std::shared_ptr<Image> &dstFlow,
+                                                        const std::shared_ptr<Image> &dstCost) const {
+    SpecConstants specConstants = {
+        32,
+        8,
+        1,
+        1,
+        static_cast<int32_t>(searchType),
+        maxSearchRange,
+        hasFlowOutput() ? dstFlow->width() : dstCost->width(),
+        hasFlowOutput() ? dstFlow->height() : dstCost->height(),
+        hasFlowOutput() ? dstFlow->stride() : 0,
+        hasCostOutput() ? dstCost->stride() : 0,
+        hasCostOutput() && dstCost->isImageStore(),
+    };
+    return specConstants;
+}
+
+SpirvBinary BlockMatch::createSpirv(const std::shared_ptr<PipelineCache> &pipelineCache) {
+    return pipelineCache->lookup(shaderName, {}, {});
+}
+
+bool BlockMatch::hasFlowOutput() const {
+    return searchType_ == SearchType::MIN_SAD_COST || searchType_ == SearchType::MIN_SAD;
+}
+
+bool BlockMatch::hasCostOutput() const {
+    return searchType_ == SearchType::MIN_SAD_COST || searchType_ == SearchType::RAW_SAD;
+}
+
+void BlockMatch::setOutputCost(std::shared_ptr<Image> dstImage) {
+    assert(Image::isCompatible(dstCost_, dstImage));
+    dstCost_ = std::move(dstImage);
+}
+
+void BlockMatch::setSearchRangeLimit(int newSearchRangeLimit) {
+    if (newSearchRangeLimit < 0 || newSearchRangeLimit > maxSearchRange_) {
+        throw std::runtime_error("Search range limit must be between 0 and maxSearchRange");
+    }
+    searchRangeLimit_ = newSearchRangeLimit;
+}
+
+void BlockMatch::bindAndDispatch(VkCommandBuffer cmdBuf) {
+    setInputStorage(cmdBuf, 0, srcTemplate_, nearestSampler_);
+    setInputStorage(cmdBuf, 1, srcSearch_, nearestSampler_);
+
+    if (hasFlowOutput()) {
+        setOutputStorage(cmdBuf, 2, dstFlow_);
+    }
+    if (hasCostOutput()) {
+        setOutputStorage(cmdBuf, dstCost_->isImageStore() ? 3 : 4, dstCost_);
+    }
+
+    bindPipeline(cmdBuf);
+
+    const int searchIndexLimit = (searchRangeLimit_ * 2 + 1) * (searchRangeLimit_ * 2 + 1);
+    const PushConstants pushConstants{searchIndexLimit};
+    setPushConstants(cmdBuf, pushConstants);
+
+    dispatchPipeline(cmdBuf);
+}
+
+} // namespace mlsdk::el::compute::optical_flow

--- a/graph/compute_optical_flow.hpp
+++ b/graph/compute_optical_flow.hpp
@@ -1,0 +1,590 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+#pragma once
+
+/*******************************************************************************
+ * Includes
+ *******************************************************************************/
+
+#include "compute_pipeline_common.hpp"
+#include "image.hpp"
+#include "mlel/utils.hpp"
+#include "pipeline_cache.hpp"
+#include "tensor.hpp"
+
+#include <vulkan/vulkan.hpp>
+
+#include <string_view>
+#include <vector>
+
+using namespace mlsdk::el::utils;
+namespace mlsdk::el::compute::optical_flow {
+
+struct DescriptorConfig {
+    uint32_t index = 0;
+    VkDescriptorType type = VK_DESCRIPTOR_TYPE_MAX_ENUM;
+    VkDescriptorBindingFlags flags{};
+    DescriptorConfig(uint32_t index_in, VkDescriptorType type_in, VkDescriptorBindingFlags flags_in)
+        : index(index_in), type(type_in), flags(flags_in) {}
+
+  private:
+    DescriptorConfig() = delete;
+};
+using DescriptorConfigs = std::vector<DescriptorConfig>;
+
+struct SpecConstants {
+    const void *pointer;
+    uint32_t sizeBytes;
+};
+
+class ScheduleHelper {
+  public:
+    ScheduleHelper(uint32_t width, uint32_t height) {
+        groupCountX = divideRoundUp(width, localSizeX);
+        groupCountY = divideRoundUp(height, localSizeY);
+    }
+    uint32_t localSizeX = 32;
+    uint32_t localSizeY = 8;
+    uint32_t groupCountX = 1;
+    uint32_t groupCountY = 1;
+    uint32_t groupCountZ = 1;
+};
+
+/*******************************************************************************
+ * ComputePipeline
+ *******************************************************************************/
+
+class ComputePipeline {
+  public:
+    ComputePipeline(const std::shared_ptr<VULKAN_HPP_NAMESPACE::detail::DispatchLoaderDynamic> &loader, VkDevice device,
+                    const std::shared_ptr<PipelineCache> &pipelineCache, const SpirvBinary &spirv,
+                    const DescriptorConfigs &descriptorConfigs, const SpecConstants &specConstants,
+                    uint32_t pushConstantsSize, const ScheduleHelper &schedule, const std::string &debugName);
+    virtual ~ComputePipeline();
+
+    void makePipeline();
+    void setInputStorage(VkCommandBuffer cmdBuf, uint32_t binding, const std::shared_ptr<Image> &image,
+                         VkSampler sampler = VK_NULL_HANDLE);
+    void setOutputStorage(VkCommandBuffer cmdBuf, uint32_t binding, const std::shared_ptr<Image> &image);
+
+    virtual void bindAndDispatch(VkCommandBuffer cmdBuf) = 0;
+
+  protected:
+    VkSampler createSampler(VkFilter filter, VkSamplerAddressMode addressMode, bool unnormalizedCoordinates);
+    template <typename T> void setPushConstants(VkCommandBuffer cmdBuf, const T &constants);
+    void bindPipeline(VkCommandBuffer cmdBuf);
+    void dispatchPipeline(VkCommandBuffer cmdBuf);
+
+  private:
+    void setCombinedImageSampler(uint32_t binding, const std::shared_ptr<Image> &image, VkSampler sampler);
+    void setOutputImage(uint32_t binding, const std::shared_ptr<Image> &image);
+    void setImage(uint32_t binding, const std::shared_ptr<Image> &image, VkDescriptorType descriptorType,
+                  VkSampler sampler);
+    void setBuffer(uint32_t binding, const std::shared_ptr<Image> &image);
+
+    std::shared_ptr<VULKAN_HPP_NAMESPACE::detail::DispatchLoaderDynamic> loader_;
+    VkDevice device_;
+    const std::shared_ptr<PipelineCache> &pipelineCache_;
+    SpirvBinary spirv_;
+    DescriptorConfigs descriptorConfigs_;
+    VkPipeline vkPipeline_{};
+    SpecConstants specConstants_;
+    uint32_t pushConstantsSize_;
+    ScheduleHelper scheduler_;
+
+    VkPipelineLayout pipelineLayout_{};
+    VkDescriptorSetLayout descriptorSetLayout_{};
+    VkDescriptorPool descriptorPool_{};
+    VkDescriptorSet descriptorSet_{};
+    const VkAllocationCallbacks *pAllocator_ = nullptr;
+    std::vector<VkSampler> samplers_;
+
+    std::string debugName_;
+};
+
+template <typename T> void ComputePipeline::setPushConstants(VkCommandBuffer cmdBuf, const T &constants) {
+    assert(pushConstantsSize_ == sizeof(T));
+    loader_->vkCmdPushConstants(cmdBuf, pipelineLayout_, VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(T), &constants);
+}
+
+/*******************************************************************************
+ * RGBToY
+ *******************************************************************************/
+
+class RGBToY : public ComputePipeline {
+  public:
+    RGBToY(const std::shared_ptr<VULKAN_HPP_NAMESPACE::detail::DispatchLoaderDynamic> &loader, VkDevice device,
+           const std::shared_ptr<PipelineCache> &pipelineCache, std::shared_ptr<Image> srcRGBImage,
+           std::shared_ptr<Image> dstDownsampledImage, std::shared_ptr<Image> dstFullImage, bool outputDownsample,
+           bool outputFullRes, float downsampleScale, const std::string &debugName);
+    ~RGBToY() override = default;
+
+    struct SpecConstants {
+        uint32_t threadGroupSizeX;
+        uint32_t threadGroupSizeY;
+        uint32_t vectorisationfactorX;
+        uint32_t vectorisationfactorY;
+        VkBool32 isLumaInput;
+        VkBool32 outputDownsampledImage;
+        VkBool32 outputFullImage;
+        VkBool32 isImageStore;
+        float downsampleScaleX;
+        float downsampleScaleY;
+        uint32_t downsampledImageWidth;
+        uint32_t downsampledImageHeight;
+        uint32_t downsampledImageStride;
+        uint32_t fullImageWidth;
+        uint32_t fullImageHeight;
+        uint32_t fullImageStride;
+    };
+
+    SpirvBinary createSpirv(const std::shared_ptr<PipelineCache> &pipelineCache);
+    SpecConstants makeSpecConstants(const std::shared_ptr<Image> &srcRGBImage,
+                                    const std::shared_ptr<Image> &dstDownsampledImage,
+                                    const std::shared_ptr<Image> &dstFullImage, bool outputDownsample,
+                                    bool outputFullRes, float downsampleScale) const;
+    void setInput(std::shared_ptr<Image> src);
+    void bindAndDispatch(VkCommandBuffer cmdBuf) override;
+
+  private:
+    static constexpr std::string_view shaderName = "rgb_to_y";
+    std::shared_ptr<Image> srcImage_;
+    std::shared_ptr<Image> dstYDownsampled_;
+    std::shared_ptr<Image> dstYFull_;
+    bool outputDS_;
+    bool outputFull_;
+    float scale_ = 1.f;
+    SpecConstants specConstants_;
+    VkSampler linearSampler_;
+
+    inline static const DescriptorConfigs descriptorConfigs_{
+        {0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, {}},                                // Src
+        {1, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT},  // DstDs
+        {2, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT}, // DstDs
+        {3, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT},  // DstFull
+        {4, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT}  // DstFull
+    };
+};
+
+/*******************************************************************************
+ * Downsample
+ *******************************************************************************/
+
+class Downsample : public ComputePipeline {
+  public:
+    Downsample(const std::shared_ptr<VULKAN_HPP_NAMESPACE::detail::DispatchLoaderDynamic> &loader, VkDevice device,
+               const std::shared_ptr<PipelineCache> &pipelineCache, std::shared_ptr<Image> src,
+               std::shared_ptr<Image> dst, const std::string &debugName);
+    ~Downsample() override = default;
+
+    struct SpecConstants {
+        uint32_t threadGroupSizeX;
+        uint32_t threadGroupSizeY;
+        uint32_t vectorisationfactorX;
+        uint32_t vectorisationfactorY;
+        VkBool32 isImageStore;
+        VkBool32 padX;
+        VkBool32 padY;
+        uint32_t outputImageWidth;
+        uint32_t outputImageHeight;
+        uint32_t outputImageStride;
+    };
+
+    SpirvBinary createSpirv(const std::shared_ptr<PipelineCache> &pipelineCache);
+    SpecConstants makeSpecConstants(const std::shared_ptr<Image> &srcImage,
+                                    const std::shared_ptr<Image> &dstImage) const;
+
+    void bindAndDispatch(VkCommandBuffer cmdBuf) override;
+
+  private:
+    static constexpr std::string_view shaderName = "downsample";
+    std::shared_ptr<Image> srcImage_;
+    std::shared_ptr<Image> dstImage_;
+    SpecConstants specConstants_;
+    VkSampler linearSampler_;
+
+    inline static const DescriptorConfigs descriptorConfigs_{
+        {0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, {}},                               // Src
+        {1, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT}, // Dst
+        {2, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT} // Dst
+    };
+};
+
+/*******************************************************************************
+ * MVProcessAndWarp
+ *******************************************************************************/
+
+class MVProcessAndWarp : public ComputePipeline {
+  public:
+    MVProcessAndWarp(const std::shared_ptr<VULKAN_HPP_NAMESPACE::detail::DispatchLoaderDynamic> &loader,
+                     VkDevice device, const std::shared_ptr<PipelineCache> &pipelineCache,
+                     std::shared_ptr<Image> srcImage, std::shared_ptr<Image> _srcFlow, std::shared_ptr<Image> dstImage,
+                     std::shared_ptr<Image> _dstFlow, const std::string &debugName);
+    ~MVProcessAndWarp() override = default;
+
+    struct SpecConstants {
+        uint32_t threadGroupSizeX;
+        uint32_t threadGroupSizeY;
+        uint32_t vectorisationfactorX;
+        uint32_t vectorisationfactorY;
+        VkBool32 isImageStore;
+        float downsampleScaleX;
+        float downsampleScaleY;
+        float upsampleScaleX;
+        float upsampleScaleY;
+        uint32_t outputImageWidth;
+        uint32_t outputImageHeight;
+        uint32_t outputImageStride;
+        uint32_t outputFlowStride;
+    };
+
+    SpirvBinary createSpirv(const std::shared_ptr<PipelineCache> &pipelineCache);
+    SpecConstants makeSpecConstants(const std::shared_ptr<Image> &dstImage,
+                                    const std::shared_ptr<Image> &dstFlow) const;
+    void bindAndDispatch(VkCommandBuffer cmdBuf) override;
+
+  private:
+    static constexpr std::string_view shaderName = "mv_process_and_warp";
+    std::shared_ptr<Image> srcSearch_;
+    std::shared_ptr<Image> srcFlow_;
+    std::shared_ptr<Image> dstWarped_;
+    std::shared_ptr<Image> dstFlow_;
+    SpecConstants specConstants_;
+    VkSampler linearSampler_;
+
+    inline static const DescriptorConfigs descriptorConfigs_{
+        {0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, {}},                                // Src
+        {1, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, {}},                                // SrcFlow
+        {2, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT},  // Dst
+        {3, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT}, // Dst
+        {4, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT},  // DstFlow
+        {5, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT}  // DstFlow
+    };
+};
+
+/*******************************************************************************
+ * DenseWarp
+ *******************************************************************************/
+
+class DenseWarp : public ComputePipeline {
+  public:
+    DenseWarp(const std::shared_ptr<VULKAN_HPP_NAMESPACE::detail::DispatchLoaderDynamic> &loader, VkDevice device,
+              const std::shared_ptr<PipelineCache> &pipelineCache, std::shared_ptr<Image> srcImage,
+              std::shared_ptr<Image> _srcFlow, std::shared_ptr<Image> dstImage, float inputFlowScale,
+              const std::string &debugName);
+    ~DenseWarp() override = default;
+
+    struct SpecConstants {
+        uint32_t threadGroupSizeX;
+        uint32_t threadGroupSizeY;
+        uint32_t vectorisationfactorX;
+        uint32_t vectorisationfactorY;
+        VkBool32 isImageStore;
+        float inputFlowScale;
+        uint32_t outputImageWidth;
+        uint32_t outputImageHeight;
+        uint32_t outputImageStride;
+    };
+
+    SpirvBinary createSpirv(const std::shared_ptr<PipelineCache> &pipelineCache);
+    SpecConstants makeSpecConstants(const std::shared_ptr<Image> &dstImage, float inputFlowScale) const;
+
+    void setInputFlow(std::shared_ptr<Image> _srcFlow);
+
+    void bindAndDispatch(VkCommandBuffer cmdBuf) override;
+
+  private:
+    static constexpr std::string_view shaderName = "dense_warp";
+    std::shared_ptr<Image> srcSearch_;
+    std::shared_ptr<Image> srcFlow_;
+    std::shared_ptr<Image> dstWarped_;
+    SpecConstants specConstants_;
+    VkSampler linearSampler_;
+    VkSampler nearestSampler_;
+
+    inline static const DescriptorConfigs descriptorConfigs_{
+        {0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, {}},                                // Src
+        {1, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, {}},                                // SrcFlow
+        {2, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT},  // Dst
+        {3, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT}, // Dst
+    };
+};
+
+/*******************************************************************************
+ * MedianFilter
+ *******************************************************************************/
+
+class MedianFilter : public ComputePipeline {
+  public:
+    MedianFilter(const std::shared_ptr<VULKAN_HPP_NAMESPACE::detail::DispatchLoaderDynamic> &loader, VkDevice device,
+                 const std::shared_ptr<PipelineCache> &pipelineCache, std::shared_ptr<Image> srcImage,
+                 std::shared_ptr<Image> dstImage, float outputFlowScale, const std::string &debugName);
+    ~MedianFilter() override = default;
+
+    struct SpecConstants {
+        uint32_t threadGroupSizeX;
+        uint32_t threadGroupSizeY;
+        uint32_t vectorisationfactorX;
+        uint32_t vectorisationfactorY;
+        VkBool32 isImageStore;
+        float outputFlowScale;
+        uint32_t outputImageWidth;
+        uint32_t outputImageHeight;
+        uint32_t outputImageStride;
+    };
+
+    SpirvBinary createSpirv(const std::shared_ptr<PipelineCache> &pipelineCache);
+    SpecConstants makeSpecConstants(const std::shared_ptr<Image> &dstImage, float outputFlowScale) const;
+
+    void setOutput(std::shared_ptr<Image> dstImage);
+    void bindAndDispatch(VkCommandBuffer cmdBuf) override;
+
+  private:
+    static constexpr std::string_view shaderName = "median_filter";
+    std::shared_ptr<Image> srcFlow_;
+    std::shared_ptr<Image> dstFlow_;
+    SpecConstants specConstants_;
+    VkSampler nearestSampler_;
+
+    inline static const DescriptorConfigs descriptorConfigs_{
+        {0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, {}},                               // Src
+        {1, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT}, // Dst
+        {2, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT} // Dst
+    };
+};
+
+/*******************************************************************************
+ * BilateralFilter
+ *******************************************************************************/
+
+class BilateralFilter : public ComputePipeline {
+  public:
+    BilateralFilter(const std::shared_ptr<VULKAN_HPP_NAMESPACE::detail::DispatchLoaderDynamic> &loader, VkDevice device,
+                    const std::shared_ptr<PipelineCache> &pipelineCache, std::shared_ptr<Image> srcImage,
+                    std::shared_ptr<Image> srcFlow, std::shared_ptr<Image> dstFlow, float outputFlowScale,
+                    const std::string &debugName);
+    ~BilateralFilter() override = default;
+
+    struct SpecConstants {
+        uint32_t threadGroupSizeX;
+        uint32_t threadGroupSizeY;
+        uint32_t vectorisationfactorX;
+        uint32_t vectorisationfactorY;
+        VkBool32 isImageStore;
+        float outputFlowScale;
+        uint32_t outputImageWidth;
+        uint32_t outputImageHeight;
+        uint32_t outputImageStride;
+    };
+
+    SpirvBinary createSpirv(const std::shared_ptr<PipelineCache> &pipelineCache);
+    SpecConstants makeSpecConstants(const std::shared_ptr<Image> &dstFlow, float outputFlowScale) const;
+
+    void setOutput(std::shared_ptr<Image> _dstFlow);
+    void bindAndDispatch(VkCommandBuffer cmdBuf) override;
+
+  private:
+    static constexpr std::string_view shaderName = "bilateral_filter";
+    std::shared_ptr<Image> srcTemplate_;
+    std::shared_ptr<Image> srcFlow_;
+    std::shared_ptr<Image> dstFlow_;
+    SpecConstants specConstants_;
+    VkSampler nearestSampler_;
+
+    inline static const DescriptorConfigs descriptorConfigs_{
+        {0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, {}},                               // Src
+        {1, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, {}},                               // SrcFlow
+        {2, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT}, // DstFlow
+        {3, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT} // DstFlow
+    };
+};
+
+/*******************************************************************************
+ * SubpixelME
+ *******************************************************************************/
+
+class SubpixelME : public ComputePipeline {
+  public:
+    SubpixelME(const std::shared_ptr<VULKAN_HPP_NAMESPACE::detail::DispatchLoaderDynamic> &loader, VkDevice device,
+               const std::shared_ptr<PipelineCache> &pipelineCache, std::shared_ptr<Image> srcImageSearch,
+               std::shared_ptr<Image> srcImageTemplate, std::shared_ptr<Image> srcFlow,
+               std::shared_ptr<Image> prevLevelFlow, std::shared_ptr<Image> dstFlow, bool doAccumulate,
+               const std::string &debugName);
+    ~SubpixelME() override = default;
+
+    struct SpecConstants {
+        uint32_t threadGroupSizeX;
+        uint32_t threadGroupSizeY;
+        uint32_t vectorisationfactorX;
+        uint32_t vectorisationfactorY;
+        VkBool32 doAccumulate;
+        VkBool32 isFlowBufferLoad;
+        VkBool32 isImageStore;
+        uint32_t outputWidth;
+        uint32_t outputHeight;
+        uint32_t inputFlowStride;
+        uint32_t previousFlowStride;
+        uint32_t outputFlowStride;
+    };
+
+    SpirvBinary createSpirv(const std::shared_ptr<PipelineCache> &pipelineCache);
+    SpecConstants makeSpecConstants(const std::shared_ptr<Image> &srcFlow, const std::shared_ptr<Image> &prevLevelFlow,
+                                    const std::shared_ptr<Image> &dstFlow, bool doAccumulate) const;
+
+    void setOutput(std::shared_ptr<Image> _dstFlow);
+    void bindAndDispatch(VkCommandBuffer cmdBuf) override;
+
+  private:
+    static constexpr std::string_view shaderName = "subpixel_me";
+    std::shared_ptr<Image> srcSearch_;
+    std::shared_ptr<Image> srcTemplate_;
+    std::shared_ptr<Image> srcFlow_;
+    std::shared_ptr<Image> srcPrevLevelFlow_;
+    std::shared_ptr<Image> dstFlow_;
+    SpecConstants specConstants_;
+    VkSampler nearestZeroPadSampler_;
+    VkSampler nearestRepeatPadSampler_;
+
+    inline static const DescriptorConfigs descriptorConfigs_{
+        {0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, {}},                                        // SrcSearch
+        {1, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, {}},                                        // SrcTemplate
+        {2, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, {}},                                                // SrcFlow
+        {3, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT}, // PrevFlow
+        {4, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT},         // PrevFlow
+        {5, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT},          // DstFlow
+        {6, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT}          // DstFlow
+    };
+};
+
+/*******************************************************************************
+ * MVReplace
+ *******************************************************************************/
+
+class MVReplace : public ComputePipeline {
+  public:
+    MVReplace(const std::shared_ptr<VULKAN_HPP_NAMESPACE::detail::DispatchLoaderDynamic> &loader, VkDevice device,
+              const std::shared_ptr<PipelineCache> &pipelineCache, std::shared_ptr<Image> mvInput,
+              std::shared_ptr<Image> flowBlockMatch, std::shared_ptr<Image> costAtInput,
+              std::shared_ptr<Image> minCostBlockMatch, std::shared_ptr<Image> dstFlow, std::shared_ptr<Image> dstCost,
+              bool outputCost, const std::string &debugName);
+    ~MVReplace() override = default;
+
+    struct SpecConstants {
+        uint32_t threadGroupSizeX;
+        uint32_t threadGroupSizeY;
+        uint32_t vectorisationfactorX;
+        uint32_t vectorisationfactorY;
+        VkBool32 outputCost;
+        VkBool32 isCostBufferLoad;
+        VkBool32 isImageStore;
+        uint32_t outputWidth;
+        uint32_t outputHeight;
+        uint32_t inputCostStride;
+        uint32_t outputFlowStride;
+        uint32_t outputCostStride;
+    };
+
+    SpirvBinary createSpirv(const std::shared_ptr<PipelineCache> &pipelineCache);
+    SpecConstants makeSpecConstants(const std::shared_ptr<Image> &costAtInput, const std::shared_ptr<Image> &dstFlow,
+                                    const std::shared_ptr<Image> &dstCost, bool outputCost) const;
+
+    void setInputMv(std::shared_ptr<Image> srcMV);
+    void setOutputFlow(std::shared_ptr<Image> dstFlow);
+    void setOutputCost(std::shared_ptr<Image> dstCost);
+    void bindAndDispatch(VkCommandBuffer cmdBuf) override;
+
+  private:
+    static constexpr std::string_view shaderName = "mv_replace";
+    std::shared_ptr<Image> srcInputMV_;
+    std::shared_ptr<Image> srcBlockMatchFlow_;
+    std::shared_ptr<Image> srcInputMVCost_;
+    std::shared_ptr<Image> srcBlockMatchCost_;
+    std::shared_ptr<Image> dstFlow_;
+    std::shared_ptr<Image> dstCost_;
+    bool outputCost_;
+    SpecConstants specConstants_;
+    VkSampler nearestSampler_;
+
+    inline static const DescriptorConfigs descriptorConfigs_{
+        {0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, {}},                                        // MvInput
+        {1, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, {}},                                        // FlowBlockMatch
+        {2, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT}, // CostAtInputMv
+        {3, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT},         // CostAtInputMv
+        {4, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+         VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT},                                       // MinCostBlockMatchMem
+        {5, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT}, // MinCostBlockMatchMem
+        {6, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT},  // DstFlow
+        {7, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT}, // DstFlow
+        {8, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT},  // DstCost
+        {9, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT}, // DstCost
+    };
+};
+
+/*******************************************************************************
+ * BlockMatch
+ *******************************************************************************/
+
+class BlockMatch : public ComputePipeline {
+  public:
+    using SearchType = common::BlockMatchMode;
+
+    BlockMatch(const std::shared_ptr<VULKAN_HPP_NAMESPACE::detail::DispatchLoaderDynamic> &loader, VkDevice device,
+               const std::shared_ptr<PipelineCache> &pipelineCache, SearchType searchType, int32_t maxSearchRange,
+               std::shared_ptr<Image> srcSearch, std::shared_ptr<Image> srcTemplate, std::shared_ptr<Image> dstFlow,
+               std::shared_ptr<Image> dstCost, const std::string &debugName);
+    ~BlockMatch() override = default;
+
+    struct SpecConstants {
+        uint32_t threadGroupSizeX;
+        uint32_t threadGroupSizeY;
+        uint32_t vectorisationfactorX;
+        uint32_t vectorisationfactorY;
+        int32_t searchType;
+        int32_t maxSearchRange;
+        uint32_t outputWidth;
+        uint32_t outputHeight;
+        uint32_t outputFlowStride;
+        uint32_t outputCostStride;
+        VkBool32 isCostImageStore;
+    };
+
+    struct PushConstants {
+        int32_t searchIndexLimit;
+    };
+
+    SpirvBinary createSpirv(const std::shared_ptr<PipelineCache> &pipelineCache);
+    SpecConstants makeSpecConstants(SearchType searchType, int32_t maxSearchRange,
+                                    const std::shared_ptr<Image> &dstFlow, const std::shared_ptr<Image> &dstCost) const;
+    bool hasFlowOutput() const;
+    bool hasCostOutput() const;
+
+    void setOutputCost(std::shared_ptr<Image> dstImage);
+    void setSearchRangeLimit(int searchRangeLimit);
+    void bindAndDispatch(VkCommandBuffer cmdBuf) override;
+
+  private:
+    static constexpr std::string_view shaderName = "block_match_of";
+    std::shared_ptr<Image> srcSearch_;
+    std::shared_ptr<Image> srcTemplate_;
+    std::shared_ptr<Image> dstFlow_;
+    std::shared_ptr<Image> dstCost_;
+    SearchType searchType_;
+    int maxSearchRange_;
+    int searchRangeLimit_;
+    SpecConstants specConstants_;
+    VkSampler nearestSampler_;
+
+    inline static const DescriptorConfigs descriptorConfigs_{
+        {0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, {}},                                // SrcSearch
+        {1, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, {}},                                // SrcTemplate
+        {2, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT}, // DstFlow
+        {3, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT},  // DstCost
+        {4, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT}, // DstCost
+    };
+};
+
+} // namespace mlsdk::el::compute::optical_flow

--- a/graph/graph_layer.cpp
+++ b/graph/graph_layer.cpp
@@ -13,6 +13,7 @@
 #include "compute_graph_op.hpp"
 #include "graph_log.hpp"
 #include "memory_planner.hpp"
+#include "optical_flow.hpp"
 #include "pipeline_cache.hpp"
 #include "source/opt/build_module.h"
 #include "source/opt/ir_context.h"
@@ -27,6 +28,7 @@
 
 using namespace mlsdk::el::compute;
 using namespace mlsdk::el::compute::graph_op;
+using namespace mlsdk::el::compute::optical_flow;
 using namespace mlsdk::el::log;
 
 /*****************************************************************************
@@ -70,6 +72,7 @@ class DataGraphDescriptorSet : public DescriptorSet {
         : DescriptorSet(_descriptorSetLayout) {
         for (const auto &[binding, descriptorSetLayoutBinding] : descriptorSetLayout->bindings) {
             tensorViews[binding].resize(descriptorSetLayoutBinding.descriptorCount);
+            imageViews[binding].resize(descriptorSetLayoutBinding.descriptorCount);
         }
     }
 
@@ -91,13 +94,24 @@ class DataGraphDescriptorSet : public DescriptorSet {
             }
             break;
         }
+        case VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER:
+        case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE:
+        case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE: {
+            for (uint32_t i = 0; i < set.descriptorCount; i++) {
+                // Only grab image view since we get image layout from connectivity map and we don't care about the
+                // sampler
+                imageViews[set.dstBinding][set.dstArrayElement + i] = set.pImageInfo[i].imageView;
+            }
+            break;
+        }
         default:
             break;
         }
     }
 
-    // Mapping from [binding, arrayIndex] to tensor view
+    // Mapping from [binding, arrayIndex] to tensor/image view
     std::map<uint32_t, std::vector<VkTensorViewARM>> tensorViews;
+    std::map<uint32_t, std::vector<VkImageView>> imageViews;
 
     // Mapping from [pipeline, set] to external descriptor sets bound by the application
     std::map<std::tuple<VkPipeline, uint32_t>, ComputeDescriptorSetMap> externalDescriptorSets;
@@ -109,13 +123,21 @@ class DataGraphDescriptorSet : public DescriptorSet {
 
 class DataGraphPipelineARM : public Loader {
   public:
+    enum class Type {
+        GRAPH,
+        OPTICAL_FLOW,
+    };
+
     explicit DataGraphPipelineARM(const std::shared_ptr<Device> &device,
-                                  const std::shared_ptr<PipelineCache> &_pipelineCache)
-        : Loader(*device), graphPipeline{std::make_shared<GraphPipeline>(device->loader,
-                                                                         device->physicalDevice->physicalDevice,
-                                                                         device->device, _pipelineCache)} {}
+                                  const std::shared_ptr<PipelineCache> &_pipelineCache, Type _pipelineType)
+        : Loader(*device), graphPipeline{std::make_shared<GraphPipeline>(
+                               device->loader, device->physicalDevice->physicalDevice, device->device, _pipelineCache)},
+          opticalFlow{std::make_shared<OpticalFlow>(device->loader, device->physicalDevice->physicalDevice,
+                                                    device->device, _pipelineCache)},
+          pipelineType(_pipelineType) {}
 
     std::shared_ptr<GraphPipeline> graphPipeline;
+    std::shared_ptr<OpticalFlow> opticalFlow;
     ComputeDescriptorSetMap constantsDescriptorSets;
 
     void makeConstantsDescriptorSets() {
@@ -124,6 +146,12 @@ class DataGraphPipelineARM : public Loader {
             descriptorSet->updateDescriptorSet();
         }
     }
+
+    bool isGraph() const { return pipelineType == Type::GRAPH; }
+    bool isOpticalFlow() const { return pipelineType == Type::OPTICAL_FLOW; }
+
+  private:
+    Type pipelineType;
 };
 
 /*****************************************************************************
@@ -133,32 +161,66 @@ class DataGraphPipelineARM : public Loader {
 class DataGraphPipelineSessionARM : public Loader {
   public:
     explicit DataGraphPipelineSessionARM(const std::shared_ptr<Device> &device,
-                                         const std::shared_ptr<DataGraphPipelineARM> &_pipeline)
+                                         const std::shared_ptr<DataGraphPipelineARM> &_pipeline,
+                                         VkDataGraphPipelineSessionCreateFlagsARM _createFlags)
         : Loader(*device), pipeline{_pipeline},
           sessionRamDescriptorSets{pipeline->graphPipeline->makeSessionRamDescriptorSets()},
-          memoryPlanner{createMemoryPlanner()} {}
+          memoryPlanner{createMemoryPlanner()}, createFlags{_createFlags} {}
 
     std::shared_ptr<DataGraphPipelineARM> pipeline;
 
     // Session ram descriptor sets
     ComputeDescriptorSetMap sessionRamDescriptorSets;
 
-    bool needsTransientRequirements() const { return getGraphPipelineMemoryRequirements().size > 0; }
+    bool transientMemoryBound = false;
+    bool opticalFlowCacheMemoryBound = false;
 
-    VkMemoryRequirements getGraphPipelineMemoryRequirements() const {
-        return memoryPlanner->getGraphPipelineSessionMemoryRequirements();
+    bool hasOpticalFlowCache() const {
+        return (createFlags & VK_DATA_GRAPH_PIPELINE_SESSION_CREATE_OPTICAL_FLOW_CACHE_BIT_ARM) != 0;
+    }
+
+    bool needsTransientRequirements() const {
+        return pipeline->isOpticalFlow() ? true : (memoryPlanner->getGraphPipelineSessionMemoryRequirements().size > 0);
+    }
+    bool needsOpticalFlowCacheRequirements() const { return pipeline->isOpticalFlow() && hasOpticalFlowCache(); }
+
+    VkMemoryRequirements getGraphPipelineMemoryRequirements(VkDataGraphPipelineSessionBindPointARM bindPoint) const {
+        if (pipeline->isGraph()) {
+            return memoryPlanner->getGraphPipelineSessionMemoryRequirements();
+        }
+        if (pipeline->isOpticalFlow()) {
+            if (bindPoint == VK_DATA_GRAPH_PIPELINE_SESSION_BIND_POINT_TRANSIENT_ARM) {
+                return pipeline->opticalFlow->getTransientMemoryRequirements();
+            }
+            if (bindPoint == VK_DATA_GRAPH_PIPELINE_SESSION_BIND_POINT_OPTICAL_FLOW_CACHE_ARM &&
+                hasOpticalFlowCache()) {
+                return pipeline->opticalFlow->getCacheMemoryRequirements();
+            }
+        }
+        return {0, 1, 0};
     }
 
     void bindTransientMemory(VkDeviceMemory memory, VkDeviceSize offset) {
-        memoryPlanner->bindGraphPipelineSessionMemory(memory, offset, sessionRamDescriptorSets);
+        if (pipeline->isGraph()) {
+            memoryPlanner->bindGraphPipelineSessionMemory(memory, offset, sessionRamDescriptorSets);
 
-        for ([[maybe_unused]] const auto &[_, descriptorSet] : sessionRamDescriptorSets) {
-            descriptorSet->updateDescriptorSet();
+            for ([[maybe_unused]] const auto &[_, descriptorSet] : sessionRamDescriptorSets) {
+                descriptorSet->updateDescriptorSet();
+            }
+        } else if (pipeline->isOpticalFlow()) {
+            pipeline->opticalFlow->bindSessionTransientMemory(memory, offset);
         }
+        transientMemoryBound = true;
+    }
+
+    void bindOpticalFlowCacheMemory(VkDeviceMemory memory, VkDeviceSize offset) {
+        pipeline->opticalFlow->bindSessionCacheMemory(memory, offset);
+        opticalFlowCacheMemoryBound = true;
     }
 
   private:
     std::shared_ptr<MemoryPlanner> memoryPlanner;
+    VkDataGraphPipelineSessionCreateFlagsARM createFlags;
 
     std::shared_ptr<MemoryPlanner> createMemoryPlanner() const {
         auto *const envMemoryPlanner = std::getenv("VMEL_MEMORY_PLANNER");
@@ -254,10 +316,11 @@ std::optional<std::string> tryGetExtInstVersion(const uint32_t *spirvCode, const
 
 } // namespace
 
-constexpr std::array<const VkExtensionProperties, 2> extensions{
+constexpr std::array<const VkExtensionProperties, 3> extensions{
     VkExtensionProperties{VK_ARM_DATA_GRAPH_EXTENSION_NAME, VK_ARM_DATA_GRAPH_SPEC_VERSION},
     VkExtensionProperties{VK_ARM_DATA_GRAPH_INSTRUCTION_SET_TOSA_EXTENSION_NAME,
                           VK_ARM_DATA_GRAPH_INSTRUCTION_SET_TOSA_SPEC_VERSION},
+    VkExtensionProperties{VK_ARM_DATA_GRAPH_OPTICAL_FLOW_EXTENSION_NAME, VK_ARM_DATA_GRAPH_OPTICAL_FLOW_SPEC_VERSION},
 };
 
 constexpr std::array<const VkExtensionProperties, 2> requiredExtensions = {
@@ -286,6 +349,8 @@ class GraphLayer : public VulkanLayerImpl {
             // PhysicalDevice functions
             {"vkGetPhysicalDeviceQueueFamilyDataGraphEngineOperationPropertiesARM",
              PFN_vkVoidFunction(vkGetPhysicalDeviceQueueFamilyDataGraphEngineOperationPropertiesARM)},
+            {"vkGetPhysicalDeviceQueueFamilyDataGraphOpticalFlowImageFormatsARM",
+             PFN_vkVoidFunction(vkGetPhysicalDeviceQueueFamilyDataGraphOpticalFlowImageFormatsARM)},
             {"vkGetPhysicalDeviceQueueFamilyDataGraphProcessingEnginePropertiesARM",
              PFN_vkVoidFunction(vkGetPhysicalDeviceQueueFamilyDataGraphProcessingEnginePropertiesARM)},
             {"vkGetPhysicalDeviceQueueFamilyDataGraphPropertiesARM",
@@ -363,6 +428,8 @@ class GraphLayer : public VulkanLayerImpl {
             // PhysicalDevice functions
             {"vkGetPhysicalDeviceQueueFamilyDataGraphEngineOperationPropertiesARM",
              PFN_vkVoidFunction(vkGetPhysicalDeviceQueueFamilyDataGraphEngineOperationPropertiesARM)},
+            {"vkGetPhysicalDeviceQueueFamilyDataGraphOpticalFlowImageFormatsARM",
+             PFN_vkVoidFunction(vkGetPhysicalDeviceQueueFamilyDataGraphOpticalFlowImageFormatsARM)},
             {"vkGetPhysicalDeviceQueueFamilyDataGraphProcessingEnginePropertiesARM",
              PFN_vkVoidFunction(vkGetPhysicalDeviceQueueFamilyDataGraphProcessingEnginePropertiesARM)},
             {"vkGetPhysicalDeviceQueueFamilyDataGraphPropertiesARM",
@@ -426,6 +493,67 @@ class GraphLayer : public VulkanLayerImpl {
         }
     }
 
+    static VkResult VKAPI_CALL vkGetPhysicalDeviceQueueFamilyDataGraphOpticalFlowImageFormatsARM(
+        VkPhysicalDevice physicalDevice, uint32_t queueFamilyIndex,
+        const VkQueueFamilyDataGraphPropertiesARM *pQueueFamilyDataGraphProperties,
+        const VkDataGraphOpticalFlowImageFormatInfoARM *pOpticalFlowImageFormatInfo, uint32_t *pFormatCount,
+        VkDataGraphOpticalFlowImageFormatPropertiesARM *pImageFormatProperties) {
+        if (!pFormatCount || !pQueueFamilyDataGraphProperties || !pOpticalFlowImageFormatInfo) {
+            return VK_ERROR_UNKNOWN;
+        }
+
+        auto handle = VulkanLayerImpl::getHandle(physicalDevice);
+        uint32_t familyCount = 0;
+        handle->loader->vkGetPhysicalDeviceQueueFamilyProperties(physicalDevice, &familyCount, nullptr);
+        if (queueFamilyIndex >= familyCount) {
+            return VK_ERROR_UNKNOWN;
+        }
+        if (pQueueFamilyDataGraphProperties->operation.operationType !=
+            VK_PHYSICAL_DEVICE_DATA_GRAPH_OPERATION_TYPE_OPTICAL_FLOW_ARM) {
+            *pFormatCount = 0;
+            return VK_ERROR_UNKNOWN;
+        }
+        const std::set<VkFormat> *pSupportedFormats = nullptr;
+
+        switch (pOpticalFlowImageFormatInfo->usage) {
+        case VK_DATA_GRAPH_OPTICAL_FLOW_IMAGE_USAGE_INPUT_BIT_ARM:
+            pSupportedFormats = &OpticalFlow::Spec::supportedImageFormats;
+            break;
+        case VK_DATA_GRAPH_OPTICAL_FLOW_IMAGE_USAGE_OUTPUT_BIT_ARM:
+        case VK_DATA_GRAPH_OPTICAL_FLOW_IMAGE_USAGE_HINT_BIT_ARM:
+            pSupportedFormats = &OpticalFlow::Spec::supportedFlowFormats;
+            break;
+        case VK_DATA_GRAPH_OPTICAL_FLOW_IMAGE_USAGE_COST_BIT_ARM:
+            pSupportedFormats = &OpticalFlow::Spec::supportedCostFormats;
+            break;
+        default:
+            *pFormatCount = 0;
+            return VK_SUCCESS;
+        }
+
+        const auto availableFormatCount = static_cast<uint32_t>(pSupportedFormats->size());
+
+        // First call: return count
+        if (pImageFormatProperties == nullptr) {
+            *pFormatCount = availableFormatCount;
+            return VK_SUCCESS;
+        }
+
+        // Second call: return formats
+        const uint32_t capacity = *pFormatCount;
+        const uint32_t numToWrite = std::min(capacity, availableFormatCount);
+
+        auto it = pSupportedFormats->cbegin();
+        for (uint32_t i = 0; i < numToWrite; ++i, ++it) {
+            pImageFormatProperties[i].sType = VK_STRUCTURE_TYPE_DATA_GRAPH_OPTICAL_FLOW_IMAGE_FORMAT_PROPERTIES_ARM;
+            pImageFormatProperties[i].pNext = nullptr;
+            pImageFormatProperties[i].format = *it;
+        }
+
+        *pFormatCount = numToWrite;
+        return (numToWrite < availableFormatCount) ? VK_INCOMPLETE : VK_SUCCESS;
+    }
+
     /**************************************************************************
      * Graph layer
      **************************************************************************/
@@ -451,113 +579,377 @@ class GraphLayer : public VulkanLayerImpl {
             const auto *dataGraphPipelineShaderModuleCreateInfo =
                 findType<VkDataGraphPipelineShaderModuleCreateInfoARM>(
                     createInfo.pNext, VK_STRUCTURE_TYPE_DATA_GRAPH_PIPELINE_SHADER_MODULE_CREATE_INFO_ARM);
-            if (dataGraphPipelineShaderModuleCreateInfo == nullptr) {
-                graphLog(Severity::Error) << "Missing shader module create info" << std::endl;
+
+            const auto *singleNodeCreateInfo = findType<VkDataGraphPipelineSingleNodeCreateInfoARM>(
+                createInfo.pNext, VK_STRUCTURE_TYPE_DATA_GRAPH_PIPELINE_SINGLE_NODE_CREATE_INFO_ARM);
+
+            const VkDataGraphPipelineOpticalFlowCreateInfoARM *opticalFlowCreateInfo = nullptr;
+            if (singleNodeCreateInfo != nullptr &&
+                singleNodeCreateInfo->nodeType == VK_DATA_GRAPH_PIPELINE_NODE_TYPE_OPTICAL_FLOW_ARM) {
+                opticalFlowCreateInfo = findType<VkDataGraphPipelineOpticalFlowCreateInfoARM>(
+                    createInfo.pNext, VK_STRUCTURE_TYPE_DATA_GRAPH_PIPELINE_OPTICAL_FLOW_CREATE_INFO_ARM);
+                if (opticalFlowCreateInfo == nullptr) {
+                    graphLog(Severity::Error) << "Missing OF create info in single node create info" << std::endl;
+                    return VK_ERROR_UNKNOWN;
+                }
+            }
+
+            if (!dataGraphPipelineShaderModuleCreateInfo && !opticalFlowCreateInfo) {
+                graphLog(Severity::Error) << "DataGraphPipelineCreateInfo Missing pNext struct" << std::endl;
+                return VK_ERROR_UNKNOWN;
+            }
+            if (dataGraphPipelineShaderModuleCreateInfo && opticalFlowCreateInfo) {
+                graphLog(Severity::Error) << "Multiple DataGraphPipelineCreateInfo pNext structs" << std::endl;
                 return VK_ERROR_UNKNOWN;
             }
 
+            const auto type = dataGraphPipelineShaderModuleCreateInfo != nullptr
+                                  ? DataGraphPipelineARM::Type::GRAPH
+                                  : DataGraphPipelineARM::Type::OPTICAL_FLOW;
             // Create pipeline handle
             auto pipeline = std::allocate_shared<DataGraphPipelineARM>(Allocator<GraphPipeline>{callbacks},
-                                                                       deviceHandle, pipelineCacheHandle);
+                                                                       deviceHandle, pipelineCacheHandle, type);
             pipelines[i] = reinterpret_cast<VkPipeline>(pipeline.get());
-            auto graphPipeline = pipeline->graphPipeline;
             graphLog(Severity::Info) << graphPipelineCreatedLog << std::endl;
 
-            // Copy tensor resources to pipeline
-            for (uint32_t j = 0; j < createInfo.resourceInfoCount; j++) {
-                const auto &resourceInfo = createInfo.pResourceInfos[j];
-                const auto *tensorDescription =
-                    findType<VkTensorDescriptionARM>(resourceInfo.pNext, VK_STRUCTURE_TYPE_TENSOR_DESCRIPTION_ARM);
+            if (pipeline->isGraph()) {
+                auto graphPipeline = pipeline->graphPipeline;
+                // Copy tensor resources to pipeline
+                for (uint32_t j = 0; j < createInfo.resourceInfoCount; j++) {
+                    const auto &resourceInfo = createInfo.pResourceInfos[j];
+                    const auto *tensorDescription =
+                        findType<VkTensorDescriptionARM>(resourceInfo.pNext, VK_STRUCTURE_TYPE_TENSOR_DESCRIPTION_ARM);
 
-                if (tensorDescription == nullptr) {
-                    graphLog(Severity::Error) << "Missing tensor description" << std::endl;
-                    return VK_ERROR_UNKNOWN;
+                    if (tensorDescription == nullptr) {
+                        graphLog(Severity::Error) << "Missing tensor description" << std::endl;
+                        return VK_ERROR_UNKNOWN;
+                    }
+
+                    graphPipeline->makeDescriptorSetBinding(resourceInfo.descriptorSet, resourceInfo.binding,
+                                                            resourceInfo.arrayElement, *tensorDescription);
                 }
 
-                graphPipeline->makeDescriptorSetBinding(resourceInfo.descriptorSet, resourceInfo.binding,
-                                                        resourceInfo.arrayElement, *tensorDescription);
-            }
+                // Constants
+                for (uint32_t j = 0; j < dataGraphPipelineShaderModuleCreateInfo->constantCount; j++) {
+                    const auto &constant = dataGraphPipelineShaderModuleCreateInfo->pConstants[j];
 
-            // Constants
-            for (uint32_t j = 0; j < dataGraphPipelineShaderModuleCreateInfo->constantCount; j++) {
-                const auto &constant = dataGraphPipelineShaderModuleCreateInfo->pConstants[j];
+                    const auto *graphPipelineConstantTensor =
+                        findType<VkTensorDescriptionARM>(constant.pNext, VK_STRUCTURE_TYPE_TENSOR_DESCRIPTION_ARM);
 
-                const auto *graphPipelineConstantTensor =
-                    findType<VkTensorDescriptionARM>(constant.pNext, VK_STRUCTURE_TYPE_TENSOR_DESCRIPTION_ARM);
+                    if (graphPipelineConstantTensor == nullptr) {
+                        graphLog(Severity::Error) << "Missing const tensor description" << std::endl;
+                        return VK_ERROR_UNKNOWN;
+                    }
 
-                if (graphPipelineConstantTensor == nullptr) {
-                    graphLog(Severity::Error) << "Missing const tensor description" << std::endl;
-                    return VK_ERROR_UNKNOWN;
+                    graphPipeline->makeConstTensor(constant.id, *graphPipelineConstantTensor, constant.pConstantData);
                 }
+                std::shared_ptr<ShaderModule> shaderModule;
+                if (dataGraphPipelineShaderModuleCreateInfo->module == VK_NULL_HANDLE) {
+                    const auto *shaderModuleCreateInfo = findType<VkShaderModuleCreateInfo>(
+                        createInfo.pNext, VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO);
+                    if (shaderModuleCreateInfo == nullptr) {
+                        graphLog(Severity::Error) << "Missing both shader handle and shader create info" << std::endl;
+                        return VK_ERROR_UNKNOWN;
+                    }
 
-                graphPipeline->makeConstTensor(constant.id, *graphPipelineConstantTensor, constant.pConstantData);
-            }
-            std::shared_ptr<ShaderModule> shaderModule;
-            if (dataGraphPipelineShaderModuleCreateInfo->module == VK_NULL_HANDLE) {
-                const auto *shaderModuleCreateInfo =
-                    findType<VkShaderModuleCreateInfo>(createInfo.pNext, VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO);
-                if (shaderModuleCreateInfo == nullptr) {
-                    graphLog(Severity::Error) << "Missing both shader handle and shader create info" << std::endl;
-                    return VK_ERROR_UNKNOWN;
-                }
-
-                std::vector<uint32_t> spirvSource = {shaderModuleCreateInfo->pCode,
-                                                     shaderModuleCreateInfo->pCode +
-                                                         shaderModuleCreateInfo->codeSize / sizeof(uint32_t)};
-                auto isGraph = isGraphSpirv(spirvSource);
-                if (!isGraph.has_value()) {
-                    graphLog(Severity::Error) << "Failed to compile spirv code." << std::endl;
-                    return VK_ERROR_UNKNOWN;
-                }
-                if (isGraph.value()) {
-                    shaderModule = std::make_shared<ShaderModule>(shaderModuleCreateInfo);
+                    std::vector<uint32_t> spirvSource = {shaderModuleCreateInfo->pCode,
+                                                         shaderModuleCreateInfo->pCode +
+                                                             shaderModuleCreateInfo->codeSize / sizeof(uint32_t)};
+                    auto isGraph = isGraphSpirv(spirvSource);
+                    if (!isGraph.has_value()) {
+                        graphLog(Severity::Error) << "Failed to compile spirv code." << std::endl;
+                        return VK_ERROR_UNKNOWN;
+                    }
+                    if (isGraph.value()) {
+                        shaderModule = std::make_shared<ShaderModule>(shaderModuleCreateInfo);
+                    } else {
+                        graphLog(Severity::Error) << "spirv code does not contain graph." << std::endl;
+                        return VK_ERROR_UNKNOWN;
+                    }
                 } else {
-                    graphLog(Severity::Error) << "spirv code does not contain graph." << std::endl;
+                    shaderModule = getHandle(deviceHandle, dataGraphPipelineShaderModuleCreateInfo->module);
+                }
+
+                if (!shaderModule) {
+                    graphLog(Severity::Error) << "Shader module not recognized by Graph layer" << std::endl;
+                    return VK_ERROR_FEATURE_NOT_PRESENT;
+                }
+
+                // Create optimizer
+                spvtools::Optimizer optimizer{SPV_ENV_UNIVERSAL_1_6};
+
+                // Register passes
+                const auto tosaVersion = tryGetExtInstVersion(shaderModule->code.data(), shaderModule->code.size(),
+                                                              std::regex("^TOSA\\.\\d{6}\\.\\d"));
+                const auto motionEngineVersion = tryGetExtInstVersion(
+                    shaderModule->code.data(), shaderModule->code.size(), std::regex("^Arm\\.MotionEngine\\.\\d{3}"));
+
+                const bool isTosaVersionUnsupported = tosaVersion.has_value() && tosaVersion != tosaSpv100;
+                if (isTosaVersionUnsupported) {
+                    graphLog(Severity::Error) << "Unsupported Tosa version provided." << std::endl;
                     return VK_ERROR_UNKNOWN;
                 }
-            } else {
-                shaderModule = getHandle(deviceHandle, dataGraphPipelineShaderModuleCreateInfo->module);
+
+                const bool isMotionEngineVersionUnsupported =
+                    motionEngineVersion.has_value() && motionEngineVersion != motionEngine100;
+                if (isMotionEngineVersionUnsupported) {
+                    graphLog(Severity::Error) << "Unsupported MotionEngine version provided." << std::endl;
+                    return VK_ERROR_UNKNOWN;
+                }
+
+                optimizer.RegisterPass(spvtools::CreateGraphPass<spvtools::opt::GraphPassTosaSpv100>(*graphPipeline));
+
+                // Run passes
+                std::vector<uint32_t> optimizedModule;
+                if (!optimizer.Run(shaderModule->code.data(), shaderModule->code.size(), &optimizedModule,
+                                   spvtools::ValidatorOptions(), true)) {
+                    graphLog(Severity::Error) << "Failed to run optimizer passes" << std::endl;
+                    return VK_ERROR_UNKNOWN;
+                }
+
+                // Create constants descriptor sets
+                pipeline->makeConstantsDescriptorSets();
+            } else if (pipeline->isOpticalFlow()) {
+                graphLog(Severity::Debug) << "Creating Optical Flow pipeline" << std::endl;
+                // Initialise OpticalFlow
+                const auto &opticalFlowPipeline = pipeline->opticalFlow;
+                OpticalFlow::Config config;
+                config.useMvInput =
+                    (opticalFlowCreateInfo->flags & VK_DATA_GRAPH_OPTICAL_FLOW_CREATE_ENABLE_HINT_BIT_ARM) != 0;
+                config.outputCost =
+                    (opticalFlowCreateInfo->flags & VK_DATA_GRAPH_OPTICAL_FLOW_CREATE_ENABLE_COST_BIT_ARM) != 0;
+                config.maxSearchRange = 3;
+
+                constexpr uint32_t supportedFlags = VK_DATA_GRAPH_OPTICAL_FLOW_CREATE_ENABLE_HINT_BIT_ARM |
+                                                    VK_DATA_GRAPH_OPTICAL_FLOW_CREATE_ENABLE_COST_BIT_ARM;
+                if (opticalFlowCreateInfo->flags & ~supportedFlags) {
+                    graphLog(Severity::Error) << "Invalid OF flags" << std::endl;
+                    return VK_ERROR_UNKNOWN;
+                }
+
+                if (config.useMvInput && !OpticalFlow::Spec::hintSupported) {
+                    graphLog(Severity::Error) << "OF hint is not supported by this implementation" << std::endl;
+                    return VK_ERROR_UNKNOWN;
+                }
+                if (config.outputCost && !OpticalFlow::Spec::costSupported) {
+                    graphLog(Severity::Error) << "OF cost output is not supported by this implementation" << std::endl;
+                    return VK_ERROR_UNKNOWN;
+                }
+
+                switch (opticalFlowCreateInfo->outputGridSize) {
+                case VK_DATA_GRAPH_OPTICAL_FLOW_GRID_SIZE_1X1_BIT_ARM:
+                    config.levelOfLastEstimation = 0;
+                    break;
+                case VK_DATA_GRAPH_OPTICAL_FLOW_GRID_SIZE_2X2_BIT_ARM:
+                    config.levelOfLastEstimation = 1;
+                    break;
+                case VK_DATA_GRAPH_OPTICAL_FLOW_GRID_SIZE_4X4_BIT_ARM:
+                    config.levelOfLastEstimation = 2;
+                    break;
+                case VK_DATA_GRAPH_OPTICAL_FLOW_GRID_SIZE_8X8_BIT_ARM:
+                    config.levelOfLastEstimation = 3;
+                    break;
+                default:
+                    graphLog(Severity::Error) << "Invalid OF output grid size" << std::endl;
+                    return VK_ERROR_UNKNOWN;
+                }
+
+                if (config.useMvInput && opticalFlowCreateInfo->hintGridSize == 0) {
+                    graphLog(Severity::Error) << "OF hint grid size cannot be zero when hint is enabled" << std::endl;
+                    return VK_ERROR_UNKNOWN;
+                }
+                if (opticalFlowCreateInfo->hintGridSize != 0 &&
+                    opticalFlowCreateInfo->hintGridSize != opticalFlowCreateInfo->outputGridSize) {
+                    graphLog(Severity::Error)
+                        << "Output and hint grid sizes must match when hint grid size is set" << std::endl;
+                    return VK_ERROR_UNKNOWN;
+                }
+                if (opticalFlowCreateInfo->hintGridSize != 0) {
+                    switch (opticalFlowCreateInfo->hintGridSize) {
+                    case VK_DATA_GRAPH_OPTICAL_FLOW_GRID_SIZE_1X1_BIT_ARM:
+                    case VK_DATA_GRAPH_OPTICAL_FLOW_GRID_SIZE_2X2_BIT_ARM:
+                    case VK_DATA_GRAPH_OPTICAL_FLOW_GRID_SIZE_4X4_BIT_ARM:
+                    case VK_DATA_GRAPH_OPTICAL_FLOW_GRID_SIZE_8X8_BIT_ARM:
+                        break;
+                    default:
+                        graphLog(Severity::Error) << "Invalid OF hint grid size" << std::endl;
+                        return VK_ERROR_UNKNOWN;
+                    }
+                }
+
+                switch (opticalFlowCreateInfo->performanceLevel) {
+                case VK_DATA_GRAPH_OPTICAL_FLOW_PERFORMANCE_LEVEL_SLOW_ARM:
+                    config.performanceLevel = OpticalFlow::PerformanceLevel::SLOW;
+                    break;
+                case VK_DATA_GRAPH_OPTICAL_FLOW_PERFORMANCE_LEVEL_MEDIUM_ARM:
+                    config.performanceLevel = OpticalFlow::PerformanceLevel::MEDIUM;
+                    break;
+                case VK_DATA_GRAPH_OPTICAL_FLOW_PERFORMANCE_LEVEL_FAST_ARM:
+                    config.performanceLevel = OpticalFlow::PerformanceLevel::FAST;
+                    break;
+                case VK_DATA_GRAPH_OPTICAL_FLOW_PERFORMANCE_LEVEL_UNKNOWN_ARM:
+                    config.performanceLevel = OpticalFlow::PerformanceLevel::UNKNOWN;
+                    break;
+                default:
+                    graphLog(Severity::Error) << "Invalid OF performance level" << std::endl;
+                    return VK_ERROR_UNKNOWN;
+                }
+
+                config.imageFormat = opticalFlowCreateInfo->imageFormat;
+                config.flowFormat = opticalFlowCreateInfo->flowVectorFormat;
+                config.costFormat = opticalFlowCreateInfo->costFormat;
+
+                config.width = opticalFlowCreateInfo->width;
+                config.height = opticalFlowCreateInfo->height;
+
+                const auto *opticalFlowNodeCreateInfo = singleNodeCreateInfo;
+                if (opticalFlowNodeCreateInfo == nullptr ||
+                    opticalFlowNodeCreateInfo->nodeType != VK_DATA_GRAPH_PIPELINE_NODE_TYPE_OPTICAL_FLOW_ARM) {
+                    graphLog(Severity::Error) << "Missing OF single node create info" << std::endl;
+                    return VK_ERROR_UNKNOWN;
+                }
+                if (opticalFlowNodeCreateInfo->connectionCount == 0 ||
+                    opticalFlowNodeCreateInfo->pConnections == nullptr) {
+                    graphLog(Severity::Error) << "Missing OF connectivity map" << std::endl;
+                    return VK_ERROR_UNKNOWN;
+                }
+
+                const auto isFormatSupported = [](VkFormat format, const auto &supported) {
+                    return supported.find(format) != supported.end();
+                };
+                if (!isFormatSupported(config.imageFormat, OpticalFlow::Spec::supportedImageFormats)) {
+                    graphLog(Severity::Error) << "Invalid OF input/reference image format" << std::endl;
+                    return VK_ERROR_UNKNOWN;
+                }
+                if (!isFormatSupported(config.flowFormat, OpticalFlow::Spec::supportedFlowFormats)) {
+                    graphLog(Severity::Error) << "Invalid OF flow vector format" << std::endl;
+                    return VK_ERROR_UNKNOWN;
+                }
+                if (config.outputCost &&
+                    !isFormatSupported(config.costFormat, OpticalFlow::Spec::supportedCostFormats)) {
+                    graphLog(Severity::Error) << "Invalid OF cost format" << std::endl;
+                    return VK_ERROR_UNKNOWN;
+                }
+                if (config.width < OpticalFlow::Spec::minWidth || config.width > OpticalFlow::Spec::maxWidth) {
+                    graphLog(Severity::Error) << "Invalid OF width" << std::endl;
+                    return VK_ERROR_UNKNOWN;
+                }
+                if (config.height < OpticalFlow::Spec::minHeight || config.height > OpticalFlow::Spec::maxHeight) {
+                    graphLog(Severity::Error) << "Invalid OF height" << std::endl;
+                    return VK_ERROR_UNKNOWN;
+                }
+
+                auto getLayout = [&createInfo](uint32_t binding, uint32_t set) -> std::optional<VkImageLayout> {
+                    for (uint32_t i = 0; i < createInfo.resourceInfoCount; ++i) {
+                        if (createInfo.pResourceInfos[i].descriptorSet == set &&
+                            createInfo.pResourceInfos[i].binding == binding) {
+                            const auto *const resourceInfoImageLayout =
+                                findType<VkDataGraphPipelineResourceInfoImageLayoutARM>(
+                                    createInfo.pResourceInfos[i].pNext,
+                                    VK_STRUCTURE_TYPE_DATA_GRAPH_PIPELINE_RESOURCE_INFO_IMAGE_LAYOUT_ARM);
+                            if (resourceInfoImageLayout == nullptr) {
+                                graphLog(Severity::Error)
+                                    << "Missing pipeline resource image info layout struct" << std::endl;
+                                return std::nullopt;
+                            }
+                            return resourceInfoImageLayout->layout;
+                        }
+                    }
+                    graphLog(Severity::Error) << "Missing OF resource info for connection set/binding" << std::endl;
+                    return std::nullopt;
+                };
+
+                bool hasInput = false;
+                bool hasReference = false;
+                bool hasHint = false;
+                bool hasFlowVector = false;
+                bool hasCost = false;
+                std::set<VkDataGraphPipelineNodeConnectionTypeARM> seenConnectionTypes;
+                std::set<std::pair<uint32_t, uint32_t>> seenSetBindingPairs;
+
+                for (uint32_t connection = 0; connection < opticalFlowNodeCreateInfo->connectionCount; connection++) {
+                    if (opticalFlowNodeCreateInfo->pConnections[connection].pNext != nullptr) {
+                        graphLog(Severity::Error) << "OF connection pNext must be null" << std::endl;
+                        return VK_ERROR_UNKNOWN;
+                    }
+
+                    const uint32_t set = opticalFlowNodeCreateInfo->pConnections[connection].set;
+                    const uint32_t binding = opticalFlowNodeCreateInfo->pConnections[connection].binding;
+                    const auto connectionType = opticalFlowNodeCreateInfo->pConnections[connection].connection;
+
+                    if (!seenSetBindingPairs.insert({set, binding}).second) {
+                        graphLog(Severity::Error) << "Duplicate OF set/binding in connectivity map" << std::endl;
+                        return VK_ERROR_UNKNOWN;
+                    }
+                    if (!seenConnectionTypes.insert(connectionType).second) {
+                        graphLog(Severity::Error) << "Duplicate OF connection type in connectivity map" << std::endl;
+                        return VK_ERROR_UNKNOWN;
+                    }
+
+                    const auto layout = getLayout(binding, set);
+                    if (!layout.has_value()) {
+                        return VK_ERROR_UNKNOWN;
+                    }
+
+                    /* Create configuration */
+                    switch (connectionType) {
+                    case VK_DATA_GRAPH_PIPELINE_NODE_CONNECTION_TYPE_OPTICAL_FLOW_REFERENCE_ARM:
+                        /* Input Image storage */
+                        hasReference = true;
+                        config.srcSearch.binding = binding;
+                        config.srcSearch.set = set;
+                        config.srcSearch.layout = *layout;
+                        break;
+                    case VK_DATA_GRAPH_PIPELINE_NODE_CONNECTION_TYPE_OPTICAL_FLOW_INPUT_ARM:
+                        /* Input Template Image storage */
+                        hasInput = true;
+                        config.srcTemplate.binding = binding;
+                        config.srcTemplate.set = set;
+                        config.srcTemplate.layout = *layout;
+                        break;
+                    case VK_DATA_GRAPH_PIPELINE_NODE_CONNECTION_TYPE_OPTICAL_FLOW_HINT_ARM:
+                        /* Input Flow Input hint storage */
+                        hasHint = true;
+                        config.srcFlow.binding = binding;
+                        config.srcFlow.set = set;
+                        config.srcFlow.layout = *layout;
+                        break;
+                    case VK_DATA_GRAPH_PIPELINE_NODE_CONNECTION_TYPE_OPTICAL_FLOW_FLOW_VECTOR_ARM:
+                        /* Output Flow Image storage */
+                        hasFlowVector = true;
+                        config.dstFlow.binding = binding;
+                        config.dstFlow.set = set;
+                        config.dstFlow.layout = *layout;
+                        break;
+                    case VK_DATA_GRAPH_PIPELINE_NODE_CONNECTION_TYPE_OPTICAL_FLOW_COST_ARM:
+                        /* Output Cost Image storage */
+                        hasCost = true;
+                        config.dstCost.binding = binding;
+                        config.dstCost.set = set;
+                        config.dstCost.layout = *layout;
+                        break;
+                    default:
+                        graphLog(Severity::Error) << "Invalid OF connection" << std::endl;
+                        return VK_ERROR_UNKNOWN;
+                    }
+                }
+
+                if (!hasInput || !hasReference || !hasFlowVector) {
+                    graphLog(Severity::Error)
+                        << "Missing required OF connections (input/reference/flow output)" << std::endl;
+                    return VK_ERROR_UNKNOWN;
+                }
+                if (config.useMvInput != hasHint) {
+                    graphLog(Severity::Error) << "OF hint connection does not match hint create flag" << std::endl;
+                    return VK_ERROR_UNKNOWN;
+                }
+                if (config.outputCost != hasCost) {
+                    graphLog(Severity::Error) << "OF cost connection does not match cost create flag" << std::endl;
+                    return VK_ERROR_UNKNOWN;
+                }
+
+                opticalFlowPipeline->init(config);
             }
-
-            if (!shaderModule) {
-                graphLog(Severity::Error) << "Shader module not recognized by Graph layer" << std::endl;
-                return VK_ERROR_FEATURE_NOT_PRESENT;
-            }
-
-            // Create optimizer
-            spvtools::Optimizer optimizer{SPV_ENV_UNIVERSAL_1_6};
-
-            // Register passes
-            const auto tosaVersion = tryGetExtInstVersion(shaderModule->code.data(), shaderModule->code.size(),
-                                                          std::regex("^TOSA\\.\\d{6}\\.\\d"));
-            const auto motionEngineVersion = tryGetExtInstVersion(shaderModule->code.data(), shaderModule->code.size(),
-                                                                  std::regex("^Arm\\.MotionEngine\\.\\d{3}"));
-
-            const bool isTosaVersionUnsupported = tosaVersion.has_value() && tosaVersion != tosaSpv100;
-            if (isTosaVersionUnsupported) {
-                graphLog(Severity::Error) << "Unsupported Tosa version provided." << std::endl;
-                return VK_ERROR_UNKNOWN;
-            }
-
-            const bool isMotionEngineVersionUnsupported =
-                motionEngineVersion.has_value() && motionEngineVersion != motionEngine100;
-            if (isMotionEngineVersionUnsupported) {
-                graphLog(Severity::Error) << "Unsupported MotionEngine version provided." << std::endl;
-                return VK_ERROR_UNKNOWN;
-            }
-
-            optimizer.RegisterPass(spvtools::CreateGraphPass<spvtools::opt::GraphPassTosaSpv100>(*graphPipeline));
-
-            // Run passes
-            std::vector<uint32_t> optimizedModule;
-            if (!optimizer.Run(shaderModule->code.data(), shaderModule->code.size(), &optimizedModule,
-                               spvtools::ValidatorOptions(), true)) {
-                graphLog(Severity::Error) << "Failed to run optimizer passes" << std::endl;
-                return VK_ERROR_UNKNOWN;
-            }
-
-            // Create constants descriptor sets
-            pipeline->makeConstantsDescriptorSets();
 
             {
                 scopedMutex l(globalMutex);
@@ -601,6 +993,12 @@ class GraphLayer : public VulkanLayerImpl {
         if (pPipelineCreationCacheControlFeatures) {
             pPipelineCreationCacheControlFeatures->pipelineCreationCacheControl = VK_FALSE;
         }
+
+        auto *pDataGraphOpticalFlowFeatures = findTypeMutable<VkPhysicalDeviceDataGraphOpticalFlowFeaturesARM>(
+            pFeatures->pNext, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DATA_GRAPH_OPTICAL_FLOW_FEATURES_ARM);
+        if (pDataGraphOpticalFlowFeatures) {
+            pDataGraphOpticalFlowFeatures->dataGraphOpticalFlow = VK_TRUE;
+        }
     }
 
     static VkResult VKAPI_CALL vkCreateDevice(VkPhysicalDevice physicalDevice, const VkDeviceCreateInfo *createInfo,
@@ -610,6 +1008,9 @@ class GraphLayer : public VulkanLayerImpl {
         VkDeviceCreateInfo newCreateInfo{*createInfo};
         findAndRemoveType<VkPhysicalDeviceDataGraphFeaturesARM>(
             &newCreateInfo, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DATA_GRAPH_FEATURES_ARM);
+        findAndRemoveType<VkPhysicalDeviceDataGraphOpticalFlowFeaturesARM>(
+            &newCreateInfo, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DATA_GRAPH_OPTICAL_FLOW_FEATURES_ARM);
+
         auto result = VulkanLayerImpl::vkCreateDevice(physicalDevice, &newCreateInfo, allocator, device);
 
         loadVkStructureList(const_cast<VkDeviceCreateInfo *>(createInfo), originCreateInfoChain);
@@ -636,11 +1037,35 @@ class GraphLayer : public VulkanLayerImpl {
     static VkResult VKAPI_CALL vkCreateDataGraphPipelineSessionARM(
         VkDevice device, const VkDataGraphPipelineSessionCreateInfoARM *createInfo,
         const VkAllocationCallbacks *callbacks, VkDataGraphPipelineSessionARM *session) {
+        if (!createInfo || !session) {
+            return VK_ERROR_UNKNOWN;
+        }
+
         auto deviceHandle = VulkanLayerImpl::getHandle(device);
         auto pipelineImpl = getHandle(deviceHandle, createInfo->dataGraphPipeline);
+        if (!pipelineImpl) {
+            return VK_ERROR_UNKNOWN;
+        }
+
+        constexpr VkDataGraphPipelineSessionCreateFlagsARM supportedSessionCreateFlags =
+            VK_DATA_GRAPH_PIPELINE_SESSION_CREATE_OPTICAL_FLOW_CACHE_BIT_ARM;
+        if ((createInfo->flags & ~supportedSessionCreateFlags) != 0) {
+            graphLog(Severity::Error) << "Unsupported data graph session create flags" << std::endl;
+            return VK_ERROR_UNKNOWN;
+        }
+        if (pipelineImpl->isGraph() &&
+            (createInfo->flags & VK_DATA_GRAPH_PIPELINE_SESSION_CREATE_OPTICAL_FLOW_CACHE_BIT_ARM) != 0) {
+            graphLog(Severity::Error) << "OF cache create flag is invalid for non-OF pipelines" << std::endl;
+            return VK_ERROR_UNKNOWN;
+        }
+        if (pipelineImpl->isOpticalFlow() &&
+            (createInfo->flags & VK_DATA_GRAPH_PIPELINE_SESSION_CREATE_OPTICAL_FLOW_CACHE_BIT_ARM) == 0) {
+            graphLog(Severity::Error) << "OF sessions currently require OF cache create flag" << std::endl;
+            return VK_ERROR_UNKNOWN;
+        }
 
         *session = reinterpret_cast<VkDataGraphPipelineSessionARM>(
-            allocateObject<DataGraphPipelineSessionARM>(callbacks, deviceHandle, pipelineImpl));
+            allocateObject<DataGraphPipelineSessionARM>(callbacks, deviceHandle, pipelineImpl, createInfo->flags));
 
         return VK_SUCCESS;
     }
@@ -651,9 +1076,13 @@ class GraphLayer : public VulkanLayerImpl {
         auto *const session = reinterpret_cast<DataGraphPipelineSessionARM *>(info->session);
 
         const auto needsTransient = session->needsTransientRequirements();
+        const auto needsOpticalFlowCache = session->needsOpticalFlowCacheRequirements();
 
         uint32_t requiredCount = 0;
         if (needsTransient) {
+            ++requiredCount;
+        }
+        if (needsOpticalFlowCache) {
             ++requiredCount;
         }
 
@@ -682,6 +1111,10 @@ class GraphLayer : public VulkanLayerImpl {
             writeRequirement(VK_DATA_GRAPH_PIPELINE_SESSION_BIND_POINT_TRANSIENT_ARM);
         }
 
+        if (needsOpticalFlowCache) {
+            writeRequirement(VK_DATA_GRAPH_PIPELINE_SESSION_BIND_POINT_OPTICAL_FLOW_CACHE_ARM);
+        }
+
         *bindPointRequirementCount = written;
 
         return (capacity < requiredCount) ? VK_INCOMPLETE : VK_SUCCESS;
@@ -693,7 +1126,7 @@ class GraphLayer : public VulkanLayerImpl {
         auto *const session = reinterpret_cast<DataGraphPipelineSessionARM *>(info->session);
 
         // Calculate how much memory pipelines hidden layers require
-        requirements->memoryRequirements = session->getGraphPipelineMemoryRequirements();
+        requirements->memoryRequirements = session->getGraphPipelineMemoryRequirements(info->bindPoint);
     }
 
     static VkResult VKAPI_CALL vkBindDataGraphPipelineSessionMemoryARM(
@@ -705,6 +1138,18 @@ class GraphLayer : public VulkanLayerImpl {
             switch (bindInfos[i].bindPoint) {
             case VK_DATA_GRAPH_PIPELINE_SESSION_BIND_POINT_TRANSIENT_ARM: {
                 session->bindTransientMemory(bindInfos[i].memory, bindInfos[i].memoryOffset);
+                break;
+            }
+            case VK_DATA_GRAPH_PIPELINE_SESSION_BIND_POINT_OPTICAL_FLOW_CACHE_ARM: {
+                if (!session->pipeline->isOpticalFlow()) {
+                    graphLog(Severity::Error) << "Invalid bind point for pipeline type" << std::endl;
+                    return VK_ERROR_UNKNOWN;
+                }
+                if (!session->hasOpticalFlowCache()) {
+                    graphLog(Severity::Error) << "OF cache bind point requires session create cache flag" << std::endl;
+                    return VK_ERROR_UNKNOWN;
+                }
+                session->bindOpticalFlowCacheMemory(bindInfos[i].memory, bindInfos[i].memoryOffset);
                 break;
             }
             default:
@@ -775,6 +1220,27 @@ class GraphLayer : public VulkanLayerImpl {
             return VK_ERROR_UNKNOWN;
         }
 
+        if ((pQueueFamilyDataGraphProperties->operation.operationType ==
+             VK_PHYSICAL_DEVICE_DATA_GRAPH_OPERATION_TYPE_OPTICAL_FLOW_ARM) &&
+            (pProperties->sType == VK_STRUCTURE_TYPE_QUEUE_FAMILY_DATA_GRAPH_OPTICAL_FLOW_PROPERTIES_ARM)) {
+            auto *opticalFlowProps = reinterpret_cast<VkQueueFamilyDataGraphOpticalFlowPropertiesARM *>(pProperties);
+
+            VkDataGraphOpticalFlowGridSizeFlagsARM gridSizes = 0;
+            for (size_t lvl : OpticalFlow::Spec::supportedLevelOfLastEstimation) {
+                gridSizes = static_cast<VkDataGraphOpticalFlowGridSizeFlagsARM>(gridSizes | (1u << lvl));
+            }
+            opticalFlowProps->supportedOutputGridSizes = gridSizes;
+            opticalFlowProps->supportedHintGridSizes = gridSizes;
+            opticalFlowProps->hintSupported = OpticalFlow::Spec::hintSupported;
+            opticalFlowProps->costSupported = OpticalFlow::Spec::costSupported;
+            opticalFlowProps->minWidth = OpticalFlow::Spec::minWidth;
+            opticalFlowProps->minHeight = OpticalFlow::Spec::minHeight;
+            opticalFlowProps->maxWidth = OpticalFlow::Spec::maxWidth;
+            opticalFlowProps->maxHeight = OpticalFlow::Spec::maxHeight;
+
+            return VK_SUCCESS;
+        }
+
         if (pQueueFamilyDataGraphProperties->engine.type !=
                 VK_PHYSICAL_DEVICE_DATA_GRAPH_PROCESSING_ENGINE_TYPE_DEFAULT_ARM ||
             pQueueFamilyDataGraphProperties->operation.operationType !=
@@ -810,7 +1276,7 @@ class GraphLayer : public VulkanLayerImpl {
             return VK_ERROR_UNKNOWN;
         }
 
-        constexpr uint32_t propertyCount = 1;
+        constexpr uint32_t propertyCount = 2;
 
         if (pQueueFamilyDataGraphProperties == nullptr) {
             *pQueueFamilyDataGraphPropertyCount = propertyCount;
@@ -831,12 +1297,24 @@ class GraphLayer : public VulkanLayerImpl {
             {},
         };
 
+        const VkPhysicalDeviceDataGraphOperationSupportARM operationSupportOF = {
+            VK_PHYSICAL_DEVICE_DATA_GRAPH_OPERATION_TYPE_OPTICAL_FLOW_ARM,
+            "OpticalFlow",
+            {},
+        };
+
         const VkQueueFamilyDataGraphPropertiesARM availableProperties[propertyCount] = {
             {
                 VK_STRUCTURE_TYPE_QUEUE_FAMILY_DATA_GRAPH_PROPERTIES_ARM,
                 nullptr,
                 processingEngine,
                 operationSupportTOSA,
+            },
+            {
+                VK_STRUCTURE_TYPE_QUEUE_FAMILY_DATA_GRAPH_PROPERTIES_ARM,
+                nullptr,
+                processingEngine,
+                operationSupportOF,
             },
         };
 
@@ -984,68 +1462,126 @@ class GraphLayer : public VulkanLayerImpl {
     }
 
     static void VKAPI_CALL vkCmdDispatchDataGraphARM(VkCommandBuffer commandBuffer,
-                                                     VkDataGraphPipelineSessionARM _session) {
+                                                     VkDataGraphPipelineSessionARM _session,
+                                                     const VkDataGraphPipelineDispatchInfoARM *pInfo) {
         auto handle = VulkanLayerImpl::getHandle(commandBuffer);
         auto *session = reinterpret_cast<DataGraphPipelineSessionARM *>(_session);
         auto pipeline = session->pipeline;
         auto *vkPipeline = reinterpret_cast<VkPipeline>(pipeline.get());
-        auto graphPipeline = pipeline->graphPipeline;
         auto deviceHandle = VulkanLayerImpl::getHandle(handle->device->device);
 
-        /*
-         * Merge descriptor sets, they can have three different origins:
-         * - Constants owned by the pipeline
-         * - Session ram owned by the session
-         * - External owned by the application
-         */
-        ComputeDescriptorSetMap allDescriptorSetMap;
+        if (pipeline->isGraph()) {
+            auto graphPipeline = pipeline->graphPipeline;
+            /*
+             * Merge descriptor sets, they can have three different origins:
+             * - Constants owned by the pipeline
+             * - Session ram owned by the session
+             * - External owned by the application
+             */
+            ComputeDescriptorSetMap allDescriptorSetMap;
 
-        for (const auto &[set, vkDescriptorSet] : handle->descriptorSets) {
-            auto descriptorSet = getHandle(deviceHandle, vkDescriptorSet);
+            for (const auto &[set, vkDescriptorSet] : handle->descriptorSets) {
+                auto descriptorSet = getHandle(deviceHandle, vkDescriptorSet);
 
-            auto &externalDescriptorSets = descriptorSet->externalDescriptorSets;
-            if (externalDescriptorSets.find({vkPipeline, set}) == externalDescriptorSets.end()) {
-                /*
-                 * A resource bound to the graph with {set, binding} can be used by multiple compute jobs,
-                 * with different {set, binding}.
-                 *
-                 * The list of compute jobs is first known when the pipeline is dispatched. A DescriptorSet is bound to
-                 * a PipelineLayout, which is why the compute DescriptorSets must be created here.
-                 *
-                 *               <- Defined by the PipelineLayout ->
-                 * +----------+    +----------+     +------------+
-                 * | GRAPH    |    | COMPUTE1 |     | COMPUTE<n> |
-                 * +----------+    +----------+     +------------+
-                 * | set      | => | set1     | ... | set<n>     |
-                 * | binding  |    | binding1 |     | binding<n> |
-                 * | resource |    | resource |     | resource   |
-                 * +----------+    +----------+     +------------+
-                 */
+                auto &externalDescriptorSets = descriptorSet->externalDescriptorSets;
+                if (externalDescriptorSets.find({vkPipeline, set}) == externalDescriptorSets.end()) {
+                    /*
+                     * A resource bound to the graph with {set, binding} can be used by multiple compute jobs,
+                     * with different {set, binding}.
+                     *
+                     * The list of compute jobs is first known when the pipeline is dispatched. A DescriptorSet is bound
+                     * to a PipelineLayout, which is why the compute DescriptorSets must be created here.
+                     *
+                     *               <- Defined by the PipelineLayout ->
+                     * +----------+    +----------+     +------------+
+                     * | GRAPH    |    | COMPUTE1 |     | COMPUTE<n> |
+                     * +----------+    +----------+     +------------+
+                     * | set      | => | set1     | ... | set<n>     |
+                     * | binding  |    | binding1 |     | binding<n> |
+                     * | resource |    | resource |     | resource   |
+                     * +----------+    +----------+     +------------+
+                     */
 
-                // Create compute descriptor sets
-                auto descriptorSetMapTemp = graphPipeline->makeExternalDescriptorSets(set);
-                auto &computeDescriptorSetMap = externalDescriptorSets[{vkPipeline, set}];
-                computeDescriptorSetMap.insert(descriptorSetMapTemp.begin(), descriptorSetMapTemp.end());
+                    // Create compute descriptor sets
+                    auto descriptorSetMapTemp = graphPipeline->makeExternalDescriptorSets(set);
+                    auto &computeDescriptorSetMap = externalDescriptorSets[{vkPipeline, set}];
+                    computeDescriptorSetMap.insert(descriptorSetMapTemp.begin(), descriptorSetMapTemp.end());
 
-                for (const auto &[binding, tensorViews] : descriptorSet->tensorViews) {
-                    for (uint32_t arrayIndex = 0; arrayIndex < tensorViews.size(); arrayIndex++) {
-                        if (tensorViews[arrayIndex] == nullptr) {
+                    for (const auto &[binding, tensorViews] : descriptorSet->tensorViews) {
+                        for (uint32_t arrayIndex = 0; arrayIndex < tensorViews.size(); arrayIndex++) {
+                            if (tensorViews[arrayIndex] == nullptr) {
+                                continue;
+                            }
+                            updateDescriptorSet(deviceHandle, tensorViews, arrayIndex, graphPipeline, set, binding,
+                                                computeDescriptorSetMap);
+                        }
+                    }
+                } // end if no entry
+
+                auto &externals = descriptorSet->externalDescriptorSets.at({vkPipeline, set});
+                allDescriptorSetMap.insert(externals.begin(), externals.end());
+            }
+
+            allDescriptorSetMap.insert(pipeline->constantsDescriptorSets.begin(),
+                                       pipeline->constantsDescriptorSets.end());
+            allDescriptorSetMap.insert(session->sessionRamDescriptorSets.begin(),
+                                       session->sessionRamDescriptorSets.end());
+
+            graphPipeline->cmdBindAndDispatch(commandBuffer, allDescriptorSetMap);
+        } else if (pipeline->isOpticalFlow()) {
+            const auto &opticalFlowPipeline = pipeline->opticalFlow;
+
+            VkDataGraphOpticalFlowExecuteFlagsARM opticalFlowFlags = 0;
+            uint32_t meanFlowL1NormHint = 0;
+            if (pInfo != nullptr) {
+                const auto *opticalFlowDispatchInfo = findType<VkDataGraphPipelineOpticalFlowDispatchInfoARM>(
+                    pInfo, VK_STRUCTURE_TYPE_DATA_GRAPH_PIPELINE_OPTICAL_FLOW_DISPATCH_INFO_ARM);
+                if (opticalFlowDispatchInfo) {
+                    opticalFlowFlags = opticalFlowDispatchInfo->flags;
+                    meanFlowL1NormHint = opticalFlowDispatchInfo->meanFlowL1NormHint;
+                }
+            }
+
+            constexpr VkDataGraphOpticalFlowExecuteFlagsARM cacheDependentExecuteFlags =
+                VK_DATA_GRAPH_OPTICAL_FLOW_EXECUTE_INPUT_UNCHANGED_BIT_ARM |
+                VK_DATA_GRAPH_OPTICAL_FLOW_EXECUTE_REFERENCE_UNCHANGED_BIT_ARM |
+                VK_DATA_GRAPH_OPTICAL_FLOW_EXECUTE_INPUT_IS_PREVIOUS_REFERENCE_BIT_ARM |
+                VK_DATA_GRAPH_OPTICAL_FLOW_EXECUTE_REFERENCE_IS_PREVIOUS_INPUT_BIT_ARM;
+            constexpr VkDataGraphOpticalFlowExecuteFlagsARM supportedExecuteFlags =
+                VK_DATA_GRAPH_OPTICAL_FLOW_EXECUTE_DISABLE_TEMPORAL_HINTS_BIT_ARM | cacheDependentExecuteFlags;
+
+            if (opticalFlowFlags & ~supportedExecuteFlags) {
+                graphLog(Severity::Error) << "Unsupported OF execute flags" << std::endl;
+                return;
+            }
+            if (!session->transientMemoryBound) {
+                graphLog(Severity::Error) << "OF session transient memory is not bound" << std::endl;
+                return;
+            }
+            if ((opticalFlowFlags & cacheDependentExecuteFlags) && !session->hasOpticalFlowCache()) {
+                graphLog(Severity::Error) << "OF execute flags require session create OF cache flag" << std::endl;
+                return;
+            }
+            if ((opticalFlowFlags & cacheDependentExecuteFlags) && !session->opticalFlowCacheMemoryBound) {
+                graphLog(Severity::Error) << "OF execute flags require OF cache memory to be bound" << std::endl;
+                return;
+            }
+
+            OpticalFlowDescriptorMap descriptorMap;
+            for (const auto &[set, vkDescriptorSet] : handle->descriptorSets) {
+                auto descriptorSet = getHandle(deviceHandle, vkDescriptorSet);
+                for (const auto &[binding, imageViews] : descriptorSet->imageViews) {
+                    for (uint32_t arrayIndex = 0; arrayIndex < imageViews.size(); arrayIndex++) {
+                        if (imageViews[arrayIndex] == VK_NULL_HANDLE) {
                             continue;
                         }
-                        updateDescriptorSet(deviceHandle, tensorViews, arrayIndex, graphPipeline, set, binding,
-                                            computeDescriptorSetMap);
+                        descriptorMap[{set, binding, arrayIndex}] = {vkDescriptorSet, imageViews[arrayIndex]};
                     }
                 }
-            } // end if no entry
-
-            auto &externals = descriptorSet->externalDescriptorSets.at({vkPipeline, set});
-            allDescriptorSetMap.insert(externals.begin(), externals.end());
+                opticalFlowPipeline->updateDescriptorSets(descriptorMap);
+            }
+            opticalFlowPipeline->cmdBindAndDispatch(commandBuffer, opticalFlowFlags, meanFlowL1NormHint);
         }
-
-        allDescriptorSetMap.insert(pipeline->constantsDescriptorSets.begin(), pipeline->constantsDescriptorSets.end());
-        allDescriptorSetMap.insert(session->sessionRamDescriptorSets.begin(), session->sessionRamDescriptorSets.end());
-
-        graphPipeline->cmdBindAndDispatch(commandBuffer, allDescriptorSetMap);
     }
 
     /*******************************************************************************

--- a/graph/image.cpp
+++ b/graph/image.cpp
@@ -1,0 +1,364 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+/*******************************************************************************
+ * Includes
+ *******************************************************************************/
+
+#include "image.hpp"
+
+#include "graph_log.hpp"
+#include "mlel/utils.hpp"
+
+#include <exception>
+#include <numeric>
+#include <vulkan/vulkan_format_traits.hpp>
+
+using namespace mlsdk::el::log;
+using namespace mlsdk::el::utils;
+
+namespace mlsdk::el::compute {
+
+/*******************************************************************************
+ * Image
+ *******************************************************************************/
+Image::Image(const std::shared_ptr<VULKAN_HPP_NAMESPACE::detail::DispatchLoaderDynamic> &loader,
+             VkPhysicalDevice physicalDevice, VkDevice device, Usage usage, VkExtent3D dim, VkFormat format,
+             VkImageTiling tiling, bool isCached, const std::string &debugName)
+    : loader_{loader}, physicalDevice_{physicalDevice}, device_{device}, usage_{usage}, dim_{dim}, format_{format},
+      tiling_{tiling}, imageType_{Type::Internal}, isCached_{isCached}, debugName_{debugName} {
+    componentCount_ = vk::componentCount(vk::Format(format_));
+    blockSize_ = vk::blockSize(vk::Format(format_));
+    if (isImageSample() || isImageStore()) {
+        makeImage();
+    }
+    if (usage == Usage::BufferStoreLoad) {
+        makeBuffer();
+    } else if (usage == Usage::BufferStoreImageSample || usage == Usage::ImageStoreBufferLoad) {
+        makeBufferAlias();
+    }
+}
+
+Image::Image(const std::shared_ptr<VULKAN_HPP_NAMESPACE::detail::DispatchLoaderDynamic> &loader, Usage usage,
+             VkExtent3D dim, VkFormat format, VkImageLayout layout)
+    : loader_{loader}, usage_(usage), dim_(dim), format_(format), imageLayout_(layout), imageType_(Type::Placeholder) {
+    componentCount_ = vk::componentCount(vk::Format(format_));
+    blockSize_ = vk::blockSize(vk::Format(format_));
+}
+
+Image::~Image() {
+    if (!isInternal()) {
+        return;
+    }
+
+    if (imageView_) {
+        loader_->vkDestroyImageView(device_, imageView_, nullptr);
+    }
+    if (image_) {
+        loader_->vkDestroyImage(device_, image_, nullptr);
+    }
+    if (buffer_) {
+        loader_->vkDestroyBuffer(device_, buffer_, nullptr);
+    }
+}
+
+void Image::makeBuffer() {
+    sizeInBytes_ = dim_.height * dim_.width * blockSize_;
+    rowPitch_ = dim_.width * blockSize_;
+
+    VkBufferCreateInfo bufferInfo{};
+    bufferInfo.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+    bufferInfo.flags = 0;
+    bufferInfo.size = sizeInBytes_;
+    bufferInfo.usage =
+        VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT;
+    bufferInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+
+    VkResult res = loader_->vkCreateBuffer(device_, &bufferInfo, VK_NULL_HANDLE, &buffer_);
+    if (res != VK_SUCCESS) {
+        throw std::runtime_error("Failed to create buffer");
+    }
+
+    VkMemoryRequirements2 mrqs{};
+    mrqs.sType = VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2;
+    const VkBufferMemoryRequirementsInfo2 memInfo = {
+        VK_STRUCTURE_TYPE_BUFFER_MEMORY_REQUIREMENTS_INFO_2,
+        nullptr,
+        buffer_,
+    };
+    loader_->vkGetBufferMemoryRequirements2(device_, &memInfo, &mrqs);
+    memoryRequirements_ = mrqs.memoryRequirements;
+
+    if (!debugName_.empty()) {
+        setDebugUtilsObjectName(loader_, device_, VK_OBJECT_TYPE_BUFFER, reinterpret_cast<uint64_t>(buffer_),
+                                debugName_ + "_buf");
+    }
+}
+
+/* Build a VkImage + VkImageView and wrap them */
+void Image::makeImage() {
+    VkImageUsageFlags imageUsage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+    if (isImageSample()) {
+        imageUsage |= VK_IMAGE_USAGE_SAMPLED_BIT;
+    }
+    if (isImageStore()) {
+        imageUsage |= VK_IMAGE_USAGE_STORAGE_BIT;
+    }
+
+    VkImageCreateInfo imageInfo{};
+    imageInfo.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+    imageInfo.imageType = VK_IMAGE_TYPE_2D;
+    imageInfo.extent = {dim_.width, dim_.height, 1};
+    imageInfo.mipLevels = 1;
+    imageInfo.arrayLayers = 1;
+    imageInfo.format = format_;
+    imageInfo.tiling = tiling_;
+    imageInfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    imageInfo.usage = imageUsage;
+    imageInfo.samples = VK_SAMPLE_COUNT_1_BIT;
+    imageInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+
+    VkResult res = loader_->vkCreateImage(device_, &imageInfo, VK_NULL_HANDLE, &image_);
+    if (res != VK_SUCCESS) {
+        throw std::runtime_error("Failed to create image");
+    }
+
+    VkMemoryRequirements2 mrqs{};
+    mrqs.sType = VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2;
+    const VkImageMemoryRequirementsInfo2 memInfo = {
+        VK_STRUCTURE_TYPE_IMAGE_MEMORY_REQUIREMENTS_INFO_2,
+        nullptr,
+        image_,
+    };
+    loader_->vkGetImageMemoryRequirements2(device_, &memInfo, &mrqs);
+    memoryRequirements_ = mrqs.memoryRequirements;
+
+    if (tiling_ == VK_IMAGE_TILING_LINEAR) // This case includes Buffer alias
+    {
+        const VkImageSubresource subResource{VK_IMAGE_ASPECT_COLOR_BIT, 0, 0};
+        VkSubresourceLayout subResourceLayout;
+        loader_->vkGetImageSubresourceLayout(device_, image_, &subResource, &subResourceLayout);
+        sizeInBytes_ = subResourceLayout.size;
+        rowPitch_ = subResourceLayout.rowPitch;
+    }
+
+    if (!debugName_.empty()) {
+        setDebugUtilsObjectName(loader_, device_, VK_OBJECT_TYPE_IMAGE, reinterpret_cast<uint64_t>(image_),
+                                debugName_ + "_img");
+    }
+}
+
+void Image::makeBufferAlias() {
+    assert(sizeInBytes_ > 0);
+    VkBufferCreateInfo bufferInfo{};
+    bufferInfo.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+    bufferInfo.flags = 0;
+    bufferInfo.size = sizeInBytes_;
+    bufferInfo.usage =
+        VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT;
+    bufferInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+
+    VkResult res = loader_->vkCreateBuffer(device_, &bufferInfo, VK_NULL_HANDLE, &buffer_);
+    if (res != VK_SUCCESS) {
+        throw std::runtime_error("Failed to create buffer alias");
+    }
+
+    if (!debugName_.empty()) {
+        setDebugUtilsObjectName(loader_, device_, VK_OBJECT_TYPE_BUFFER, reinterpret_cast<uint64_t>(buffer_),
+                                debugName_ + "_buf");
+    }
+}
+
+void Image::bindToMemory(VkDeviceMemory memory, VkDeviceSize baseOffset) {
+    assert(isInternal());
+    if (hasBuffer()) {
+        auto res = loader_->vkBindBufferMemory(device_, buffer_, memory, baseOffset + memoryOffset_);
+        if (res != VK_SUCCESS) {
+            throw std::runtime_error("Failed to bind buffer alias");
+        }
+    }
+    if (hasImage()) {
+        auto res = loader_->vkBindImageMemory(device_, image_, memory, baseOffset + memoryOffset_);
+        if (res != VK_SUCCESS) {
+            throw std::runtime_error("Failed to bind image memory");
+        }
+
+        VkImageViewCreateInfo imageViewInfo{};
+        imageViewInfo.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+        imageViewInfo.image = image_;
+        imageViewInfo.viewType = VK_IMAGE_VIEW_TYPE_2D;
+        imageViewInfo.format = format_;
+        imageViewInfo.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+        imageViewInfo.subresourceRange.baseMipLevel = 0;
+        imageViewInfo.subresourceRange.levelCount = 1;
+        imageViewInfo.subresourceRange.baseArrayLayer = 0;
+        imageViewInfo.subresourceRange.layerCount = 1;
+
+        res = loader_->vkCreateImageView(device_, &imageViewInfo, VK_NULL_HANDLE, &imageView_);
+        if (res != VK_SUCCESS) {
+            throw std::runtime_error("Failed to create image view");
+        }
+    }
+}
+
+void Image::setExternalDescriptor(VkDescriptorSet descriptorSet, uint32_t binding, VkImageView imageView) {
+    assert(!isInternal());
+    imageType_ = Type::External;
+    externalDescriptorSet_ = descriptorSet;
+    externalBinding_ = binding;
+    externalImageView_ = imageView;
+}
+
+std::vector<uint32_t> Image::candidateMemoryTypes(uint32_t bits, VkMemoryPropertyFlags wanted) const {
+    VkPhysicalDeviceMemoryProperties memProps{};
+    loader_->vkGetPhysicalDeviceMemoryProperties(physicalDevice_, &memProps);
+
+    std::vector<uint32_t> out;
+    out.reserve(memProps.memoryTypeCount);
+    for (uint32_t i = 0; i < memProps.memoryTypeCount; ++i) {
+        if ((bits & (1u << i)) == 0) {
+            continue;
+        }
+        if ((memProps.memoryTypes[i].propertyFlags & wanted) != wanted) {
+            continue;
+        }
+        out.emplace_back(i);
+    }
+    std::sort(out.begin(), out.end(), [&](uint32_t a, uint32_t b) {
+        auto ha = memProps.memoryHeaps[memProps.memoryTypes[a].heapIndex];
+        auto hb = memProps.memoryHeaps[memProps.memoryTypes[b].heapIndex];
+        bool aDev = memProps.memoryTypes[a].propertyFlags & VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
+        bool bDev = memProps.memoryTypes[b].propertyFlags & VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
+        if (aDev != bDev) {
+            return aDev > bDev;
+        }
+        return ha.size > hb.size;
+    });
+    return out;
+}
+
+VkDeviceMemory Image::allocateDeviceMemory(VkMemoryRequirements mrq, VkMemoryPropertyFlags wanted) {
+    for (auto idx : candidateMemoryTypes(mrq.memoryTypeBits, wanted)) {
+        VkMemoryAllocateInfo ai{VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO, nullptr, mrq.size, idx};
+        VkDeviceMemory mem{};
+        if (loader_->vkAllocateMemory(device_, &ai, nullptr, &mem) == VK_SUCCESS) {
+            return mem;
+        }
+    }
+    throw std::runtime_error("Failed to allocate memory");
+}
+
+std::tuple<VkPipelineStageFlags2, VkAccessFlags2, VkImageLayout> Image::barrierProps(BarrierState state) {
+    switch (state) {
+    case BarrierState::Undefined:
+        return {VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT, VK_ACCESS_2_NONE, VK_IMAGE_LAYOUT_UNDEFINED};
+    case BarrierState::TransferSrc:
+        return {VK_PIPELINE_STAGE_2_TRANSFER_BIT, VK_ACCESS_2_TRANSFER_READ_BIT, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL};
+    case BarrierState::TransferDst:
+        return {VK_PIPELINE_STAGE_2_TRANSFER_BIT, VK_ACCESS_2_TRANSFER_WRITE_BIT, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL};
+    case BarrierState::ShaderRead:
+        return {VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT, VK_ACCESS_2_SHADER_READ_BIT,
+                VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL};
+    case BarrierState::ShaderWrite:
+        return {VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT, VK_ACCESS_2_SHADER_WRITE_BIT, VK_IMAGE_LAYOUT_GENERAL};
+    case BarrierState::HostRead:
+        return {VK_PIPELINE_STAGE_2_HOST_BIT, VK_ACCESS_2_HOST_READ_BIT, VK_IMAGE_LAYOUT_GENERAL};
+    case BarrierState::HostWrite:
+        return {VK_PIPELINE_STAGE_2_HOST_BIT, VK_ACCESS_2_HOST_WRITE_BIT, VK_IMAGE_LAYOUT_GENERAL};
+
+    case BarrierState::GraphRead:
+        return {VK_PIPELINE_STAGE_2_DATA_GRAPH_BIT_ARM, VK_ACCESS_2_DATA_GRAPH_READ_BIT_ARM,
+                VK_IMAGE_LAYOUT_TENSOR_ALIASING_ARM};
+    case BarrierState::GraphWrite:
+        return {VK_PIPELINE_STAGE_2_DATA_GRAPH_BIT_ARM, VK_ACCESS_2_DATA_GRAPH_WRITE_BIT_ARM,
+                VK_IMAGE_LAYOUT_TENSOR_ALIASING_ARM};
+
+    default:
+        assert(false);
+    }
+    return {VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT, VK_ACCESS_2_NONE, VK_IMAGE_LAYOUT_UNDEFINED};
+}
+
+void Image::makeBarrier(VkCommandBuffer cmdBuf, BarrierState newState) {
+    if (isExternal()) {
+        // application-owned images should be externally synchronised
+        return;
+    }
+
+    VkImageMemoryBarrier2 imageBarrier;
+    VkBufferMemoryBarrier2 bufferBarrier;
+    VkDependencyInfo dependencyInfo{};
+    dependencyInfo.sType = VK_STRUCTURE_TYPE_DEPENDENCY_INFO;
+
+    const auto [srcStageMask, srcAccessMask, srcImageLayout] = barrierProps(state_);
+    const auto [dstStageMask, dstAccessMask, dstImageLayout] = barrierProps(newState);
+
+    if (hasBuffer()) {
+        bufferBarrier = {
+            VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER_2,
+            nullptr,
+            srcStageMask,
+            srcAccessMask,
+            dstStageMask,
+            dstAccessMask,
+            VK_QUEUE_FAMILY_IGNORED,
+            VK_QUEUE_FAMILY_IGNORED,
+            buffer_,
+            0,
+            sizeInBytes_,
+        };
+        dependencyInfo.bufferMemoryBarrierCount = 1;
+        dependencyInfo.pBufferMemoryBarriers = &bufferBarrier;
+    }
+
+    if (hasImage()) {
+        imageBarrier = {
+            VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER_2,
+            nullptr,
+            srcStageMask,
+            srcAccessMask,
+            dstStageMask,
+            dstAccessMask,
+            srcImageLayout,
+            dstImageLayout,
+            VK_QUEUE_FAMILY_IGNORED,
+            VK_QUEUE_FAMILY_IGNORED,
+            image_,
+            VkImageSubresourceRange{VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1},
+        };
+        dependencyInfo.imageMemoryBarrierCount = 1;
+        dependencyInfo.pImageMemoryBarriers = &imageBarrier;
+    }
+
+    loader_->vkCmdPipelineBarrier2(cmdBuf, &dependencyInfo);
+
+    state_ = newState;
+    imageLayout_ = dstImageLayout;
+}
+
+void Image::swapHandles(Image &other) {
+    assert(usage_ == other.usage_);
+    assert(dim_.height == other.dim_.height);
+    assert(dim_.width == other.dim_.width);
+    assert(dim_.depth == other.dim_.depth);
+    assert(format_ == other.format_);
+    assert(tiling_ == other.tiling_);
+    std::swap(buffer_, other.buffer_);
+    std::swap(image_, other.image_);
+    std::swap(imageView_, other.imageView_);
+    std::swap(imageLayout_, other.imageLayout_);
+    std::swap(state_, other.state_);
+}
+
+bool Image::isCompatible(const std::shared_ptr<Image> &a, const std::shared_ptr<Image> &b) {
+    if (!a || !b) {
+        return false;
+    }
+    return (a->usage() == b->usage()) && (a->width() == b->width()) && (a->height() == b->height()) &&
+           (a->format() == b->format());
+}
+
+} // namespace mlsdk::el::compute

--- a/graph/image.hpp
+++ b/graph/image.hpp
@@ -1,0 +1,204 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+#pragma once
+
+/*******************************************************************************
+ * Includes
+ *******************************************************************************/
+
+#include <vulkan/vulkan.hpp>
+
+#include <memory>
+#include <optional>
+
+namespace mlsdk::el::compute {
+
+/*******************************************************************************
+ * Image
+ *******************************************************************************/
+
+class Image {
+  public:
+    enum class Usage {
+        BufferStoreLoad,        // Producer stores to Buffer, consumer loads from Buffer
+        ImageStoreSample,       // Producer stores to Image, consumer samples from Image
+        BufferStoreImageSample, // Producer stores to Buffer, consumer samples from Image
+        ImageStoreBufferLoad,   // Producer stores to Image, consumer loads from Buffer
+        NoStoreImageSample,     // Read-only. Consumer samples from Image
+        HostBuffer,             // Host visible and coherent buffer. Mainly for staging buffer
+    };
+
+    enum class BarrierState {
+        Undefined,
+        TransferSrc,
+        TransferDst,
+        ShaderRead,
+        ShaderWrite,
+        HostRead,
+        HostWrite,
+        GraphRead,
+        GraphWrite,
+    };
+
+    enum class Type {
+        Internal,    // owned by the OpticalFlow instance
+        External,    // owned by the application
+        Placeholder, // placeholder to ensure compatability later
+    };
+
+    // Factories
+    static std::shared_ptr<Image>
+    makeInternal(const std::shared_ptr<VULKAN_HPP_NAMESPACE::detail::DispatchLoaderDynamic> &loader,
+                 VkPhysicalDevice physicalDevice, VkDevice device, Usage usage, VkExtent3D dim, VkFormat format,
+                 VkImageTiling tiling, bool isCached = false, const std::string &debugName = "") {
+        return std::make_shared<Image>(loader, physicalDevice, device, usage, dim, format, tiling, isCached, debugName);
+    }
+
+    static std::shared_ptr<Image>
+    makePlaceholder(const std::shared_ptr<VULKAN_HPP_NAMESPACE::detail::DispatchLoaderDynamic> &loader, Usage usage,
+                    VkExtent3D dim, VkFormat format, VkImageLayout layout) {
+        return std::make_shared<Image>(loader, usage, dim, format, layout);
+    }
+
+    // Creates an internal image
+    Image(const std::shared_ptr<VULKAN_HPP_NAMESPACE::detail::DispatchLoaderDynamic> &loader,
+          VkPhysicalDevice physicalDevice, VkDevice device, Usage usage, VkExtent3D dim, VkFormat format,
+          VkImageTiling tiling, bool isCached, const std::string &debugName);
+    // Creates a placeholder image
+    Image(const std::shared_ptr<VULKAN_HPP_NAMESPACE::detail::DispatchLoaderDynamic> &loader, Usage usage,
+          VkExtent3D dim, VkFormat format, VkImageLayout layout);
+
+    ~Image();
+
+    // Internal resource creation
+    void makeImage();
+    void makeBuffer();
+    void makeBufferAlias();
+    // External resource connection
+    void setExternalDescriptor(VkDescriptorSet descriptorSet, uint32_t binding, VkImageView imageView);
+
+    // Memory helpers
+    VkMemoryRequirements getMemoryRequirements() const;
+    void setMemoryOffset(VkDeviceSize offset);
+    void bindToMemory(VkDeviceMemory memory, VkDeviceSize baseOffset);
+    VkDeviceMemory allocateDeviceMemory(VkMemoryRequirements mrq, VkMemoryPropertyFlags wantedProps);
+
+    void makeBarrier(VkCommandBuffer cmdBuf, BarrierState newState);
+
+    // Utils
+    void swapHandles(Image &other);
+
+    bool isBufferStore() const;
+    bool isBufferLoad() const;
+    bool isImageStore() const;
+    bool isImageSample() const;
+
+    bool isLinearTiling() const;
+
+    bool isPlaceholder() const;
+    bool isExternal() const;
+    bool isInternal() const;
+    bool isCached() const;
+
+    bool hasImage() const;
+    bool hasBuffer() const;
+
+    uint32_t height() const;
+    uint32_t width() const;
+    uint32_t stride() const;
+    uint32_t componentCount() const;
+    Usage usage() const;
+    VkFormat format() const;
+
+    VkImageView getImageView() const;
+    VkImageLayout getImageLayout() const;
+    VkBuffer getBuffer() const;
+
+    // checks if two images are compatible for binding
+    static bool isCompatible(const std::shared_ptr<Image> &a, const std::shared_ptr<Image> &b);
+
+  private:
+    std::vector<uint32_t> candidateMemoryTypes(uint32_t memoryTypeBits, VkMemoryPropertyFlags wanted) const;
+    std::tuple<VkPipelineStageFlags2, VkAccessFlags2, VkImageLayout> barrierProps(BarrierState state);
+
+    std::shared_ptr<VULKAN_HPP_NAMESPACE::detail::DispatchLoaderDynamic> loader_;
+    VkPhysicalDevice physicalDevice_;
+    VkDevice device_;
+
+    Usage usage_ = Usage::BufferStoreLoad;
+    VkExtent3D dim_;
+    BarrierState state_ = BarrierState::Undefined;
+    VkDeviceSize sizeInBytes_ = 0;
+    VkDeviceSize blockSize_ = 1;
+    VkDeviceSize rowPitch_ = 1;
+    uint32_t componentCount_ = 1;
+    VkFormat format_ = VK_FORMAT_UNDEFINED;
+    VkImageTiling tiling_ = VK_IMAGE_TILING_LINEAR;
+    VkImageLayout imageLayout_ = VK_IMAGE_LAYOUT_UNDEFINED;
+    Type imageType_;
+    bool isCached_ = false;
+    std::string debugName_;
+
+    VkMemoryRequirements memoryRequirements_;
+    VkDeviceSize memoryOffset_;
+
+    // Internal resource handles
+    VkImageView imageView_ = VK_NULL_HANDLE;
+    VkImage image_ = VK_NULL_HANDLE;
+    VkBuffer buffer_ = VK_NULL_HANDLE;
+
+    // External images only
+    VkDescriptorSet externalDescriptorSet_ = VK_NULL_HANDLE;
+    uint32_t externalBinding_ = 0;
+    VkImageView externalImageView_ = VK_NULL_HANDLE;
+};
+
+inline bool Image::isBufferStore() const {
+    return usage_ == Usage::BufferStoreLoad || usage_ == Usage::BufferStoreImageSample;
+}
+inline bool Image::isBufferLoad() const {
+    return usage_ == Usage::BufferStoreLoad || usage_ == Usage::ImageStoreBufferLoad;
+}
+inline bool Image::isImageStore() const {
+    return usage_ == Usage::ImageStoreSample || usage_ == Usage::ImageStoreBufferLoad;
+}
+inline bool Image::isImageSample() const {
+    return usage_ == Usage::ImageStoreSample || usage_ == Usage::BufferStoreImageSample ||
+           usage_ == Usage::NoStoreImageSample;
+}
+
+inline bool Image::isLinearTiling() const { return tiling_ == VK_IMAGE_TILING_LINEAR; }
+
+inline bool Image::isPlaceholder() const { return imageType_ == Type::Placeholder; }
+inline bool Image::isExternal() const { return imageType_ == Type::External; }
+inline bool Image::isInternal() const { return imageType_ == Type::Internal; }
+inline bool Image::isCached() const { return isCached_; }
+
+inline bool Image::hasBuffer() const { return buffer_ != VK_NULL_HANDLE; }
+inline bool Image::hasImage() const { return image_ != VK_NULL_HANDLE; }
+
+inline VkImageView Image::getImageView() const { return isInternal() ? imageView_ : externalImageView_; }
+inline VkImageLayout Image::getImageLayout() const { return imageLayout_; }
+inline VkBuffer Image::getBuffer() const { return buffer_; }
+
+inline VkMemoryRequirements Image::getMemoryRequirements() const { return memoryRequirements_; }
+inline void Image::setMemoryOffset(VkDeviceSize offset) { memoryOffset_ = offset; }
+
+inline Image::Usage Image::usage() const { return usage_; }
+inline VkFormat Image::format() const { return format_; }
+inline uint32_t Image::height() const { return dim_.height; }
+inline uint32_t Image::width() const { return dim_.width; }
+inline uint32_t Image::stride() const {
+    if (isLinearTiling()) {
+        return static_cast<uint32_t>(rowPitch_ / blockSize_);
+    }
+    // This should not be used in the shader
+    return 0;
+}
+inline uint32_t Image::componentCount() const { return componentCount_; }
+
+} // namespace mlsdk::el::compute

--- a/graph/layer.d/VkLayer_Graph.json.in
+++ b/graph/layer.d/VkLayer_Graph.json.in
@@ -56,6 +56,14 @@
                 "entrypoints": [
                     "vkGetPhysicalDeviceQueueFamilyDataGraphEngineOperationPropertiesARM"
                 ]
+            },
+            {
+                "name": "VK_ARM_data_graph_optical_flow",
+                "spec_version": "1",
+                "entrypoints": [
+                    "vkGetPhysicalDeviceQueueFamilyDataGraphEngineOperationPropertiesARM",
+                    "vkGetPhysicalDeviceQueueFamilyDataGraphOpticalFlowImageFormatsARM"
+                ]
             }
         ]
     }

--- a/graph/optical_flow.cpp
+++ b/graph/optical_flow.cpp
@@ -1,0 +1,537 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+/*******************************************************************************
+ * Includes
+ *******************************************************************************/
+
+#include "optical_flow.hpp"
+#include "compute_optical_flow.hpp"
+#include "image.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <vulkan/vulkan.hpp>
+
+using namespace mlsdk::el::utils;
+using SearchType = mlsdk::el::compute::common::BlockMatchMode;
+
+namespace mlsdk::el::compute::optical_flow {
+
+/*******************************************************************************
+ * OpticalFlow
+ *******************************************************************************/
+
+OpticalFlow::OpticalFlow(std::shared_ptr<VULKAN_HPP_NAMESPACE::detail::DispatchLoaderDynamic> loader,
+                         VkPhysicalDevice physicalDevice, VkDevice device,
+                         const std::shared_ptr<PipelineCache> &pipelineCache)
+    : loader_(loader), physicalDevice_(physicalDevice), device_(device), pipelineCache_(pipelineCache) {}
+
+void OpticalFlow::init(const Config &config) {
+    // Check configuration is supported
+    [[maybe_unused]] auto isSupported = [](auto fmt, const auto &supported) -> bool {
+        return supported.find(fmt) != supported.end();
+    };
+    assert(isSupported(config.imageFormat, Spec::supportedImageFormats));
+    assert(isSupported(config.flowFormat, Spec::supportedFlowFormats));
+    if (config.outputCost) {
+        assert(isSupported(config.costFormat, Spec::supportedCostFormats));
+    }
+    assert(isSupported(config.levelOfLastEstimation, Spec::supportedLevelOfLastEstimation));
+    assert(config.width >= Spec::minWidth && config.width <= Spec::maxWidth);
+    assert(config.height >= Spec::minHeight && config.height <= Spec::maxHeight);
+    assert(!(config.useMvInput && !Spec::hintSupported));
+    assert(!(config.outputCost && !Spec::costSupported));
+
+    config_ = config;
+    const auto inputUsage = Image::Usage::NoStoreImageSample;
+    const auto outputUsage = Image::Usage::ImageStoreSample;
+    const VkExtent3D inputDims{config.width, config.height, 1};
+    setupPyramidLevelDimensions(inputDims.width, inputDims.height);
+
+    const auto granularity = static_cast<uint32_t>(std::pow(2, config.levelOfLastEstimation));
+    const VkExtent3D outputDims{divideRoundUp(inputDims.width, granularity),
+                                divideRoundUp(inputDims.height, granularity), 1};
+
+    outputFlowScale_ = calcOutputFlowScale();
+
+    assert(!inputSearchRGB_ && !inputTemplateRGB_ && !inputMV_ && !outputFlow_ && !outputCost_);
+
+    // Create placeholder images, with no resource attached, to ensure compatability when replacing them with external
+    // (application-owned) images.
+    inputSearchRGB_ =
+        Image::makePlaceholder(loader_, inputUsage, inputDims, config.imageFormat, config.srcSearch.layout);
+
+    inputTemplateRGB_ =
+        Image::makePlaceholder(loader_, inputUsage, inputDims, config.imageFormat, config.srcTemplate.layout);
+
+    if (config_.useMvInput) {
+        inputMV_ = Image::makePlaceholder(loader_, inputUsage, outputDims, config.flowFormat, config.srcFlow.layout);
+    }
+
+    outputFlow_ = Image::makePlaceholder(loader_, outputUsage, outputDims, config.flowFormat, config.dstFlow.layout);
+    if (config_.outputCost) {
+        outputCost_ =
+            Image::makePlaceholder(loader_, outputUsage, outputDims, config.costFormat, config.dstCost.layout);
+    }
+
+    makeDownsamplePyramid(dsBlocksSearch_, inputSearchRGB_, rgbToYSearch_, downsampleSearchPipelines_);
+    makeDownsamplePyramid(dsBlocksTemplate_, inputTemplateRGB_, rgbToYTemplate_, downsampleTemplatePipelines_);
+    makeMotionEstimationBlocks();
+
+    if (config_.useMvInput) {
+        makeReplaceWithMvInput();
+    }
+
+    computeMemoryRequirements();
+
+    for (const auto &pipeline : downsampleSearchPipelines_) {
+        pipeline->makePipeline();
+    }
+
+    for (const auto &pipeline : downsampleTemplatePipelines_) {
+        pipeline->makePipeline();
+    }
+
+    for (const auto &pipeline : motionEstimationPipelines_) {
+        pipeline->makePipeline();
+    }
+}
+
+void OpticalFlow::setInputSearch(std::shared_ptr<Image> input) {
+    inputSearchRGB_ = input;
+    if (rgbToYSearch_) {
+        rgbToYSearch_->setInput(inputSearchRGB_);
+    }
+}
+
+void OpticalFlow::setInputTemplate(std::shared_ptr<Image> input) {
+    inputTemplateRGB_ = input;
+    if (rgbToYTemplate_) {
+        rgbToYTemplate_->setInput(inputTemplateRGB_);
+    }
+}
+
+void OpticalFlow::setInputMV(std::shared_ptr<Image> input) {
+    inputMV_ = input;
+    if (warpByMvInput_) {
+        warpByMvInput_->setInputFlow(inputMV_);
+    }
+    if (mvReplace_) {
+        mvReplace_->setInputMv(inputMV_);
+    }
+}
+
+void OpticalFlow::setOutputFlow(std::shared_ptr<Image> output) {
+    outputFlow_ = output;
+
+    if (config_.useMvInput) {
+        mvReplaceFlowOut_ = outputFlow_;
+        if (mvReplace_) {
+            mvReplace_->setOutputFlow(outputFlow_);
+        }
+    } else {
+        assert(config_.levelOfLastEstimation < MEBlocks_.size());
+        auto &block = MEBlocks_[config_.levelOfLastEstimation];
+        if (config_.performanceLevel == PerformanceLevel::FAST) {
+            block.medianFilterOut = outputFlow_;
+            if (block.medianFilterPipeline) {
+                block.medianFilterPipeline->setOutput(outputFlow_);
+            }
+        } else {
+            block.bilateralFilterOut = outputFlow_;
+            if (block.bilateralFilterPipeline) {
+                block.bilateralFilterPipeline->setOutput(outputFlow_);
+            }
+        }
+    }
+}
+
+void OpticalFlow::setOutputCost(std::shared_ptr<Image> output) {
+    outputCost_ = output;
+
+    if (config_.useMvInput) {
+        mvReplaceCostOut_ = outputCost_;
+        if (mvReplace_) {
+            mvReplace_->setOutputCost(outputCost_);
+        }
+    } else if (config_.outputCost) {
+        auto lastBlockMatchPipeline = MEBlocks_[config_.levelOfLastEstimation].blockMatchPipeline;
+        if (lastBlockMatchPipeline) {
+            lastBlockMatchPipeline->setOutputCost(outputCost_);
+        }
+    }
+}
+
+void OpticalFlow::setupPyramidLevelDimensions(uint32_t initialWidth, uint32_t initialHeight) {
+    pyramidDimensions_.clear();
+    pyramidDimensions_.reserve(pyramidLevels_);
+    pyramidDimensions_.emplace_back(VkExtent3D{initialWidth, initialHeight, 1});
+    for (size_t level = 1; level < pyramidLevels_; ++level) {
+        const auto &prev = pyramidDimensions_.back();
+        const auto width = roundUp<uint32_t>(divideRoundUp(prev.width, 2), 2);
+        const auto height = roundUp<uint32_t>(divideRoundUp(prev.height, 2), 2);
+        pyramidDimensions_.emplace_back(VkExtent3D{width, height, 1});
+    }
+}
+
+void OpticalFlow::makeDownsamplePyramid(std::vector<DownsampleBlock> &blocks, std::shared_ptr<Image> &srcImage,
+                                        std::shared_ptr<RGBToY> &rgbToY,
+                                        std::vector<std::shared_ptr<ComputePipeline>> &pipelines) {
+    blocks.resize(pyramidLevels_);
+    const bool cacheImages = true;
+    // Handle first level separately. For 1x1 granularity variant, we need luma image in original resolution.
+    const bool isRGBToYOutputFull = (config_.levelOfLastEstimation == 0);
+    if (isRGBToYOutputFull) {
+        auto lumaImage = makeImage(Image::Usage::BufferStoreImageSample, pyramidDimensions_[0], VK_FORMAT_R8_UNORM,
+                                   VK_IMAGE_TILING_LINEAR, std::string("luma"), cacheImages);
+
+        blocks[0].image = lumaImage;
+    }
+
+    for (size_t level = 0; level < pyramidLevels_ - 1; ++level) {
+        const auto levelStr = std::to_string(level);
+        if (level == 0) {
+            const auto usage =
+                isRGBToYOutputFull ? Image::Usage::BufferStoreImageSample : Image::Usage::ImageStoreSample;
+            const auto tiling = isRGBToYOutputFull ? VK_IMAGE_TILING_LINEAR : VK_IMAGE_TILING_OPTIMAL;
+
+            auto downscaledImage = makeImage(usage, pyramidDimensions_[level + 1], VK_FORMAT_R8_UNORM, tiling,
+                                             std::string("downscaled_L") + levelStr, cacheImages);
+            blocks[level + 1].image = downscaledImage;
+
+            // RGB-to-Y + downsample
+            rgbToY = makePipeline<RGBToY>(pipelines, srcImage, blocks[level + 1].image, blocks[level].image, true,
+                                          isRGBToYOutputFull, 2.0f, std::string("RGBtoY_L") + levelStr);
+        } else {
+            auto downscaledImage =
+                makeImage(Image::Usage::ImageStoreSample, pyramidDimensions_[level + 1], VK_FORMAT_R8_UNORM,
+                          VK_IMAGE_TILING_OPTIMAL, std::string("downscaled_L") + levelStr, cacheImages);
+            blocks[level + 1].image = downscaledImage;
+            // blur + downsample
+            blocks[level].pipeline = makePipeline<Downsample>(pipelines, blocks[level].image, downscaledImage,
+                                                              std::string("Downsample_L") + levelStr);
+        }
+    }
+}
+
+void OpticalFlow::makeMotionEstimationBlocks() {
+    MEBlocks_.resize(pyramidLevels_);
+
+    setOutputFlow(outputFlow_);
+    setOutputCost(outputCost_);
+
+    // Start at the bottom of the pyramid and work up.
+    const auto first = pyramidLevels_ - 1;
+    const auto last = config_.levelOfLastEstimation;
+    for (size_t level = first; level + 1 > last; --level) {
+        auto getFlowDim = [&](size_t l) -> VkExtent3D {
+            return {pyramidDimensions_[l].width, pyramidDimensions_[l].height, 1};
+        };
+
+        const auto levelStr = std::to_string(level);
+        auto createFlowMem = [&](Image::Usage usage, std::string debugPrefix) -> std::shared_ptr<Image> {
+            const auto tiling =
+                usage == Image::Usage::ImageStoreSample ? VK_IMAGE_TILING_OPTIMAL : VK_IMAGE_TILING_LINEAR;
+            return makeImage(usage, getFlowDim(level), VK_FORMAT_R16G16_SFLOAT, tiling,
+                             debugPrefix.append("_flow_L").append(levelStr));
+        };
+
+        const bool isLastLevel = (level == config_.levelOfLastEstimation);
+
+        auto &block = MEBlocks_[level];
+        bool accumulatePrevFlow = true;
+        if (level == first) {
+            // previous flow not avaible
+            accumulatePrevFlow = false;
+            block.upscaledFlow = createFlowMem(Image::Usage::BufferStoreLoad, "upscaled");
+            // image is not warped here
+            block.warpedImage = dsBlocksSearch_[level].image;
+        } else {
+            // MV process and warp
+            block.warpedImage =
+                makeImage(Image::Usage::BufferStoreImageSample, pyramidDimensions_[level], VK_FORMAT_R8_UNORM,
+                          VK_IMAGE_TILING_LINEAR, std::string("warped_L") + levelStr);
+            block.upscaledFlow = createFlowMem(Image::Usage::BufferStoreLoad, "upscaled");
+
+            block.mvWarpPipeline = makePipeline<MVProcessAndWarp>(
+                motionEstimationPipelines_, dsBlocksSearch_[level].image, MEBlocks_[level + 1].filteredFlowOut,
+                block.warpedImage, block.upscaledFlow, std::string("MVProcessAndWarp_L") + levelStr);
+        }
+        // Block match
+        block.blockMatchOut = makeImage(Image::Usage::BufferStoreLoad, getFlowDim(level), VK_FORMAT_R8G8_SINT,
+                                        VK_IMAGE_TILING_LINEAR, std::string("blockmatch_flow_L") + levelStr);
+
+        std::shared_ptr<Image> costOut{};
+        auto searchType = SearchType::MIN_SAD;
+        if (isLastLevel) {
+            if (config_.useMvInput) {
+                searchType = SearchType::MIN_SAD_COST;
+                minCostBlockMatch_ =
+                    makeImage(Image::Usage::BufferStoreImageSample, pyramidDimensions_[level], VK_FORMAT_R16_UINT,
+                              VK_IMAGE_TILING_LINEAR, std::string("blockmatch_cost_L") + levelStr);
+                costOut = minCostBlockMatch_;
+            } else if (config_.outputCost) {
+                searchType = SearchType::MIN_SAD_COST;
+                costOut = outputCost_;
+            }
+        }
+
+        block.blockMatchPipeline = makePipeline<BlockMatch>(
+            motionEstimationPipelines_, searchType, config_.maxSearchRange, block.warpedImage,
+            dsBlocksTemplate_[level].image, block.blockMatchOut, costOut, std::string("BlockMatch_L") + levelStr);
+
+        // Subpixel motion estimation
+        block.subpixelOut = createFlowMem(Image::Usage::BufferStoreImageSample, "subpixel");
+        block.subpixelMEPipeline = makePipeline<SubpixelME>(
+            motionEstimationPipelines_, block.warpedImage, dsBlocksTemplate_[level].image, block.blockMatchOut,
+            block.upscaledFlow, block.subpixelOut, accumulatePrevFlow, std::string("SubpixelME_L") + levelStr);
+
+        // median filter
+        if (block.medianFilterOut == nullptr) {
+            block.medianFilterOut = createFlowMem(Image::Usage::ImageStoreSample, "medianF");
+        }
+
+        float medianFilterOutputScale = 1.0f;
+        if (isLastLevel && config_.performanceLevel == PerformanceLevel::FAST) {
+            medianFilterOutputScale = outputFlowScale_;
+        }
+
+        block.medianFilterPipeline =
+            makePipeline<MedianFilter>(motionEstimationPipelines_, block.subpixelOut, block.medianFilterOut,
+                                       medianFilterOutputScale, std::string("MedianFilter_L") + levelStr);
+        block.filteredFlowOut = block.medianFilterOut;
+
+        if (config_.performanceLevel != PerformanceLevel::FAST) {
+            // joint bilateral filter
+            if (block.bilateralFilterOut == nullptr) {
+                block.bilateralFilterOut = createFlowMem(Image::Usage::BufferStoreImageSample, "bilatF");
+            }
+
+            float bilateralFilterOutputScale = 1.0f;
+            if (isLastLevel) {
+                bilateralFilterOutputScale = outputFlowScale_;
+            }
+
+            block.bilateralFilterPipeline = makePipeline<BilateralFilter>(
+                motionEstimationPipelines_, dsBlocksTemplate_[level].image, block.medianFilterOut,
+                block.bilateralFilterOut, bilateralFilterOutputScale, std::string("BilateralFilter_L") + levelStr);
+            block.filteredFlowOut = block.bilateralFilterOut;
+        }
+    }
+}
+
+void OpticalFlow::makeReplaceWithMvInput() {
+    const auto level = config_.levelOfLastEstimation;
+    const auto levelStr = std::to_string(level);
+
+    // warp search image by MV input
+    warpedByMvInputImage_ = makeImage(Image::Usage::ImageStoreSample, pyramidDimensions_[level], VK_FORMAT_R8_UNORM,
+                                      VK_IMAGE_TILING_OPTIMAL, std::string("warpedByMVInput_L") + levelStr);
+    warpByMvInput_ =
+        makePipeline<DenseWarp>(motionEstimationPipelines_, dsBlocksSearch_[level].image, inputMV_,
+                                warpedByMvInputImage_, 1.f / outputFlowScale_, std::string("DenseWarp_L") + levelStr);
+
+    // calculate cost at MV input
+    costAtMvInput_ = makeImage(Image::Usage::BufferStoreImageSample, pyramidDimensions_[level], VK_FORMAT_R16_UINT,
+                               VK_IMAGE_TILING_LINEAR, std::string("costAtMVInput_L") + levelStr);
+    rawSad_ = makePipeline<BlockMatch>(motionEstimationPipelines_, SearchType::RAW_SAD, 0, warpedByMvInputImage_,
+                                       dsBlocksTemplate_[level].image, nullptr, costAtMvInput_,
+                                       std::string("BlockMatch_L") + levelStr);
+
+    // replace MV depending on cost value
+    mvReplace_ = makePipeline<MVReplace>(motionEstimationPipelines_, inputMV_, MEBlocks_[level].filteredFlowOut,
+                                         costAtMvInput_, minCostBlockMatch_, mvReplaceFlowOut_, mvReplaceCostOut_,
+                                         config_.outputCost, std::string("MVReplace_L") + levelStr);
+}
+
+void OpticalFlow::computeMemoryRequirements() {
+    VkMemoryRequirements cacheMemReqs{0, 1, ~0u};
+    VkMemoryRequirements transientMemReqs{0, 1, ~0u};
+
+    VkPhysicalDeviceProperties physicalDeviceProperties;
+    loader_->vkGetPhysicalDeviceProperties(physicalDevice_, &physicalDeviceProperties);
+    const VkDeviceSize bufferImageGranularity = physicalDeviceProperties.limits.bufferImageGranularity;
+
+    for (const auto &image : allImages_) {
+        const auto mrqs = image->getMemoryRequirements();
+        const auto alignment = std::max(mrqs.alignment, bufferImageGranularity);
+        if (image->isCached()) {
+            cacheMemReqs.size = roundUp(cacheMemReqs.size, alignment);
+            image->setMemoryOffset(cacheMemReqs.size);
+
+            cacheMemReqs.size += mrqs.size;
+            cacheMemReqs.alignment = std::max(cacheMemReqs.alignment, alignment);
+            cacheMemReqs.memoryTypeBits &= mrqs.memoryTypeBits;
+        } else {
+            transientMemReqs.size = roundUp(transientMemReqs.size, alignment);
+            image->setMemoryOffset(transientMemReqs.size);
+
+            transientMemReqs.size += mrqs.size;
+            transientMemReqs.alignment = std::max(transientMemReqs.alignment, alignment);
+            transientMemReqs.memoryTypeBits &= mrqs.memoryTypeBits;
+        }
+    }
+
+    cacheMemoryRequirements_ = cacheMemReqs;
+    transientMemoryRequirements_ = transientMemReqs;
+}
+
+VkMemoryRequirements OpticalFlow::getCacheMemoryRequirements() const { return cacheMemoryRequirements_; }
+VkMemoryRequirements OpticalFlow::getTransientMemoryRequirements() const { return transientMemoryRequirements_; }
+
+void OpticalFlow::bindSessionTransientMemory(VkDeviceMemory memory, VkDeviceSize offset) {
+    for (const auto &image : allImages_) {
+        if (!image->isCached()) {
+            image->bindToMemory(memory, offset);
+        }
+    }
+}
+
+void OpticalFlow::bindSessionCacheMemory(VkDeviceMemory memory, VkDeviceSize offset) {
+    for (const auto &image : allImages_) {
+        if (image->isCached()) {
+            image->bindToMemory(memory, offset);
+        }
+    }
+}
+
+void OpticalFlow::updateDescriptorSets(const OpticalFlowDescriptorMap &descriptorMap) {
+    auto getDescriptorSetAndImageView =
+        [&descriptorMap](const Config::InputImage &in) -> std::pair<VkDescriptorSet, VkImageView> {
+        const auto it = descriptorMap.find({in.set, in.binding, 0});
+        if (it != descriptorMap.end()) {
+            return it->second;
+        }
+        throw std::runtime_error("Optical flow descriptors inconsistent with connectivity map");
+    };
+
+    VkDescriptorSet vkDescriptorSet;
+    VkImageView vkImageView;
+
+    std::tie(vkDescriptorSet, vkImageView) = getDescriptorSetAndImageView(config_.srcSearch);
+    inputSearchRGB_->setExternalDescriptor(vkDescriptorSet, config_.srcSearch.binding, vkImageView);
+    setInputSearch(inputSearchRGB_);
+
+    std::tie(vkDescriptorSet, vkImageView) = getDescriptorSetAndImageView(config_.srcTemplate);
+    inputTemplateRGB_->setExternalDescriptor(vkDescriptorSet, config_.srcTemplate.binding, vkImageView);
+    setInputTemplate(inputTemplateRGB_);
+
+    if (config_.useMvInput) {
+        std::tie(vkDescriptorSet, vkImageView) = getDescriptorSetAndImageView(config_.srcFlow);
+        inputMV_->setExternalDescriptor(vkDescriptorSet, config_.srcFlow.binding, vkImageView);
+        setInputMV(inputMV_);
+    }
+
+    std::tie(vkDescriptorSet, vkImageView) = getDescriptorSetAndImageView(config_.dstFlow);
+    outputFlow_->setExternalDescriptor(vkDescriptorSet, config_.dstFlow.binding, vkImageView);
+    setOutputFlow(outputFlow_);
+
+    if (config_.outputCost) {
+        std::tie(vkDescriptorSet, vkImageView) = getDescriptorSetAndImageView(config_.dstCost);
+        outputCost_->setExternalDescriptor(vkDescriptorSet, config_.dstCost.binding, vkImageView);
+        setOutputCost(outputCost_);
+    }
+}
+
+void OpticalFlow::cmdBindAndDispatch(VkCommandBuffer cmdBuf, VkDataGraphOpticalFlowExecuteFlagsARM flags,
+                                     uint32_t meanFlowL1NormHint) {
+    if (!validateConfiguration()) {
+        throw std::runtime_error("Invalid configuration");
+    }
+
+    constexpr VkDataGraphOpticalFlowExecuteFlagsARM temporalHintFlags =
+        VK_DATA_GRAPH_OPTICAL_FLOW_EXECUTE_INPUT_UNCHANGED_BIT_ARM |
+        VK_DATA_GRAPH_OPTICAL_FLOW_EXECUTE_REFERENCE_UNCHANGED_BIT_ARM |
+        VK_DATA_GRAPH_OPTICAL_FLOW_EXECUTE_INPUT_IS_PREVIOUS_REFERENCE_BIT_ARM |
+        VK_DATA_GRAPH_OPTICAL_FLOW_EXECUTE_REFERENCE_IS_PREVIOUS_INPUT_BIT_ARM;
+
+    const bool disableTemporalHints = (flags & VK_DATA_GRAPH_OPTICAL_FLOW_EXECUTE_DISABLE_TEMPORAL_HINTS_BIT_ARM) != 0;
+    const VkDataGraphOpticalFlowExecuteFlagsARM effectiveFlags =
+        disableTemporalHints ? static_cast<VkDataGraphOpticalFlowExecuteFlagsARM>(
+                                   flags & static_cast<VkDataGraphOpticalFlowExecuteFlagsARM>(~temporalHintFlags))
+                             : flags;
+
+    // Indicates that the previous template image is the current search image or vice-versa
+    if (effectiveFlags & (VK_DATA_GRAPH_OPTICAL_FLOW_EXECUTE_INPUT_IS_PREVIOUS_REFERENCE_BIT_ARM |
+                          VK_DATA_GRAPH_OPTICAL_FLOW_EXECUTE_REFERENCE_IS_PREVIOUS_INPUT_BIT_ARM)) {
+        // Swap image pyramids to avoid regenerating for the same image
+        swapImagePyramids();
+    }
+
+    const int searchRangeLimit = toSearchRangeLimit(meanFlowL1NormHint);
+    for (auto &me : MEBlocks_) {
+        if (me.blockMatchPipeline) {
+            me.blockMatchPipeline->setSearchRangeLimit(searchRangeLimit);
+        }
+    }
+
+    if (!(effectiveFlags & (VK_DATA_GRAPH_OPTICAL_FLOW_EXECUTE_REFERENCE_UNCHANGED_BIT_ARM |
+                            VK_DATA_GRAPH_OPTICAL_FLOW_EXECUTE_REFERENCE_IS_PREVIOUS_INPUT_BIT_ARM))) {
+        for (const auto &pipeline : downsampleTemplatePipelines_) {
+            pipeline->bindAndDispatch(cmdBuf);
+        }
+    }
+
+    if (!(effectiveFlags & (VK_DATA_GRAPH_OPTICAL_FLOW_EXECUTE_INPUT_UNCHANGED_BIT_ARM |
+                            VK_DATA_GRAPH_OPTICAL_FLOW_EXECUTE_INPUT_IS_PREVIOUS_REFERENCE_BIT_ARM))) {
+        for (const auto &pipeline : downsampleSearchPipelines_) {
+            pipeline->bindAndDispatch(cmdBuf);
+        }
+    }
+
+    for (const auto &pipeline : motionEstimationPipelines_) {
+        pipeline->bindAndDispatch(cmdBuf);
+    }
+}
+
+void OpticalFlow::swapImagePyramids() {
+    for (size_t i = 0; i < dsBlocksSearch_.size(); ++i) {
+        if (dsBlocksSearch_[i].image) {
+            dsBlocksSearch_[i].image->swapHandles(*dsBlocksTemplate_[i].image);
+        }
+    }
+}
+
+float OpticalFlow::calcOutputFlowScale() const { return static_cast<float>(1 << config_.levelOfLastEstimation); }
+
+int OpticalFlow::toSearchRangeLimit(uint32_t meanFlowL1NormHint) const {
+    const uint32_t maxDimension = std::max(config_.width, config_.height);
+    meanFlowL1NormHint = std::min(meanFlowL1NormHint, maxDimension);
+    if (meanFlowL1NormHint == 0) {
+        return config_.maxSearchRange;
+    }
+
+    const int factor = (1 << (pyramidLevels_ - 1)) / 2;
+    int searchRangeLimit = static_cast<int>(std::ceil(meanFlowL1NormHint / static_cast<float>(factor)));
+    searchRangeLimit = std::clamp(searchRangeLimit, 1, config_.maxSearchRange);
+    return searchRangeLimit;
+}
+
+bool OpticalFlow::validateConfiguration() const {
+    bool anyPlaceholder = false;
+    anyPlaceholder |= inputSearchRGB_->isPlaceholder();
+    anyPlaceholder |= inputTemplateRGB_->isPlaceholder();
+    if (config_.useMvInput) {
+        anyPlaceholder |= inputMV_->isPlaceholder();
+    }
+    anyPlaceholder |= outputFlow_->isPlaceholder();
+    if (config_.outputCost) {
+        anyPlaceholder |= outputCost_->isPlaceholder();
+    }
+
+    return !anyPlaceholder;
+}
+
+std::shared_ptr<Image> OpticalFlow::makeImage(Image::Usage usage, VkExtent3D dim, VkFormat format, VkImageTiling tiling,
+                                              const std::string &debugName, bool isCached) {
+    auto image =
+        Image::makeInternal(loader_, physicalDevice_, device_, usage, dim, format, tiling, isCached, debugName);
+    allImages_.push_back(image);
+    return image;
+}
+
+} // namespace mlsdk::el::compute::optical_flow

--- a/graph/optical_flow.hpp
+++ b/graph/optical_flow.hpp
@@ -1,0 +1,206 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+#pragma once
+
+/*******************************************************************************
+ * Includes
+ *******************************************************************************/
+
+#include "compute_optical_flow.hpp"
+#include "image.hpp"
+#include "mlel/utils.hpp"
+#include "tensor.hpp"
+
+#include <set>
+#include <type_traits>
+#include <vulkan/vulkan.hpp>
+
+namespace mlsdk::el::compute::optical_flow {
+
+// Map descriptor set index + binding + array element -> descriptor set + image view
+using OpticalFlowDescriptorMap =
+    std::map<std::tuple<uint32_t, uint32_t, uint32_t>, std::pair<VkDescriptorSet, VkImageView>>;
+
+/*******************************************************************************
+ * OpticalFlow
+ *******************************************************************************/
+
+class OpticalFlow {
+  public:
+    OpticalFlow(std::shared_ptr<VULKAN_HPP_NAMESPACE::detail::DispatchLoaderDynamic> loader,
+                VkPhysicalDevice physicalDevice, VkDevice device, const std::shared_ptr<PipelineCache> &pipelineCache);
+    ~OpticalFlow() = default;
+
+    struct Spec {
+        static constexpr VkBool32 hintSupported = VK_TRUE;
+        static constexpr VkBool32 costSupported = VK_TRUE;
+
+        static constexpr uint32_t minWidth = 64;
+        static constexpr uint32_t minHeight = 64;
+        static constexpr uint32_t maxWidth = 8192;
+        static constexpr uint32_t maxHeight = 8192;
+
+        // Correspondns to supportedOutputGridSizes and supportedHintGridSizes.
+        // To convert to VkOpticalFlowGridSizeFlagsARM, do (1 << levelOfLastEstimation).
+        // OutputGridSize and HintGridSize must be the same value in creating session.
+        inline static const std::set<size_t> supportedLevelOfLastEstimation{0, 1, 2, 3};
+
+        inline static const std::set<VkFormat> supportedImageFormats{
+            VK_FORMAT_R8G8B8_UNORM,
+            VK_FORMAT_B8G8R8_UNORM,
+            VK_FORMAT_R8G8B8A8_UNORM,
+            VK_FORMAT_B8G8R8A8_UNORM,
+            VK_FORMAT_B10G11R11_UFLOAT_PACK32,
+            VK_FORMAT_R8_UNORM,
+        };
+
+        inline static const std::set<VkFormat> supportedFlowFormats{
+            VK_FORMAT_R16G16_SFLOAT,
+        };
+
+        inline static const std::set<VkFormat> supportedCostFormats{
+            VK_FORMAT_R16_UINT,
+        };
+    };
+
+    enum class PerformanceLevel { MEDIUM, FAST, SLOW, UNKNOWN };
+
+    struct Config {
+        uint32_t width;
+        uint32_t height;
+        size_t levelOfLastEstimation = 2;
+        bool useMvInput = false;
+        bool outputCost = false;
+        PerformanceLevel performanceLevel = PerformanceLevel::MEDIUM;
+        int maxSearchRange = 3;
+        VkFormat imageFormat = VK_FORMAT_R8G8B8_UNORM;
+        VkFormat flowFormat = VK_FORMAT_R16G16_SFLOAT;
+        VkFormat costFormat = VK_FORMAT_R16_UINT;
+
+        struct InputImage {
+            uint32_t binding;
+            uint32_t set;
+            VkImageLayout layout;
+        };
+        InputImage srcSearch;
+        InputImage srcTemplate;
+        InputImage srcFlow;
+        InputImage dstFlow;
+        InputImage dstCost;
+    };
+
+    void init(const Config &config);
+
+    void setInputSearch(std::shared_ptr<Image> input);
+    void setInputTemplate(std::shared_ptr<Image> input);
+    void setInputMV(std::shared_ptr<Image> input);
+    void setOutputFlow(std::shared_ptr<Image> output);
+    void setOutputCost(std::shared_ptr<Image> output);
+
+    VkMemoryRequirements getTransientMemoryRequirements() const;
+    VkMemoryRequirements getCacheMemoryRequirements() const;
+    void bindSessionTransientMemory(VkDeviceMemory memory, VkDeviceSize offset);
+    void bindSessionCacheMemory(VkDeviceMemory memory, VkDeviceSize offset);
+    void updateDescriptorSets(const OpticalFlowDescriptorMap &descriptorMap);
+    void cmdBindAndDispatch(VkCommandBuffer cmdBuf, VkDataGraphOpticalFlowExecuteFlagsARM flags,
+                            uint32_t meanFlowL1NormHint);
+
+    std::shared_ptr<Image> makeImage(Image::Usage usage, VkExtent3D dim, VkFormat format, VkImageTiling tiling,
+                                     const std::string &debugName = "", bool isCached = false);
+    template <typename T, typename... Args>
+    std::shared_ptr<T> makePipeline(std::vector<std::shared_ptr<ComputePipeline>> &pipelines, Args &&...args);
+
+  private:
+    struct MotionEstimationBlock {
+        std::shared_ptr<Image> warpedImage;
+        std::shared_ptr<Image> blockMatchOut;
+        std::shared_ptr<Image> upscaledFlow;
+        std::shared_ptr<Image> subpixelOut;
+        std::shared_ptr<Image> medianFilterOut;
+        std::shared_ptr<Image> bilateralFilterOut;
+        // alias to the output
+        std::shared_ptr<Image> filteredFlowOut;
+
+        std::shared_ptr<MVProcessAndWarp> mvWarpPipeline;
+        std::shared_ptr<BlockMatch> blockMatchPipeline;
+        std::shared_ptr<SubpixelME> subpixelMEPipeline;
+        std::shared_ptr<MedianFilter> medianFilterPipeline;
+        std::shared_ptr<BilateralFilter> bilateralFilterPipeline;
+    };
+
+    struct DownsampleBlock {
+        std::shared_ptr<Image> image;
+        std::shared_ptr<Downsample> pipeline;
+    };
+
+    void makeDownsamplePyramid(std::vector<DownsampleBlock> &blocks, std::shared_ptr<Image> &srcImage,
+                               std::shared_ptr<RGBToY> &rgbToY,
+                               std::vector<std::shared_ptr<ComputePipeline>> &pipelines);
+    void makeMotionEstimationBlocks();
+    void makeReplaceWithMvInput();
+
+    void swapImagePyramids();
+    float calcOutputFlowScale() const;
+    int toSearchRangeLimit(uint32_t meanFlowL1NormHint) const;
+    bool validateConfiguration() const;
+
+    void setupPyramidLevelDimensions(uint32_t initialWidth, uint32_t initialHeight);
+
+    void computeMemoryRequirements();
+
+    std::shared_ptr<VULKAN_HPP_NAMESPACE::detail::DispatchLoaderDynamic> loader_;
+    VkPhysicalDevice physicalDevice_;
+    VkDevice device_;
+    std::shared_ptr<PipelineCache> pipelineCache_;
+
+    Config config_ = {};
+
+    std::vector<MotionEstimationBlock> MEBlocks_;
+
+    std::vector<DownsampleBlock> dsBlocksSearch_;
+    std::vector<DownsampleBlock> dsBlocksTemplate_;
+
+    std::shared_ptr<Image> inputSearchRGB_;
+    std::shared_ptr<Image> inputTemplateRGB_;
+    std::shared_ptr<Image> inputMV_;
+    std::shared_ptr<Image> outputFlow_;
+    std::shared_ptr<Image> outputCost_;
+    std::shared_ptr<RGBToY> rgbToYSearch_;
+    std::shared_ptr<RGBToY> rgbToYTemplate_;
+
+    std::shared_ptr<Image> warpedByMvInputImage_;
+    std::shared_ptr<Image> costAtMvInput_;
+    std::shared_ptr<Image> minCostBlockMatch_;
+    std::shared_ptr<Image> mvReplaceFlowOut_;
+    std::shared_ptr<Image> mvReplaceCostOut_;
+
+    std::shared_ptr<DenseWarp> warpByMvInput_;
+    std::shared_ptr<BlockMatch> rawSad_;
+    std::shared_ptr<MVReplace> mvReplace_;
+
+    size_t pyramidLevels_ = 6;
+    std::vector<VkExtent3D> pyramidDimensions_;
+    float outputFlowScale_ = 0.0f;
+
+    VkMemoryRequirements cacheMemoryRequirements_;
+    VkMemoryRequirements transientMemoryRequirements_;
+
+    std::vector<std::shared_ptr<ComputePipeline>> downsampleSearchPipelines_;
+    std::vector<std::shared_ptr<ComputePipeline>> downsampleTemplatePipelines_;
+    std::vector<std::shared_ptr<ComputePipeline>> motionEstimationPipelines_;
+    std::vector<std::shared_ptr<Image>> allImages_;
+};
+
+template <typename T, typename... Args>
+inline std::shared_ptr<T> OpticalFlow::makePipeline(std::vector<std::shared_ptr<ComputePipeline>> &pipelines,
+                                                    Args &&...args) {
+    auto pipeline = std::make_shared<T>(loader_, device_, pipelineCache_, std::forward<Args>(args)...);
+    pipelines.push_back(pipeline);
+    return pipeline;
+}
+
+} // namespace mlsdk::el::compute::optical_flow

--- a/graph/shaders/CMakeLists.txt
+++ b/graph/shaders/CMakeLists.txt
@@ -11,25 +11,33 @@ file(GLOB_RECURSE SOURCES_GRAPH_OP CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR
 list(FILTER SOURCES_GRAPH_OP EXCLUDE REGEX "/common\\.comp$")
 list(SORT SOURCES_GRAPH_OP)
 
-# Merge common header with GLSL sources
 set(GLSL_SOURCES "")
 add_custom_target(mlel_generate_shader_comp)
-macro(mlel_add_glsl_source SOURCE)
-    get_filename_component(NAME "${SOURCE}" NAME)
-    set(OUT_FILE "${CMAKE_CURRENT_BINARY_DIR}/${NAME}")
+macro(mlel_add_glsl_source SOURCE USE_COMMON)
+    if("${USE_COMMON}")
+        get_filename_component(NAME "${SOURCE}" NAME)
+        set(OUT_FILE "${CMAKE_CURRENT_BINARY_DIR}/${NAME}")
 
-    add_custom_command(
-        OUTPUT "${OUT_FILE}"
-        COMMAND ${CMAKE_COMMAND} -E cat "${CMAKE_CURRENT_SOURCE_DIR}/graph_op/common.comp" "${SOURCE}" > "${OUT_FILE}"
-        DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/graph_op/common.comp" "${SOURCE}")
-    add_custom_target("mlel_generate_shader_${NAME}" DEPENDS "${OUT_FILE}")
-    add_dependencies(mlel_generate_shader_comp "mlel_generate_shader_${NAME}")
-
-    list(APPEND GLSL_SOURCES "${OUT_FILE}")
+        add_custom_command(
+            OUTPUT "${OUT_FILE}"
+            COMMAND ${CMAKE_COMMAND} -E cat "${CMAKE_CURRENT_SOURCE_DIR}/graph_op/common.comp" "${SOURCE}" > "${OUT_FILE}"
+            DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/graph_op/common.comp" "${SOURCE}")
+        add_custom_target("mlel_generate_shader_${NAME}" DEPENDS "${OUT_FILE}")
+        add_dependencies(mlel_generate_shader_comp "mlel_generate_shader_${NAME}")
+        list(APPEND GLSL_SOURCES "${OUT_FILE}")
+    else()
+        list(APPEND GLSL_SOURCES "${SOURCE}")
+    endif()
 endmacro()
 
 foreach(SOURCE ${SOURCES_GRAPH_OP})
-    mlel_add_glsl_source("${SOURCE}")
+    mlel_add_glsl_source("${SOURCE}" TRUE)
+endforeach()
+
+file(GLOB SOURCES_OPTICAL_FLOW CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/optical_flow/*.comp")
+list(SORT SOURCES_OPTICAL_FLOW)
+foreach(SOURCE ${SOURCES_OPTICAL_FLOW})
+    mlel_add_glsl_source("${SOURCE}" FALSE)
 endforeach()
 
 # Combine all outputs into a single target
@@ -383,6 +391,22 @@ endmacro()
 mlel_spv_block_match(block_match "0")
 mlel_spv_block_match(block_match "1")
 mlel_spv_block_match(block_match "2")
+
+# Optical Flow
+macro(mlel_spv_optical_flow)
+    foreach(SOURCE ${SOURCES_OPTICAL_FLOW})
+        get_filename_component(NAME "${SOURCE}" NAME_WE)
+        set(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${NAME}.spv")
+
+        mlel_generate_glsl(
+            INPUT "${SOURCE}"
+            OUTPUT ${OUTPUT})
+
+        list(APPEND SPV_FILES ${OUTPUT})
+    endforeach()
+endmacro()
+
+mlel_spv_optical_flow()
 
 # Generate header file with SPIR-V modules
 mlel_generate_spv_inc()

--- a/graph/shaders/optical_flow/bilateral_filter.comp
+++ b/graph/shaders/optical_flow/bilateral_filter.comp
@@ -1,0 +1,85 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2023-2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#version 450
+precision highp float;
+precision mediump sampler2D;
+precision mediump image2D;
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+#extension GL_EXT_shader_explicit_arithmetic_types_int8 : require
+#extension GL_EXT_shader_16bit_storage : require
+#extension GL_EXT_shader_8bit_storage : require
+
+#define MACRO_BLOCK (5)
+#define BLOCK_R (MACRO_BLOCK / 2)
+
+// Local Work Size set as Specialization Constants
+layout (local_size_x_id = 0, local_size_y_id = 1, local_size_z = 1) in;
+
+layout(constant_id = 2) const int VECTORIZE_X = 1;  // unused
+layout(constant_id = 3) const int VECTORIZE_Y = 1;  // unused
+layout(constant_id = 4) const bool IMAGE_STORE = false;
+layout(constant_id = 5) const float OUTPUT_FLOW_SCALE = 1.f;
+layout(constant_id = 6) const int OUTPUT_SIZE_X = 480;
+layout(constant_id = 7) const int OUTPUT_SIZE_Y = 270;
+layout(constant_id = 8) const uint STRIDE_DST = 480;   // The number of elements in a row (x-axis) including padding
+
+layout (binding = 0) uniform mediump sampler2D imageSampler;
+layout (binding = 1) uniform mediump sampler2D flowImageSampler;
+
+layout(set=0, binding=2, rg16f) uniform writeonly image2D dst_flow_img;
+layout (set = 0, binding = 3, std430) buffer _dst_flow_buf{
+    f16vec2 dst_flow_buf[];
+};
+
+// The parameters below need to be adjusted in accordance with the reference
+// sigma_spatial=7.4, sigma_intensity=0.14
+const float16_t SIGMA_INTENSITY_DIV_SQRT = 5.05129933779HF;  // sqrt(SIGMA_INTENSITY_DIV)
+const float16_t CONSTANT_SPATIAL_KERNEL = -0.00913HF;
+
+float16_t triangular_func(float16_t x)
+{
+    return clamp(1.HF - abs(x), 0.HF, 1.HF);
+}
+
+f16vec2 calc(ivec2 pos)
+{
+    float16_t compare_pix = float16_t(texture(imageSampler, pos).x);
+
+    // 5x5 coeff generation and convolution
+    float16_t coeff_sum = 0.HF;
+    f16vec2 filter_sum = f16vec2(0.HF);
+    for (int ky = -2; ky <= 2; ++ky) {
+        for (int kx = -2; kx <=2; ++kx) {
+
+            const ivec2 k_pos = pos + ivec2(kx, ky);
+            float16_t compare_kernel = float16_t(texture(imageSampler, k_pos).x);
+            float16_t diff = compare_pix - compare_kernel;
+            diff *= SIGMA_INTENSITY_DIV_SQRT;
+            float16_t intensity_diff = diff * diff;
+
+            float16_t coeff = triangular_func(CONSTANT_SPATIAL_KERNEL - intensity_diff);
+            coeff_sum += coeff;
+            filter_sum += coeff * f16vec2(texture(flowImageSampler, k_pos).xy);
+        }
+    }
+
+    f16vec2 filtered = filter_sum / coeff_sum;
+    filtered *= f16vec2(OUTPUT_FLOW_SCALE);
+    return filtered;
+}
+
+void main()
+{
+    const ivec2 pos = ivec2(gl_GlobalInvocationID.xy);
+    if (any(greaterThanEqual(pos, ivec2(OUTPUT_SIZE_X, OUTPUT_SIZE_Y)))) return;
+
+    f16vec2 flow = calc(pos);
+
+    if (IMAGE_STORE)
+        imageStore(dst_flow_img, pos, f16vec4(flow, 0, 0));
+    else
+        dst_flow_buf[STRIDE_DST * pos.y + pos.x] = flow;
+}

--- a/graph/shaders/optical_flow/block_match_of.comp
+++ b/graph/shaders/optical_flow/block_match_of.comp
@@ -1,0 +1,153 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2023-2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#version 450
+precision mediump float;
+precision mediump sampler2D;
+precision mediump image2D;
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+#extension GL_EXT_shader_explicit_arithmetic_types_int8 : require
+#extension GL_EXT_shader_explicit_arithmetic_types_int16 : require
+#extension GL_EXT_shader_16bit_storage : require
+#extension GL_EXT_shader_8bit_storage : require
+#extension GL_GOOGLE_include_directive : enable
+
+#define MAX_SEARCH_RANGE (3)
+#define MACRO_BLOCK (5)  // This shader assumes the value is 5 for optimization purpose
+#define MAX_SEARCH_W (MAX_SEARCH_RANGE * 2 + 1)
+#define BLOCK_R (MACRO_BLOCK / 2)
+#define BLOCK_R (MACRO_BLOCK / 2)
+
+// Threshold to judge if float values are equal as we need to take floating point errors into account.
+#define THR_FOR_EQUAL (float16_t(0.5f / 255.f))
+
+/* Search pattern which defines the priority in case the cost values are the same between candidates
+            'spiral':
+                Spiral pattern as traversed in Motion Engine
+               [44, 43, 42, 41, 40, 39, 38,
+                45, 22, 21, 20, 19, 18, 37,
+                46, 23,  8,  7,  6, 17, 36,
+                47, 24,  9,  1,  5, 16, 35,
+                48, 25,  2,  3,  4, 15, 34,
+                49, 10, 11, 12, 13, 14, 33,
+                26, 27, 28, 29, 30, 31, 32]
+
+                indecies in case of SEARCH_RANGE=1 (3x3) :
+                    [0, 1, 2,
+                     3, 4, 5,
+                     6, 7, 8]
+                indecies in case of SEARCH_RANGE=2 (5x5) :
+                    [ 0,  1,  2,  3,  4,
+                      5,  6,  7,  8,  9,
+                     10, 11, 12, 13, 14,
+                     15, 16, 17, 18, 19,
+                     20, 21, 22, 23, 24]
+                indecies in case of SEARCH_RANGE=3 (7x7) :
+                    [ 0,  1,  2,  3,  4,  5,  6,
+                      7,  8,  9, 10, 11, 12, 13,
+                     14, 15, 16, 17, 18, 19, 20,
+                     21, 22, 23, 24, 25, 26, 27,
+                     28, 29, 30, 31, 32, 33, 34,
+                     35, 36, 37, 38, 39, 40, 41,
+                     42, 43, 44, 45, 46, 47, 48]
+
+*/
+int16_t SEARCH_ORDER[MAX_SEARCH_W * MAX_SEARCH_W] = {
+    24S, // Center : top priority
+    30S, 31S, 32S, 25S, 18S, 17S, 16S, 23S,
+    36S, 37S, 38S, 39S, 40S, 33S, 26S, 19S, 12S, 11S, 10S, 9S, 8S, 15S, 22S, 29S,
+    42S, 43S, 44S, 45S, 46S, 47S, 48S, 41S, 34S, 27S, 20S, 13S, 6S, 5S, 4S, 3S, 2S, 1S, 0S, 7S, 14S, 21S, 28S, 35S
+};
+
+#define get_spiral_search_position(_index) \
+    i16vec2((SEARCH_ORDER[_index] % MAX_SEARCH_W) - MAX_SEARCH_RANGE, \
+            (SEARCH_ORDER[_index] / MAX_SEARCH_W) - MAX_SEARCH_RANGE)
+
+// SEARCH_MODE
+#define MIN_SAD (0)
+#define MIN_SAD_COST (1)
+#define RAW_SAD (2)
+
+
+// Local Work Size set as Specialization Constants
+layout (local_size_x_id = 0, local_size_y_id = 1, local_size_z = 1) in;
+
+// Vectorization is not available, just for compatibility
+layout(constant_id = 2) const int VECTORIZE_X = 1;
+layout(constant_id = 3) const int VECTORIZE_Y = 1;
+
+layout(constant_id = 4) const int SEARCH_MODE = MIN_SAD;
+layout(constant_id = 5) const int SEARCH_RANGE = 1;
+layout(constant_id = 6) const int OUTPUT_SIZE_X = 480;
+layout(constant_id = 7) const int OUTPUT_SIZE_Y = 270;
+layout(constant_id = 8) const uint STRIDE_DST_FLOW = 480;   // The number of elements in a row (x-axis) including padding
+layout(constant_id = 9) const uint STRIDE_DST_COST = 480;   // The number of elements in a row (x-axis) including padding
+layout(constant_id = 10) const bool COST_IMAGE_STORE = false;
+
+layout (binding = 0) uniform mediump sampler2D imageTemplateSampler;
+layout (binding = 1) uniform mediump sampler2D imageSearchSampler;
+
+layout (set = 0, binding = 2, std430) buffer _dst_flow_buf{
+    i8vec2 dst_flow_buf[];
+};
+
+layout(set=0, binding=3, r16ui) uniform writeonly uimage2D dst_cost_img;
+layout (set = 0, binding = 4, std430) buffer _dst_cost_buf{
+    uint16_t dst_cost_buf[];
+};
+
+layout (push_constant) uniform PushConstants {
+    int search_index_limit;  // (2 * SR + 1)^2, where SR is the limit of search range
+};
+
+void calc(i16vec2 pos, out i8vec2 flow_out, out uint16_t cost_at_min)
+{
+    float16_t min_dist = 65504.HF;  // half float max
+
+    for (int si = 0; si < search_index_limit; ++si) {
+        i16vec2 search_pos = get_spiral_search_position(si);
+
+        // Compute SAD (sum of absolute difference)
+        float16_t dist = 0.HF;
+        for (int by = -BLOCK_R; by <= BLOCK_R; ++by) {
+            for (int bx = -BLOCK_R; bx <= BLOCK_R; ++bx) {
+                ivec2 b_pos = ivec2(pos) + ivec2(bx, by);
+                float16_t template_val = float16_t(texture(imageTemplateSampler, b_pos).x);
+                float16_t window_val   = float16_t(texture(imageSearchSampler, b_pos + ivec2(search_pos)).x);
+                dist += abs(window_val - template_val);
+            }
+        }
+
+        if (min_dist - dist > THR_FOR_EQUAL) {
+            // Update min and flow
+            min_dist = dist;
+            flow_out = i8vec2(search_pos);
+        }
+    }
+
+    cost_at_min = uint16_t(round(min_dist * 255.HF));
+}
+
+void main()
+{
+    const i16vec2 pos = i16vec2(gl_GlobalInvocationID.x,
+                                gl_GlobalInvocationID.y);
+    if (any(greaterThanEqual(pos, ivec2(OUTPUT_SIZE_X, OUTPUT_SIZE_Y)))) return;
+
+    i8vec2 flow;
+    uint16_t cost_at_min;
+    calc(pos, flow, cost_at_min);
+
+    if (SEARCH_MODE == MIN_SAD || SEARCH_MODE == MIN_SAD_COST) {
+        dst_flow_buf[STRIDE_DST_FLOW * pos.y + pos.x] = flow;
+    }
+    if (SEARCH_MODE == RAW_SAD || SEARCH_MODE == MIN_SAD_COST) {
+        // RAW_SAD is supportd only in case of SEARCH_RANGE=0 in this shader
+        if (COST_IMAGE_STORE)
+            imageStore(dst_cost_img, ivec2(pos), uvec4(cost_at_min, 0, 0, 0));
+        else
+            dst_cost_buf[STRIDE_DST_COST * pos.y + pos.x] = cost_at_min;
+    }
+}

--- a/graph/shaders/optical_flow/dense_warp.comp
+++ b/graph/shaders/optical_flow/dense_warp.comp
@@ -1,0 +1,88 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2023-2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#version 450
+precision highp float;
+precision mediump sampler2D;
+precision mediump image2D;
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+#extension GL_EXT_shader_explicit_arithmetic_types_int8 : require
+#extension GL_EXT_shader_8bit_storage : require
+
+// Local Work Size set as Specialization Constants
+layout (local_size_x_id = 0, local_size_y_id = 1, local_size_z = 1) in;
+
+// Supported : VECTORIZE_X: 1 or 2, VECTORIZE_Y: 1
+layout(constant_id = 2) const int VECTORIZE_X = 1;
+layout(constant_id = 3) const int VECTORIZE_Y = 1;
+
+layout(constant_id = 4) const bool IMAGE_STORE = false;
+layout(constant_id = 5) const float INPUT_FLOW_SCALE = 1.f;
+layout(constant_id = 6) const int OUTPUT_SIZE_X = 960;
+layout(constant_id = 7) const int OUTPUT_SIZE_Y = 540;
+layout(constant_id = 8) const uint STRIDE_DST = 960;   // The number of elements in a row (x-axis) including padding
+
+layout (binding = 0) uniform mediump sampler2D imageSampler;
+layout (binding = 1) uniform highp sampler2D flowImageSampler;
+
+layout (set=0, binding = 2, r8) uniform writeonly image2D dst_img;
+layout (set = 0, binding = 3, std430) buffer _dst_buf_u8{
+    uint8_t dst_buf_u8[];
+};
+// Attribute alias for vectorized(x2) store
+layout (set = 0, binding = 3, std430) buffer _dst_buf_u8x2{
+    u8vec2 dst_buf_u8x2[];
+};
+
+// We expect flow is positive forward flow from dst to src,
+// while anet and tfa "expects the negative forward flow from output image to source image"
+float16_t calc_dense_warp(vec2 flow, ivec2 pos)
+{
+    vec2 src_pos = vec2(pos) + 0.5f + flow;
+    return float16_t(texture(imageSampler, src_pos).x);
+}
+
+uint8_t convert_uint8(float16_t x)
+{
+    return uint8_t(round(x * 255.HF));
+}
+
+void main()
+{
+     const ivec2 pos = ivec2(gl_GlobalInvocationID.x * VECTORIZE_X,
+                             gl_GlobalInvocationID.y);
+    if (any(greaterThanEqual(pos, ivec2(OUTPUT_SIZE_X, OUTPUT_SIZE_Y)))) return;
+
+    vec2 flow[VECTORIZE_X];
+    for (int vx = 0; vx < VECTORIZE_X; ++vx) {
+        flow[vx] = texelFetch(flowImageSampler, ivec2(pos.x + vx, pos.y), 0).xy;
+        flow[vx] *= INPUT_FLOW_SCALE;
+    }
+
+    float16_t warped[VECTORIZE_X];
+    for (int vx = 0; vx < VECTORIZE_X; ++vx) {
+        warped[vx] = calc_dense_warp(flow[vx], ivec2(pos.x + vx, pos.y));
+    }
+
+    if (IMAGE_STORE) {
+        for (int vx = 0; vx < VECTORIZE_X; ++vx) {
+            ivec2 vpos = ivec2(pos.x + vx, pos.y);
+            imageStore(dst_img, vpos, vec4(warped[vx], 0, 0, 0));
+        }
+    } else {
+        if (VECTORIZE_X == 2) {
+            u8vec2 dst_val;
+            for (int vx = 0; vx < VECTORIZE_X; ++vx) {
+                dst_val[vx] = convert_uint8(warped[vx]);
+            }
+            uint index_for_vec2 = (STRIDE_DST * pos.y + pos.x) / VECTORIZE_X;
+            dst_buf_u8x2[index_for_vec2] = dst_val;
+        } else {
+            uint8_t dst_val = convert_uint8(warped[0]);
+            uint index = STRIDE_DST * pos.y + pos.x;
+            dst_buf_u8[index] = dst_val;
+        }
+    }
+}

--- a/graph/shaders/optical_flow/downsample.comp
+++ b/graph/shaders/optical_flow/downsample.comp
@@ -1,0 +1,98 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2023-2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#version 450
+precision highp float;
+precision mediump sampler2D;
+precision highp image2D;
+#extension GL_EXT_shader_explicit_arithmetic_types_int8 : require
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+#extension GL_EXT_shader_8bit_storage : require
+
+// Local Work Size set as Specialization Constants
+layout (local_size_x_id = 0, local_size_y_id = 1, local_size_z = 1) in;
+
+// Supported : VECTORIZE_X: 1 or 2, VECTORIZE_Y: 1
+layout(constant_id = 2) const int VECTORIZE_X = 1;
+layout(constant_id = 3) const int VECTORIZE_Y = 1;
+
+layout(constant_id = 4) const bool IMAGE_STORE = false;
+layout(constant_id = 5) const bool PAD_X = true;
+layout(constant_id = 6) const bool PAD_Y = true;
+layout(constant_id = 7) const int OUTPUT_SIZE_X = 960;
+layout(constant_id = 8) const int OUTPUT_SIZE_Y = 540;
+layout(constant_id = 9) const uint STRIDE_DST = 960;   // The number of elements in a row (x-axis) including padding
+
+layout (binding = 0) uniform sampler2D imageSampler;
+
+layout (set = 0, binding = 1, r8) uniform writeonly image2D dst_img;
+layout (set = 0, binding = 2, std430) buffer _dst_buf_u8{
+    uint8_t dst_buf_u8[];
+};
+// Attribute alias for vectorized(x2) store
+layout (set = 0, binding = 2, std430) buffer _dst_buf_u8x2{
+    u8vec2 dst_buf_u8x2[];
+};
+
+
+float16_t calc_blur_and_bilinear_fused_4samples(vec2 src_pos) {
+    // By taking advantage of linear interporaltion by GPU sampler,
+    // 4x4 filter is computed by 4 bilinear samplings from 2x2 pixels each
+    // The sampling location (+-0.75) is calculated from coefficient values, which is H(1,3,3,1) * V(1,3,3,1)
+    float sum = 0.f;
+    sum += float(texture(imageSampler, src_pos + vec2(-0.75f, -0.75f)).x);
+    sum += float(texture(imageSampler, src_pos + vec2(+0.75f, -0.75f)).x);
+    sum += float(texture(imageSampler, src_pos + vec2(-0.75f, +0.75f)).x);
+    sum += float(texture(imageSampler, src_pos + vec2(+0.75f, +0.75f)).x);
+    return float16_t(sum * 0.25f);
+}
+
+uint8_t convert_uint8(float16_t x)
+{
+    return uint8_t(round(min(x * 255.HF, 255.HF)));
+}
+
+void main()
+{
+    const ivec2 pos = ivec2(gl_GlobalInvocationID.x * VECTORIZE_X,
+                            gl_GlobalInvocationID.y);
+    if (any(greaterThanEqual(pos, ivec2(OUTPUT_SIZE_X, OUTPUT_SIZE_Y)))) return;
+
+    float16_t downsampled[VECTORIZE_X];
+    vec2 scale = vec2(2.f);
+    ivec2 edge_wo_pad = ivec2(PAD_X ? OUTPUT_SIZE_X - 2 : OUTPUT_SIZE_X - 1,
+                              PAD_Y ? OUTPUT_SIZE_Y - 2 : OUTPUT_SIZE_Y - 1);
+
+    for (int vx = 0; vx < VECTORIZE_X; ++vx) {
+        // In computing pixels on the edge, we could rely on CLAM_TO_EDGE addressing,
+        // however we follow the reference implementation strictly to mitigate difference.
+        // In case the src resolution is not exactly multiple of the dst resolution,
+        // i.e. PAD_X, PAD_Y is true,
+        // The below casing results in replicating values of right and bottom edges
+        vec2 dst_pos = vec2(min(ivec2(pos.x + vx, pos.y), edge_wo_pad));
+
+        vec2 uv = (dst_pos + 0.5f) * scale;
+        downsampled[vx] = calc_blur_and_bilinear_fused_4samples(uv);
+    }
+
+    if (IMAGE_STORE) {
+        for (int vx = 0; vx < VECTORIZE_X; ++vx) {
+            imageStore(dst_img, ivec2(pos.x + vx, pos.y), vec4(min(downsampled[vx], 1.HF), 0, 0, 0));
+        }
+    } else {
+        if (VECTORIZE_X == 2) {
+            u8vec2 dst_val;
+            for (int vx = 0; vx < VECTORIZE_X; ++vx) {
+                dst_val[vx] = convert_uint8(downsampled[vx]);
+            }
+            uint index_for_vec2 = (STRIDE_DST * pos.y + pos.x) / VECTORIZE_X;
+            dst_buf_u8x2[index_for_vec2] = dst_val;
+        } else {
+            uint8_t dst_val = convert_uint8(downsampled[0]);
+            uint index = STRIDE_DST * pos.y + pos.x;
+            dst_buf_u8[index] = dst_val;
+        }
+    }
+}

--- a/graph/shaders/optical_flow/median_filter.comp
+++ b/graph/shaders/optical_flow/median_filter.comp
@@ -1,0 +1,146 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2023-2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#version 450
+precision highp float;
+precision mediump sampler2D;
+precision mediump image2D;
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+#extension GL_EXT_shader_16bit_storage : require
+
+// Local Work Size set as Specialization Constants
+layout (local_size_x_id = 0, local_size_y_id = 1, local_size_z = 1) in;
+
+// Supported : VECTORIZE_X: 1 or 2, VECTORIZE_Y: 1 or 2
+layout(constant_id = 2) const int VECTORIZE_X = 1;
+layout(constant_id = 3) const int VECTORIZE_Y = 1;
+
+layout(constant_id = 4) const bool IMAGE_STORE = false;
+layout(constant_id = 5) const float OUTPUT_FLOW_SCALE = 1.f;
+layout(constant_id = 6) const int OUTPUT_SIZE_X = 480;
+layout(constant_id = 7) const int OUTPUT_SIZE_Y = 270;
+layout(constant_id = 8) const uint STRIDE_DST = 480;   // The number of elements in a row (x-axis) including padding
+
+layout (binding = 0) uniform mediump sampler2D imageSampler;
+
+layout (set=0, binding = 1, rg16f) uniform writeonly image2D dst_img;
+layout (set = 0, binding = 2, std430) buffer _dst_buf{
+    f16vec2 dst_buf[];
+};
+
+
+/** Sorts element-wise two vectors.
+ */
+#define sort(a, b) \
+    { \
+        f16vec2 min_val = min(a, b); \
+        f16vec2 max_val = max(a, b); \
+        a = min_val; \
+        b = max_val; \
+    }
+
+/*
+    Sorting network to sort 9 vectors of 2 elements and return their median.
+ */
+f16vec2 sort9(f16vec2 p0, f16vec2 p1, f16vec2 p2, f16vec2 p3, f16vec2 p4, f16vec2 p5, f16vec2 p6, f16vec2 p7, f16vec2 p8)
+{
+    sort(p1, p2);
+    sort(p4, p5);
+    sort(p7, p8);
+    sort(p0, p1);
+    sort(p3, p4);
+    sort(p6, p7);
+    sort(p1, p2);
+    sort(p4, p5);
+    sort(p7, p8);
+    sort(p0, p3);
+    sort(p5, p8);
+    sort(p4, p7);
+    sort(p3, p6);
+    sort(p1, p4);
+    sort(p2, p5);
+    sort(p4, p7);
+    sort(p4, p2);
+    sort(p6, p4);
+    sort(p4, p2);
+
+    return p4;
+}
+
+#define READ_QUAD(_SAMP, _POS, _COMP) \
+    textureGather(_SAMP, _POS + vec2(1.f), _COMP).wzxy
+
+void calc(ivec2 _pos, out f16vec2 filtered[VECTORIZE_Y][VECTORIZE_X])
+{
+    vec2 pos = vec2(_pos);
+    // Load 3x3 neighbours. e.g. load 4x4 in case VECTORIZE = (2, 2)
+    /*
+        + + + -
+        + P + -     "P" : pos
+        + + + -     "+" : 3x3 neighbours for (vx, vy) = (0, 0)
+        - - - -
+    */
+    f16vec2 p[4][4];
+
+    #define read_2x2_v2(_px, _py) \
+    { \
+        vec2 bpos = pos + vec2(_px - 1, _py - 1); \
+        f16vec4 p_u = f16vec4(READ_QUAD(imageSampler, bpos, 0)); \
+        f16vec4 p_v = f16vec4(READ_QUAD(imageSampler, bpos, 1)); \
+        for (int vy = 0; vy < 2; ++vy) { \
+            for (int vx = 0; vx < 2; ++vx) { \
+                p[_py + vy][_px + vx] = f16vec2(p_u[vy * 2 + vx], p_v[vy * 2 + vx]); \
+            } \
+        } \
+    }
+
+    /*
+        + + - -
+        + + - -
+        - - - -     "+" : quad loaded by read_2x2_v2(0, 0)
+        - - - -
+    */
+    read_2x2_v2(0, 0);
+    read_2x2_v2(2, 0);
+    read_2x2_v2(0, 2);
+    read_2x2_v2(2, 2);
+
+    // Compute median
+    for (int vy = 0; vy < VECTORIZE_Y; ++vy) {
+        for (int vx = 0; vx < VECTORIZE_X; ++vx) {
+            filtered[vy][vx] = sort9(p[0 + vy][0 + vx], p[0 + vy][1 + vx], p[0 + vy][2 + vx],
+                                     p[1 + vy][0 + vx], p[1 + vy][1 + vx], p[1 + vy][2 + vx],
+                                     p[2 + vy][0 + vx], p[2 + vy][1 + vx], p[2 + vy][2 + vx]);
+            filtered[vy][vx] *= f16vec2(OUTPUT_FLOW_SCALE);
+        }
+    }
+    return;
+}
+
+
+void main()
+{
+    const ivec2 pos = ivec2(gl_GlobalInvocationID.x * VECTORIZE_X,
+                            gl_GlobalInvocationID.y * VECTORIZE_Y);
+    if (any(greaterThanEqual(pos, ivec2(OUTPUT_SIZE_X, OUTPUT_SIZE_Y)))) return;
+
+    f16vec2 dst_val[VECTORIZE_Y][VECTORIZE_X];
+    calc(pos, dst_val);
+
+    for (int vy = 0; vy < VECTORIZE_Y; ++vy) {
+
+        // This shader accepts the VECTORIZE_Y which is not a divisor of OUTPUT_SIZE_Y,
+        // so the boundary check below is necessary.
+        if (OUTPUT_SIZE_Y % 2 == 1 && pos.y + vy >= OUTPUT_SIZE_Y)
+            break;
+
+        for (int vx = 0; vx < VECTORIZE_X; ++vx) {
+            if (IMAGE_STORE)
+                imageStore(dst_img, pos + ivec2(vx, vy), f16vec4(dst_val[vy][vx], 0, 0));
+            else
+                dst_buf[STRIDE_DST * (pos.y + vy) + pos.x + vx] = dst_val[vy][vx];
+        }
+    }
+}

--- a/graph/shaders/optical_flow/mv_process_and_warp.comp
+++ b/graph/shaders/optical_flow/mv_process_and_warp.comp
@@ -1,0 +1,113 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2023-2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#version 450
+precision highp float;
+precision mediump sampler2D;
+precision mediump image2D;
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+#extension GL_EXT_shader_explicit_arithmetic_types_int8 : require
+#extension GL_EXT_shader_16bit_storage : require
+#extension GL_EXT_shader_8bit_storage : require
+
+// Local Work Size set as Specialization Constants
+layout (local_size_x_id = 0, local_size_y_id = 1, local_size_z = 1) in;
+
+// Supported : VECTORIZE_X: 1 or 2, VECTORIZE_Y: 1
+layout(constant_id = 2) const int VECTORIZE_X = 1;
+layout(constant_id = 3) const int VECTORIZE_Y = 1;
+
+layout(constant_id = 4) const bool IMAGE_STORE = false;
+layout(constant_id = 5) const float SCALE_X = 0.5f;  // The ratio of src/dst, used to scale the magnitude of flow
+layout(constant_id = 6) const float SCALE_Y = 0.5f;  // The ratio of src/dst, used to scale the magnitude of flow
+layout(constant_id = 7) const float INV_SCALE_X = 2.f;  // The ratio of dst/src, used for upsampling
+layout(constant_id = 8) const float INV_SCALE_Y = 2.f;  // The ratio of dst/src, used for upsampling
+layout(constant_id = 9) const int OUTPUT_SIZE_X = 480;
+layout(constant_id = 10) const int OUTPUT_SIZE_Y = 270;
+layout(constant_id = 11) const uint STRIDE_DST = 480;   // The number of elements in a row (x-axis) including padding
+layout(constant_id = 12) const uint STRIDE_DST_FLOW = 480;   // The number of elements in a row (x-axis) including padding
+
+layout (binding = 0) uniform mediump sampler2D imageSampler;
+layout (binding = 1) uniform highp sampler2D flowImageSampler;
+
+layout (set=0, binding = 2, r8) uniform writeonly image2D dst_img;
+layout (set = 0, binding = 3, std430) buffer _dst_buf_u8{
+    uint8_t dst_buf_u8[];
+};
+// Attribute alias for vectorized(x2) store
+layout (set = 0, binding = 3, std430) buffer _dst_buf_u8x2{
+    u8vec2 dst_buf_u8x2[];
+};
+
+layout (set=0, binding = 4, rg16f) uniform writeonly image2D dst_flow_img;
+layout (set = 0, binding = 5, std430) buffer _dst_flow_buf{
+    f16vec2 dst_flow_buf[];
+};
+
+
+vec2 calc_mv_process(vec2 src_pos)
+{
+    vec2 flow = texture(flowImageSampler, src_pos).xy;  // bilinear upsample
+    vec2 scale = vec2(SCALE_X, SCALE_Y);
+    flow *= scale;
+    return flow;
+}
+
+// We expect flow is positive forward flow from dst to src,
+// while anet and tfa "expects the negative forward flow from output image to source image"
+float16_t calc_dense_warp(vec2 flow, ivec2 pos)
+{
+    vec2 src_pos = vec2(pos) + 0.5f + flow;
+    return float16_t(texture(imageSampler, src_pos).x);
+}
+
+uint8_t convert_uint8(float16_t x)
+{
+    return uint8_t(round(x * 255.HF));
+}
+
+void main()
+{
+     const ivec2 pos = ivec2(gl_GlobalInvocationID.x * VECTORIZE_X,
+                             gl_GlobalInvocationID.y);
+    if (any(greaterThanEqual(pos, ivec2(OUTPUT_SIZE_X, OUTPUT_SIZE_Y)))) return;
+
+    vec2 flow[VECTORIZE_X];
+    vec2 inv_scale = vec2(INV_SCALE_X, INV_SCALE_Y);
+    for (int vx = 0; vx < VECTORIZE_X; ++vx) {
+        vec2 uv = (vec2(pos.x + vx, pos.y) + 0.5f) * inv_scale;
+        flow[vx] = calc_mv_process(uv);
+    }
+
+    float16_t warped[VECTORIZE_X];
+    for (int vx = 0; vx < VECTORIZE_X; ++vx) {
+        warped[vx] = calc_dense_warp(flow[vx], ivec2(pos.x + vx, pos.y));
+    }
+
+    if (IMAGE_STORE) {
+        for (int vx = 0; vx < VECTORIZE_X; ++vx) {
+            ivec2 vpos = ivec2(pos.x + vx, pos.y);
+            imageStore(dst_img, vpos, vec4(warped[vx], 0, 0, 0));
+            imageStore(dst_flow_img, vpos, f16vec4(flow[vx], 0, 0));
+        }
+    } else {
+        if (VECTORIZE_X == 2) {
+            u8vec2 dst_val;
+            for (int vx = 0; vx < VECTORIZE_X; ++vx) {
+                dst_val[vx] = convert_uint8(warped[vx]);
+            }
+            uint index_for_vec2 = (STRIDE_DST * pos.y + pos.x) / VECTORIZE_X;
+            dst_buf_u8x2[index_for_vec2] = dst_val;
+        } else {
+            uint8_t dst_val = convert_uint8(warped[0]);
+            uint index = STRIDE_DST * pos.y + pos.x;
+            dst_buf_u8[index] = dst_val;
+        }
+
+        for (int vx = 0; vx < VECTORIZE_X; ++vx) {  // Compiler vectorizes this data type
+            dst_flow_buf[STRIDE_DST_FLOW * pos.y + pos.x + vx] = f16vec2(flow[vx]);
+        }
+    }
+}

--- a/graph/shaders/optical_flow/mv_replace.comp
+++ b/graph/shaders/optical_flow/mv_replace.comp
@@ -1,0 +1,128 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2023-2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#version 450
+precision highp float;
+precision mediump sampler2D;
+precision mediump image2D;
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+#extension GL_EXT_shader_explicit_arithmetic_types_int16 : require
+#extension GL_EXT_shader_16bit_storage : require
+
+// Local Work Size set as Specialization Constants
+layout (local_size_x_id = 0, local_size_y_id = 1, local_size_z = 1) in;
+
+// Supported : VECTORIZE_X: 1 or 2, VECTORIZE_Y: 1 or 2
+layout(constant_id = 2) const int VECTORIZE_X = 1;
+layout(constant_id = 3) const int VECTORIZE_Y = 1;
+
+layout(constant_id = 4) const bool OUTPUT_COST = false;
+layout(constant_id = 5) const bool COST_BUFFER_LOAD = false;
+layout(constant_id = 6) const bool IMAGE_STORE = false;
+layout(constant_id = 7) const int OUTPUT_SIZE_X = 480;
+layout(constant_id = 8) const int OUTPUT_SIZE_Y = 270;
+layout(constant_id = 9) const uint STRIDE_SRC_COST = 480;   // The number of elements in a row (x-axis) including padding
+layout(constant_id = 10) const uint STRIDE_DST_FLOW = 480;   // The number of elements in a row (x-axis) including padding
+layout(constant_id = 11) const uint STRIDE_DST_COST = 480;   // The number of elements in a row (x-axis) including padding
+
+
+layout (binding = 0) uniform mediump sampler2D mvInputSampler;
+layout (binding = 1) uniform mediump sampler2D flowBlockMatchSampler;
+
+layout (binding = 2) uniform usampler2D costAtInputMvSampler;
+layout (set = 0, binding = 3, std430) buffer _cost_at_input_mv_buf{
+    uint16_t cost_at_input_mv_buf[];
+};
+
+layout (binding = 4) uniform usampler2D minCostBlockMatchSampler;
+layout (set = 0, binding = 5, std430) buffer _min_cost_block_match_buf{
+    uint16_t min_cost_block_match_buf[];
+};
+
+layout (set=0, binding=6, rg16f) uniform writeonly image2D dst_flow_img;
+layout (set = 0, binding = 7, std430) buffer _dst_flow_buf{
+    f16vec2 dst_flow_buf[];
+};
+
+layout (set=0, binding=8, r16ui) uniform writeonly uimage2D dst_cost_img;
+layout (set = 0, binding = 9, std430) buffer _dst_cost_buf{
+    uint16_t dst_cost_buf[];
+};
+
+
+void replace_flow(ivec2 pos, uint16_t cost_at_input_mv, uint16_t min_cost_block_match,
+                  out f16vec2 flow_out, out uint16_t cost_out)
+{
+    // Read MV and flow
+    f16vec2 mv_input         = f16vec2(texelFetch(mvInputSampler, pos, 0).xy);
+    f16vec2 flow_block_match = f16vec2(texelFetch(flowBlockMatchSampler, pos, 0).xy);
+
+    // Select by comparing cost
+    bool min_is_mv = cost_at_input_mv < min_cost_block_match;
+    flow_out = min_is_mv ? mv_input : flow_block_match;
+    cost_out = min_is_mv ? cost_at_input_mv : min_cost_block_match;
+}
+
+void main()
+{
+     const ivec2 pos = ivec2(gl_GlobalInvocationID.x * VECTORIZE_X,
+                             gl_GlobalInvocationID.y * VECTORIZE_Y);
+    if (any(greaterThanEqual(pos, ivec2(OUTPUT_SIZE_X, OUTPUT_SIZE_Y)))) return;
+
+    // Load all costs, expecting vectorization by compiler
+    uint16_t cost_at_input_mv[VECTORIZE_Y][VECTORIZE_X];
+    uint16_t min_cost_block_match[VECTORIZE_Y][VECTORIZE_X];
+
+    for (int vy = 0; vy < VECTORIZE_Y; ++vy) {
+        int vpos_y = pos.y + vy;
+        for (int vx = 0; vx < VECTORIZE_X; ++vx) {
+            if (COST_BUFFER_LOAD) {
+                const uint vpos_1d = STRIDE_SRC_COST * vpos_y + pos.x + vx;
+                cost_at_input_mv[vy][vx]     = cost_at_input_mv_buf[vpos_1d];
+                min_cost_block_match[vy][vx] = min_cost_block_match_buf[vpos_1d];
+            } else {
+                const ivec2 vpos = ivec2(pos.x + vx, vpos_y);
+                cost_at_input_mv[vy][vx]     = uint16_t(texelFetch(costAtInputMvSampler, vpos, 0).x);
+                min_cost_block_match[vy][vx] = uint16_t(texelFetch(minCostBlockMatchSampler, vpos, 0).x);
+            }
+        }
+    }
+
+    // Perform replacement
+    f16vec2 flow[VECTORIZE_Y][VECTORIZE_X];
+    uint16_t cost[VECTORIZE_Y][VECTORIZE_X];
+
+    for (int vy = 0; vy < VECTORIZE_Y; ++vy) {
+        for (int vx = 0; vx < VECTORIZE_X; ++vx) {
+            replace_flow(ivec2(pos.x + vx, pos.y + vy), cost_at_input_mv[vy][vx], min_cost_block_match[vy][vx],
+                         flow[vy][vx], cost[vy][vx]);
+        }
+    }
+
+    // Store output
+    for (int vy = 0; vy < VECTORIZE_Y; ++vy) {
+        int vpos_y = pos.y + vy;
+
+        // This shader accepts the VECTORIZE_Y which is not a divisor of OUTPUT_SIZE_Y,
+        // so the boundary check below is necessary.
+        if (OUTPUT_SIZE_Y % 2 == 1 && vpos_y >= OUTPUT_SIZE_Y)
+            break;
+
+        for (int vx = 0; vx < VECTORIZE_X; ++vx) {
+            if (IMAGE_STORE) {
+                imageStore(dst_flow_img, ivec2(pos.x + vx, vpos_y), f16vec4(flow[vy][vx], 0, 0));
+                if (OUTPUT_COST) {
+                    imageStore(dst_cost_img, ivec2(pos.x + vx, vpos_y), u16vec4(cost[vy][vx], 0, 0, 0));
+                }
+            } else {
+                // Compiler vectorizes this data type
+                dst_flow_buf[STRIDE_DST_FLOW * vpos_y + pos.x + vx] = flow[vy][vx];
+                if (OUTPUT_COST) {
+                    dst_cost_buf[STRIDE_DST_COST * vpos_y + pos.x + vx] = cost[vy][vx];
+                }
+            }
+        }
+    }
+}

--- a/graph/shaders/optical_flow/rgb_to_y.comp
+++ b/graph/shaders/optical_flow/rgb_to_y.comp
@@ -1,0 +1,138 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2023-2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#version 450
+precision highp float;
+precision highp sampler2D;
+precision highp image2D;
+#extension GL_EXT_shader_explicit_arithmetic_types_int8 : require
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+#extension GL_EXT_shader_8bit_storage : require
+
+/*
+RGB to Y color conversion + downsampling
+  - Input image : Full size RGB(3 or 4 ch) or Luma(1ch)
+  - Output images : Full size Luma and/or Downsampled Luma depending on OUTPUT_FULL and OUTPUT_DOWNSAMPLE
+  - If OUTPUT_FULL, DOWNSAMPLE_SCALE must be 2.f (hard-coded)
+  - Full size Luma is processed in 2x2 pixels per thread. Vectorization is not configurable.
+  - Downsampling is simple bilinear filtering which is performed by Texture H/W sampler
+*/
+
+// Local Work Size set as Specialization Constants
+layout (local_size_x_id = 0, local_size_y_id = 1, local_size_z = 1) in;
+
+// Supported : VECTORIZE_X: 1, VECTORIZE_Y: 1
+layout(constant_id = 2) const int VECTORIZE_X = 1;
+layout(constant_id = 3) const int VECTORIZE_Y = 1;
+
+layout(constant_id = 4) const bool LUMA_INPUT = false;
+layout(constant_id = 5) const bool OUTPUT_DOWNSAMPLE = true;
+layout(constant_id = 6) const bool OUTPUT_FULL = false;
+layout(constant_id = 7) const bool IMAGE_STORE = false;
+layout(constant_id = 8) const float DOWNSAMPLE_SCALE_X = 2.f;  // If OUTPUT_FULL, fixed to 2.f
+layout(constant_id = 9) const float DOWNSAMPLE_SCALE_Y = 2.f;  // If OUTPUT_FULL, fixed to 2.f
+layout(constant_id = 10) const int DS_OUTPUT_SIZE_X = 960;
+layout(constant_id = 11) const int DS_OUTPUT_SIZE_Y = 540;
+layout(constant_id = 12) const uint DS_STRIDE_DST = 960;   // The number of elements in a row (x-axis) including padding
+layout(constant_id = 13) const int FULL_OUTPUT_SIZE_X = 1920;
+layout(constant_id = 14) const int FULL_OUTPUT_SIZE_Y = 1080;
+layout(constant_id = 15) const uint FULL_STRIDE_DST = 1920;   // The number of elements in a row (x-axis) including padding
+
+layout (binding = 0) uniform sampler2D imageSampler;
+
+layout (set=0, binding = 1, r8) uniform writeonly image2D dst_ds_img;
+layout (set = 0, binding = 2, std430) buffer _dst_ds_buf{
+    uint8_t dst_ds_buf[];
+};
+
+layout (set=0, binding = 3, r8) uniform writeonly image2D dst_full_img;
+layout (set = 0, binding = 4, std430) buffer _dst_full_buf{
+    uint8_t dst_full_buf[];
+};
+
+
+const f16vec3 COEFF = f16vec3(0.25f, 0.5f, 0.25f);
+
+#define READ_QUAD_CENTER(_SAMP, _POS, _COMP) \
+    textureGather(_SAMP, _POS, _COMP).wzxy
+
+float16_t rgb_to_y(f16vec3 rgb) {
+    // NOTE: assuming value is normalized in 0.0-1.0 range in B10G11R11_UFLOAT format
+    return dot(rgb, COEFF);
+}
+
+float16_t calc_ds(vec2 src_pos)
+{
+    if (LUMA_INPUT) {
+        return float16_t(texture(imageSampler, src_pos).x);
+    } else {
+        return rgb_to_y(f16vec3(texture(imageSampler, src_pos).xyz));
+    }
+}
+
+f16vec4 calc_2x2(vec2 src_pos)
+{
+    f16vec4 luma;
+    if (LUMA_INPUT) {
+        luma = f16vec4(READ_QUAD_CENTER(imageSampler, src_pos, 0));
+
+    } else {
+        f16vec4 r = f16vec4(READ_QUAD_CENTER(imageSampler, src_pos, 0));
+        f16vec4 g = f16vec4(READ_QUAD_CENTER(imageSampler, src_pos, 1));
+        f16vec4 b = f16vec4(READ_QUAD_CENTER(imageSampler, src_pos, 2));
+
+        for (int i = 0; i < 4; ++i) {
+            luma[i] = rgb_to_y(f16vec3(r[i], g[i], b[i]));
+        }
+    }
+
+    return luma;
+}
+
+uint8_t convert_uint8(float16_t x)
+{
+    return uint8_t(round(x * 255.HF));
+}
+
+void main()
+{
+    const ivec2 ds_pos = ivec2(gl_GlobalInvocationID.x,
+                               gl_GlobalInvocationID.y);
+
+    vec2 downsample_scale = vec2(DOWNSAMPLE_SCALE_X, DOWNSAMPLE_SCALE_Y);
+    if (OUTPUT_FULL) {
+        downsample_scale = vec2(2.f);
+    }
+    vec2 src_pos = (vec2(ds_pos) + 0.5f) * downsample_scale;
+
+    if (OUTPUT_DOWNSAMPLE) {
+        if (any(greaterThanEqual(ds_pos, ivec2(DS_OUTPUT_SIZE_X, DS_OUTPUT_SIZE_Y)))) return;
+        float16_t luma_ds = calc_ds(src_pos);
+
+        if (IMAGE_STORE) {
+            imageStore(dst_ds_img, ds_pos, vec4(luma_ds, 0, 0, 0));
+        } else {
+            dst_ds_buf[DS_STRIDE_DST * ds_pos.y + ds_pos.x] = convert_uint8(luma_ds);
+        }
+    }
+
+    if (OUTPUT_FULL) {
+        f16vec4 luma = calc_2x2(src_pos);
+
+        for (int qy = 0; qy < 2 && ds_pos.y * 2 + qy < FULL_OUTPUT_SIZE_Y; ++qy) {
+            for (int qx = 0; qx < 2 && ds_pos.x * 2 + qx < FULL_OUTPUT_SIZE_X; ++qx) {
+
+                ivec2 full_pos = ds_pos * 2 + ivec2(qx, qy);
+
+                const int index_1d = qy * 2 + qx;
+                if (IMAGE_STORE) {
+                    imageStore(dst_full_img, full_pos, vec4(luma[index_1d], 0, 0, 0));
+                } else {
+                    dst_full_buf[FULL_STRIDE_DST * full_pos.y + full_pos.x] = convert_uint8(luma[index_1d]);
+                }
+            }
+        }
+    }
+}

--- a/graph/shaders/optical_flow/subpixel_me.comp
+++ b/graph/shaders/optical_flow/subpixel_me.comp
@@ -1,0 +1,175 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2023-2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#version 450
+precision highp float;  // 32bit precision is necessary for det_A
+precision mediump sampler2D;
+precision mediump image2D;
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+#extension GL_EXT_shader_explicit_arithmetic_types_int8 : require
+#extension GL_EXT_shader_explicit_arithmetic_types_int16 : require
+#extension GL_EXT_shader_16bit_storage : require
+#extension GL_EXT_shader_8bit_storage : require
+
+#define MACRO_BLOCK (5)
+#define BLOCK_R (MACRO_BLOCK / 2)
+
+// Local Work Size set as Specialization Constants
+layout (local_size_x_id = 0, local_size_y_id = 1, local_size_z = 1) in;
+
+// Vectorization is not available, just for compatibility
+layout(constant_id = 2) const int VECTORIZE_X = 1;
+layout(constant_id = 3) const int VECTORIZE_Y = 1;
+
+layout(constant_id = 4) const bool DO_ACCUMULATE = true;
+layout(constant_id = 5) const bool FLOW_BUFFER_LOAD = false;
+layout(constant_id = 6) const bool IMAGE_STORE = false;
+layout(constant_id = 7) const int OUTPUT_SIZE_X = 480;
+layout(constant_id = 8) const int OUTPUT_SIZE_Y = 270;
+layout(constant_id = 9) const uint STRIDE_INT_FLOW = 480;   // The number of elements in a row (x-axis) including padding
+layout(constant_id = 10) const uint STRIDE_PREV_FLOW = 480;
+layout(constant_id = 11) const uint STRIDE_DST_FLOW = 480;
+
+layout (set = 0, binding = 0) uniform mediump sampler2D imageSearchSampler;
+
+layout (set = 0, binding = 1) uniform mediump sampler2D imageTemplateSampler;
+
+layout (set = 0, binding = 2, std430) buffer _int_flow_buf{
+    i8vec2 int_flow_buf[];
+};
+
+layout (set = 0, binding = 3) uniform mediump sampler2D prevFlowSampler;
+layout (set = 0, binding = 4, std430) buffer _prev_flow_buf{
+    f16vec2 prev_flow_buf[];
+};
+
+layout(set = 0, binding = 5, rg16f) uniform writeonly image2D dst_flow_img;
+layout (set = 0, binding = 6, std430) buffer _dst_flow_buf{
+    f16vec2 dst_flow_buf[];
+};
+
+const ivec2 output_size = ivec2(OUTPUT_SIZE_X, OUTPUT_SIZE_Y);
+
+
+void unpack_from_u32(highp uint packed, out float16_t f, out float16_t dfx, out float16_t dfy)
+{
+    f   = float16_t(packed         & 0xff)  / 255.HF;           //  8 bit, [0, 1.0]
+    dfx = float16_t(((packed >>  8) & 0xfff) / 4095.f - 0.5f);  // 12 bit, [-0.5, +0.5]
+    dfy = float16_t(((packed >> 20) & 0xfff) / 4095.f - 0.5f);  // 12 bit, [-0.5, +0.5]
+}
+
+bool is_outside(ivec2 pos)
+{
+    return pos.x < 0 || pos.x >= output_size.x || pos.y < 0 || pos.y >= output_size.y;
+}
+
+void calc_gradient(ivec2 pos, out float16_t dfx, out float16_t dfy, out float16_t f)
+{
+    // Compute gradient on the fly
+    {
+        float16_t f_m1 = float16_t(texture(imageTemplateSampler, pos + ivec2(-1, 0)).x);
+        f              = float16_t(texture(imageTemplateSampler, pos               ).x);
+        float16_t f_p1 = float16_t(texture(imageTemplateSampler, pos + ivec2(+1, 0)).x);
+        dfx = (f_p1 - f_m1) * 0.5HF;
+    }
+    {
+        float16_t f_m1 = float16_t(texture(imageTemplateSampler, pos + ivec2(0, -1)).x);
+        float16_t f_p1 = float16_t(texture(imageTemplateSampler, pos + ivec2(0, +1)).x);
+        dfy = (f_p1 - f_m1) * 0.5HF;
+    }
+
+    // Zero padding in case pos is outside
+    // NOTE: CLAMP_TO_EDGE sampler is used to read f to compute gradient
+    float16_t is_inside = is_outside(pos) ? 0.HF : 1.HF;
+    f   = f   * is_inside;
+    dfx = dfx * is_inside;
+    dfy = dfy * is_inside;
+}
+
+f16vec2 calc(const ivec2 pos)
+{
+    float16_t a = 0.HF, b = 0.HF, d = 0.HF, p = 0.HF, q = 0.HF;
+    ivec2 int_flow = ivec2(int_flow_buf[STRIDE_INT_FLOW * pos.y + pos.x]);
+
+    // Read inputs and accumulate value, which updates:
+    //   - a, b, d, p, q
+    #define acc_work(_bx, _by) \
+    { \
+        ivec2 bpos = pos + ivec2(_bx, _by); \
+        float16_t f, dfx, dfy; \
+        calc_gradient(bpos, dfx, dfy, f); \
+        a += dfx * dfx; \
+        b += dfx * dfy; \
+        d += dfy * dfy; \
+        ivec2 g_pos = bpos + int_flow; \
+        float16_t g = float16_t(texture(imageSearchSampler, g_pos).x); \
+        float16_t z = g - f;\
+        p += z * dfx; \
+        q += z * dfy; \
+    }
+
+    /*
+        5x5 Reduction with predicate, where 0 means we don't accumulate
+        1, 1, 1, 1, 1,
+        1, 0, 0, 0, 1,
+        1, 0, 0, 0, 1,
+        1, 0, 0, 0, 1,
+        1, 1, 1, 1, 1
+    */
+    // Top edge, loop for x
+    for (int bx = -BLOCK_R; bx <= BLOCK_R; ++bx) {
+        acc_work(bx, -BLOCK_R);
+    }
+    // Middle rows, loop for y
+    for (int by = -BLOCK_R + 1; by <= BLOCK_R - 1; ++by) {
+        acc_work(-BLOCK_R, by);  // Left edge
+        acc_work( BLOCK_R, by);  // Right edge
+    }
+    // Bottom edge, loop for x
+    for (int bx = -BLOCK_R; bx <= BLOCK_R; ++bx) {
+        acc_work(bx, BLOCK_R);
+    }
+
+    // Use 32 bit float for numeric error sensitive process
+    float det_A = float(a) * float(d) - float(b) * float(b);
+    vec2 subpixel;
+    subpixel.x = float(d) * float(p) - float(b) * float(q);
+    subpixel.y = float(a) * float(q) - float(b) * float(p);
+    subpixel = subpixel / det_A;
+
+    // Validation
+    bool cond1 = (det_A <= 1e-7f);
+    bvec2 cond2 = greaterThanEqual(abs(subpixel), vec2(1.f));
+    // NOTE : element-wise vector operator of '||' cannot be compiled
+    bvec2 invalid_mask = bvec2(cond1 || cond2.x, cond1 || cond2.y);
+    subpixel = mix(subpixel, vec2(0.f), invalid_mask);
+
+    // Add integer flow here to save memory bandwidth
+    // Also accumulate the flow from previous level
+    // NOTE: The reference implementaion returns negated integer flow, but Motin Engine doesn't.
+    f16vec2 out_flow = f16vec2(int_flow) - f16vec2(subpixel);
+
+    if (DO_ACCUMULATE)
+        if (FLOW_BUFFER_LOAD)
+            out_flow += prev_flow_buf[STRIDE_PREV_FLOW * pos.y + pos.x];
+        else
+            out_flow += f16vec2(texelFetch(prevFlowSampler, ivec2(pos.x, pos.y), 0).xy);
+
+    return out_flow;
+}
+
+
+void main()
+{
+    const ivec2 pos = ivec2(gl_GlobalInvocationID.xy);
+    if (any(greaterThanEqual(pos, output_size))) return;
+
+    f16vec2 flow = calc(pos);
+
+    if (IMAGE_STORE)
+        imageStore(dst_flow_img, pos, f16vec4(flow, 0, 0));
+    else
+        dst_flow_buf[STRIDE_DST_FLOW * pos.y + pos.x] = flow;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -34,6 +34,7 @@ if(NOT APPLE)
     mlel_add_test(
         TARGET mlel_unit_tests
         SOURCES
+            optical_flow_tests.cpp
             vulkan.cpp
         DEFINITIONS
             SHADER_SOURCE_DIR=${SHADER_SOURCE_DIR}

--- a/tests/optical_flow_tests.cpp
+++ b/tests/optical_flow_tests.cpp
@@ -1,0 +1,649 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+#include <gtest/gtest.h>
+
+#include "mlel/device.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cstring>
+#include <optional>
+#include <stdexcept>
+#include <vector>
+
+using namespace mlsdk::el::utilities;
+
+namespace {
+
+std::shared_ptr<Device> createDevice() {
+    std::vector<const char *> layers = {"VK_LAYER_ML_Graph_Emulation", "VK_LAYER_ML_Tensor_Emulation"};
+    std::vector<const char *> extensions = {
+        VK_ARM_DATA_GRAPH_EXTENSION_NAME,
+        VK_ARM_DATA_GRAPH_OPTICAL_FLOW_EXTENSION_NAME,
+        VK_ARM_TENSORS_EXTENSION_NAME,
+    };
+
+    auto *const envValidation = std::getenv("VMEL_VALIDATION");
+    if (envValidation && !std::string(envValidation).empty() && std::string(envValidation) != "0") {
+        layers.emplace_back("VK_LAYER_KHRONOS_validation");
+    }
+
+    vk::PhysicalDeviceFeatures baseFeatures = {};
+    baseFeatures.shaderInt64 = VK_TRUE;
+    baseFeatures.shaderFloat64 = VK_TRUE;
+
+    vk::PhysicalDeviceFeatures2 features2 = {};
+    features2.setFeatures(baseFeatures);
+
+    auto context = std::make_shared<vk::raii::Context>();
+    auto instance = std::make_shared<Instance>(context, layers);
+    auto physicalDevice = std::make_shared<PhysicalDevice>(instance, extensions);
+
+    return std::make_shared<Device>(physicalDevice, extensions, &features2);
+}
+
+struct ImageResource {
+    vk::raii::Image image{nullptr};
+    vk::raii::DeviceMemory memory{nullptr};
+    vk::raii::ImageView view{nullptr};
+};
+
+ImageResource createImageResource(const std::shared_ptr<Device> &device, vk::Format format, uint32_t width,
+                                  uint32_t height, vk::ImageUsageFlags usage) {
+    const vk::ImageCreateInfo imageCreateInfo{
+        {},
+        vk::ImageType::e2D,
+        format,
+        vk::Extent3D{width, height, 1},
+        1,
+        1,
+        vk::SampleCountFlagBits::e1,
+        vk::ImageTiling::eOptimal,
+        usage,
+        vk::SharingMode::eExclusive,
+        0,
+        nullptr,
+        vk::ImageLayout::eUndefined,
+    };
+
+    ImageResource out;
+    out.image = vk::raii::Image(&(*device), imageCreateInfo);
+
+    const auto memReq = out.image.getMemoryRequirements();
+    const auto memoryTypeIndices = device->getPhysicalDevice()->getMemoryTypeIndices(
+        vk::MemoryPropertyFlagBits::eDeviceLocal, memReq.memoryTypeBits);
+    if (memoryTypeIndices.empty()) {
+        throw std::runtime_error("Failed to find device local memory type for image");
+    }
+
+    out.memory = vk::raii::DeviceMemory(&(*device), vk::MemoryAllocateInfo{memReq.size, memoryTypeIndices[0]});
+    out.image.bindMemory(*out.memory, 0);
+
+    const vk::ImageViewCreateInfo imageViewCreateInfo{
+        {},
+        *out.image,
+        vk::ImageViewType::e2D,
+        format,
+        vk::ComponentMapping{},
+        vk::ImageSubresourceRange{vk::ImageAspectFlagBits::eColor, 0, 1, 0, 1},
+    };
+    out.view = vk::raii::ImageView(&(*device), imageViewCreateInfo);
+
+    return out;
+}
+
+class OpticalFlow {
+  public:
+    struct Config {
+        VkDataGraphOpticalFlowGridSizeFlagsARM outputGridSize = VK_DATA_GRAPH_OPTICAL_FLOW_GRID_SIZE_4X4_BIT_ARM;
+        VkDataGraphOpticalFlowPerformanceLevelARM performanceLevel =
+            VK_DATA_GRAPH_OPTICAL_FLOW_PERFORMANCE_LEVEL_MEDIUM_ARM;
+        bool enableHint = false;
+        bool enableCost = false;
+    };
+
+    OpticalFlow(const std::shared_ptr<Device> &device, uint32_t width, uint32_t height, const Config &config)
+        : device_(device), vkDevice_(&(*device)), config_(config) {
+        std::vector<vk::DescriptorSetLayoutBinding> bindings;
+        for (uint32_t binding = 0; binding < descriptorCount(); binding++) {
+            bindings.push_back(vk::DescriptorSetLayoutBinding{binding, vk::DescriptorType::eStorageImage, 1,
+                                                              vk::ShaderStageFlagBits::eAll});
+        }
+
+        const vk::DescriptorSetLayoutCreateInfo dsLayoutCI{{}, static_cast<uint32_t>(bindings.size()), bindings.data()};
+        descriptorSetLayout_ = vk::raii::DescriptorSetLayout{&(*device), dsLayoutCI};
+
+        const vk::DescriptorPoolSize poolSize{vk::DescriptorType::eStorageImage, descriptorCount()};
+        const vk::DescriptorPoolCreateInfo descriptorPoolCreateInfo{{}, 1, 1, &poolSize};
+        descriptorPool_ = vk::raii::DescriptorPool{&(*device), descriptorPoolCreateInfo};
+
+        const vk::DescriptorSetLayout layouts[] = {*descriptorSetLayout_};
+        const vk::DescriptorSetAllocateInfo descriptorSetAllocateInfo{*descriptorPool_, 1, layouts};
+        descriptorSets_ = vk::raii::DescriptorSets{&(*device), descriptorSetAllocateInfo};
+
+        const vk::PipelineLayoutCreateInfo pipelineLayoutCI{{}, 1, layouts};
+        pipelineLayout_ = vk::raii::PipelineLayout{&(*device), pipelineLayoutCI};
+
+        std::vector<VkDataGraphPipelineResourceInfoImageLayoutARM> resourceLayouts(descriptorCount());
+        std::vector<VkDataGraphPipelineResourceInfoARM> resourceInfos(descriptorCount());
+        for (uint32_t i = 0; i < descriptorCount(); i++) {
+            resourceLayouts[i] = {
+                VK_STRUCTURE_TYPE_DATA_GRAPH_PIPELINE_RESOURCE_INFO_IMAGE_LAYOUT_ARM,
+                nullptr,
+                VK_IMAGE_LAYOUT_GENERAL,
+            };
+            resourceInfos[i] = {
+                VK_STRUCTURE_TYPE_DATA_GRAPH_PIPELINE_RESOURCE_INFO_ARM, &resourceLayouts[i], 0, i, 0,
+            };
+        }
+
+        std::vector<VkDataGraphPipelineSingleNodeConnectionARM> connections;
+        connections.push_back({VK_STRUCTURE_TYPE_DATA_GRAPH_PIPELINE_SINGLE_NODE_CONNECTION_ARM, nullptr, 0, 0,
+                               VK_DATA_GRAPH_PIPELINE_NODE_CONNECTION_TYPE_OPTICAL_FLOW_INPUT_ARM});
+        connections.push_back({VK_STRUCTURE_TYPE_DATA_GRAPH_PIPELINE_SINGLE_NODE_CONNECTION_ARM, nullptr, 0, 1,
+                               VK_DATA_GRAPH_PIPELINE_NODE_CONNECTION_TYPE_OPTICAL_FLOW_REFERENCE_ARM});
+        connections.push_back({VK_STRUCTURE_TYPE_DATA_GRAPH_PIPELINE_SINGLE_NODE_CONNECTION_ARM, nullptr, 0, 2,
+                               VK_DATA_GRAPH_PIPELINE_NODE_CONNECTION_TYPE_OPTICAL_FLOW_FLOW_VECTOR_ARM});
+        if (config_.enableHint) {
+            connections.push_back({VK_STRUCTURE_TYPE_DATA_GRAPH_PIPELINE_SINGLE_NODE_CONNECTION_ARM, nullptr, 0,
+                                   hintBinding(), VK_DATA_GRAPH_PIPELINE_NODE_CONNECTION_TYPE_OPTICAL_FLOW_HINT_ARM});
+        }
+        if (config_.enableCost) {
+            connections.push_back({VK_STRUCTURE_TYPE_DATA_GRAPH_PIPELINE_SINGLE_NODE_CONNECTION_ARM, nullptr, 0,
+                                   costBinding(), VK_DATA_GRAPH_PIPELINE_NODE_CONNECTION_TYPE_OPTICAL_FLOW_COST_ARM});
+        }
+
+        VkDataGraphPipelineOpticalFlowCreateInfoARM opticalFlowCreateInfo{};
+        opticalFlowCreateInfo.sType = VK_STRUCTURE_TYPE_DATA_GRAPH_PIPELINE_OPTICAL_FLOW_CREATE_INFO_ARM;
+        opticalFlowCreateInfo.flags = 0;
+        if (config_.enableHint) {
+            opticalFlowCreateInfo.flags |= VK_DATA_GRAPH_OPTICAL_FLOW_CREATE_ENABLE_HINT_BIT_ARM;
+        }
+        if (config_.enableCost) {
+            opticalFlowCreateInfo.flags |= VK_DATA_GRAPH_OPTICAL_FLOW_CREATE_ENABLE_COST_BIT_ARM;
+        }
+        opticalFlowCreateInfo.outputGridSize = config_.outputGridSize;
+        opticalFlowCreateInfo.hintGridSize = config_.enableHint ? config_.outputGridSize : 0;
+        opticalFlowCreateInfo.performanceLevel = config_.performanceLevel;
+        opticalFlowCreateInfo.imageFormat = VK_FORMAT_R8_UNORM;
+        opticalFlowCreateInfo.flowVectorFormat = VK_FORMAT_R16G16_SFLOAT;
+        opticalFlowCreateInfo.costFormat = VK_FORMAT_R16_UINT;
+        opticalFlowCreateInfo.width = width;
+        opticalFlowCreateInfo.height = height;
+
+        VkDataGraphPipelineSingleNodeCreateInfoARM singleNodeCreateInfo{};
+        singleNodeCreateInfo.sType = VK_STRUCTURE_TYPE_DATA_GRAPH_PIPELINE_SINGLE_NODE_CREATE_INFO_ARM;
+        singleNodeCreateInfo.pNext = &opticalFlowCreateInfo;
+        singleNodeCreateInfo.nodeType = VK_DATA_GRAPH_PIPELINE_NODE_TYPE_OPTICAL_FLOW_ARM;
+        singleNodeCreateInfo.connectionCount = static_cast<uint32_t>(connections.size());
+        singleNodeCreateInfo.pConnections = connections.data();
+
+        VkDataGraphPipelineCreateInfoARM createInfo{};
+        createInfo.sType = VK_STRUCTURE_TYPE_DATA_GRAPH_PIPELINE_CREATE_INFO_ARM;
+        createInfo.pNext = &singleNodeCreateInfo;
+        createInfo.layout = *pipelineLayout_;
+        createInfo.resourceInfoCount = static_cast<uint32_t>(resourceInfos.size());
+        createInfo.pResourceInfos = resourceInfos.data();
+
+        VkResult result = vkDevice_.getDispatcher()->vkCreateDataGraphPipelinesARM(
+            *vkDevice_, VK_NULL_HANDLE, VK_NULL_HANDLE, 1, &createInfo, nullptr, &pipeline_);
+        if (result != VK_SUCCESS) {
+            throw std::runtime_error("Failed to create data graph optical flow pipeline");
+        }
+
+        VkDataGraphPipelineSessionCreateInfoARM sessionCreateInfo{};
+        sessionCreateInfo.sType = VK_STRUCTURE_TYPE_DATA_GRAPH_PIPELINE_SESSION_CREATE_INFO_ARM;
+        sessionCreateInfo.flags = VK_DATA_GRAPH_PIPELINE_SESSION_CREATE_OPTICAL_FLOW_CACHE_BIT_ARM;
+        sessionCreateInfo.dataGraphPipeline = pipeline_;
+
+        result = vkDevice_.getDispatcher()->vkCreateDataGraphPipelineSessionARM(*vkDevice_, &sessionCreateInfo, nullptr,
+                                                                                &session_);
+        if (result != VK_SUCCESS) {
+            throw std::runtime_error("Failed to create data graph optical flow session_");
+        }
+
+        allocateAndBindSessionMemory();
+    }
+
+    ~OpticalFlow() {
+        if (session_ != VK_NULL_HANDLE) {
+            vkDevice_.getDispatcher()->vkDestroyDataGraphPipelineSessionARM(*vkDevice_, session_, nullptr);
+        }
+        if (pipeline_ != VK_NULL_HANDLE) {
+            vkDevice_.getDispatcher()->vkDestroyPipeline(*vkDevice_, pipeline_, nullptr);
+        }
+    }
+
+    void bindImages(vk::ImageView inputView, vk::ImageView referenceView, vk::ImageView flowVectorView,
+                    std::optional<vk::ImageView> hintView = std::nullopt,
+                    std::optional<vk::ImageView> costView = std::nullopt) {
+        std::vector<vk::DescriptorImageInfo> imageInfos;
+        imageInfos.reserve(descriptorCount());
+        imageInfos.push_back(vk::DescriptorImageInfo{VK_NULL_HANDLE, inputView, vk::ImageLayout::eGeneral});
+        imageInfos.push_back(vk::DescriptorImageInfo{VK_NULL_HANDLE, referenceView, vk::ImageLayout::eGeneral});
+        imageInfos.push_back(vk::DescriptorImageInfo{VK_NULL_HANDLE, flowVectorView, vk::ImageLayout::eGeneral});
+
+        if (config_.enableHint) {
+            if (!hintView.has_value()) {
+                throw std::runtime_error("Hint image view is required when hint is enabled");
+            }
+            imageInfos.push_back(vk::DescriptorImageInfo{VK_NULL_HANDLE, *hintView, vk::ImageLayout::eGeneral});
+        }
+        if (config_.enableCost) {
+            if (!costView.has_value()) {
+                throw std::runtime_error("Cost image view is required when cost output is enabled");
+            }
+            imageInfos.push_back(vk::DescriptorImageInfo{VK_NULL_HANDLE, *costView, vk::ImageLayout::eGeneral});
+        }
+
+        std::vector<vk::WriteDescriptorSet> descriptorWrites;
+        descriptorWrites.reserve(descriptorCount());
+        for (uint32_t i = 0; i < descriptorCount(); i++) {
+            descriptorWrites.push_back(vk::WriteDescriptorSet{*descriptorSets_[0], i, 0, 1,
+                                                              vk::DescriptorType::eStorageImage, &imageInfos[i]});
+        }
+
+        vkDevice_.updateDescriptorSets(descriptorWrites, {});
+    }
+
+    void dispatchSubmit(const std::vector<vk::Image> &images) {
+        const vk::CommandPoolCreateInfo commandPoolCreateInfo{{},
+                                                              device_->getPhysicalDevice()->getComputeFamilyIndex()};
+        vk::raii::CommandPool commandPool{&(*device_), commandPoolCreateInfo};
+        const vk::CommandBufferAllocateInfo commandBufferAllocInfo{*commandPool, vk::CommandBufferLevel::ePrimary, 1};
+        vk::raii::CommandBuffers commandBuffers{&(*device_), commandBufferAllocInfo};
+        auto commandBuffer = std::move(commandBuffers.front());
+
+        commandBuffer.begin({vk::CommandBufferUsageFlagBits::eOneTimeSubmit});
+
+        for (const auto &image : images) {
+            VkImageMemoryBarrier2 imageBarrier{};
+            imageBarrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER_2;
+            imageBarrier.srcStageMask = VK_PIPELINE_STAGE_2_TRANSFER_BIT;
+            imageBarrier.srcAccessMask = VK_ACCESS_2_TRANSFER_WRITE_BIT;
+            imageBarrier.dstStageMask = VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT;
+            imageBarrier.dstAccessMask = VK_ACCESS_2_SHADER_READ_BIT | VK_ACCESS_2_SHADER_WRITE_BIT;
+            imageBarrier.oldLayout = VK_IMAGE_LAYOUT_GENERAL;
+            imageBarrier.newLayout = VK_IMAGE_LAYOUT_GENERAL;
+            imageBarrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+            imageBarrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+            imageBarrier.image = image;
+            imageBarrier.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+
+            VkDependencyInfo depInfo{};
+            depInfo.sType = VK_STRUCTURE_TYPE_DEPENDENCY_INFO;
+            depInfo.imageMemoryBarrierCount = 1;
+            depInfo.pImageMemoryBarriers = &imageBarrier;
+            vkDevice_.getDispatcher()->vkCmdPipelineBarrier2(*commandBuffer, &depInfo);
+        }
+
+        vkDevice_.getDispatcher()->vkCmdBindPipeline(*commandBuffer, VK_PIPELINE_BIND_POINT_DATA_GRAPH_ARM, pipeline_);
+        const VkDescriptorSet vkDescriptorSet = *descriptorSets_[0];
+        vkDevice_.getDispatcher()->vkCmdBindDescriptorSets(*commandBuffer, VK_PIPELINE_BIND_POINT_DATA_GRAPH_ARM,
+                                                           *pipelineLayout_, 0, 1, &vkDescriptorSet, 0, nullptr);
+        vkDevice_.getDispatcher()->vkCmdDispatchDataGraphARM(*commandBuffer, session_, nullptr);
+        commandBuffer.end();
+
+        vk::raii::Queue queue(&(*device_), device_->getPhysicalDevice()->getComputeFamilyIndex(), 0);
+        vk::raii::Fence fence(&(*device_), vk::FenceCreateInfo{});
+        const vk::SubmitInfo submitInfo{0, nullptr, nullptr, 1, &(*commandBuffer), 0, nullptr};
+        queue.submit({1, &submitInfo}, *fence);
+        const auto waitResult = (&(*device_)).waitForFences({*fence}, vk::True, uint64_t(-1));
+        if (waitResult != vk::Result::eSuccess) {
+            throw std::runtime_error("Failed waiting for optical flow dispatch completion");
+        }
+    }
+
+  private:
+    void allocateAndBindSessionMemory() {
+        const VkDataGraphPipelineSessionBindPointRequirementsInfoARM bindPointReqInfo = {
+            VK_STRUCTURE_TYPE_DATA_GRAPH_PIPELINE_SESSION_BIND_POINT_REQUIREMENTS_INFO_ARM,
+            nullptr,
+            session_,
+        };
+
+        uint32_t bindPointCount = 0;
+        VkResult result = vkDevice_.getDispatcher()->vkGetDataGraphPipelineSessionBindPointRequirementsARM(
+            *vkDevice_, &bindPointReqInfo, &bindPointCount, nullptr);
+        if (result != VK_SUCCESS || bindPointCount == 0) {
+            throw std::runtime_error("Failed querying optical flow bind point requirements");
+        }
+
+        std::vector<VkDataGraphPipelineSessionBindPointRequirementARM> bindPointRequirements(bindPointCount);
+        for (auto &r : bindPointRequirements) {
+            r = {};
+            r.sType = VK_STRUCTURE_TYPE_DATA_GRAPH_PIPELINE_SESSION_BIND_POINT_REQUIREMENT_ARM;
+        }
+        uint32_t retrievedBindPointCount = bindPointCount;
+        result = vkDevice_.getDispatcher()->vkGetDataGraphPipelineSessionBindPointRequirementsARM(
+            *vkDevice_, &bindPointReqInfo, &retrievedBindPointCount, bindPointRequirements.data());
+        if (result != VK_SUCCESS || retrievedBindPointCount != bindPointCount) {
+            throw std::runtime_error("Failed retrieving optical flow bind point requirements");
+        }
+
+        std::vector<VkBindDataGraphPipelineSessionMemoryInfoARM> bindInfos;
+        for (const auto &req : bindPointRequirements) {
+            for (uint32_t objectIndex = 0; objectIndex < req.numObjects; objectIndex++) {
+                VkMemoryRequirements2 memReq{};
+                memReq.sType = VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2;
+
+                VkDataGraphPipelineSessionMemoryRequirementsInfoARM memReqInfo{};
+                memReqInfo.sType = VK_STRUCTURE_TYPE_DATA_GRAPH_PIPELINE_SESSION_MEMORY_REQUIREMENTS_INFO_ARM;
+                memReqInfo.session = session_;
+                memReqInfo.bindPoint = req.bindPoint;
+                memReqInfo.objectIndex = objectIndex;
+                vkDevice_.getDispatcher()->vkGetDataGraphPipelineSessionMemoryRequirementsARM(*vkDevice_, &memReqInfo,
+                                                                                              &memReq);
+
+                const auto memoryTypeIndices = device_->getPhysicalDevice()->getMemoryTypeIndices(
+                    vk::MemoryPropertyFlagBits::eDeviceLocal, memReq.memoryRequirements.memoryTypeBits);
+                if (memoryTypeIndices.empty()) {
+                    throw std::runtime_error("Failed finding optical flow session_ memory type index");
+                }
+
+                sessionMemories_.emplace_back(
+                    &(*device_), vk::MemoryAllocateInfo{memReq.memoryRequirements.size, memoryTypeIndices[0]});
+
+                VkBindDataGraphPipelineSessionMemoryInfoARM bindInfo{};
+                bindInfo.sType = VK_STRUCTURE_TYPE_BIND_DATA_GRAPH_PIPELINE_SESSION_MEMORY_INFO_ARM;
+                bindInfo.session = session_;
+                bindInfo.bindPoint = req.bindPoint;
+                bindInfo.objectIndex = objectIndex;
+                bindInfo.memory = *sessionMemories_.back();
+                bindInfo.memoryOffset = 0;
+                bindInfos.push_back(bindInfo);
+            }
+        }
+
+        result = vkDevice_.getDispatcher()->vkBindDataGraphPipelineSessionMemoryARM(
+            *vkDevice_, static_cast<uint32_t>(bindInfos.size()), bindInfos.data());
+        if (result != VK_SUCCESS) {
+            throw std::runtime_error("Failed binding optical flow session_ memory");
+        }
+    }
+
+    uint32_t descriptorCount() const { return 3u + (config_.enableHint ? 1u : 0u) + (config_.enableCost ? 1u : 0u); }
+    uint32_t hintBinding() const { return 3u; }
+    uint32_t costBinding() const { return config_.enableHint ? 4u : 3u; }
+
+    std::shared_ptr<Device> device_;
+    const vk::raii::Device &vkDevice_;
+    Config config_;
+    vk::raii::DescriptorSetLayout descriptorSetLayout_{nullptr};
+    vk::raii::DescriptorPool descriptorPool_{nullptr};
+    vk::raii::DescriptorSets descriptorSets_{nullptr};
+    vk::raii::PipelineLayout pipelineLayout_{nullptr};
+    VkPipeline pipeline_{VK_NULL_HANDLE};
+    VkDataGraphPipelineSessionARM session_{VK_NULL_HANDLE};
+    std::vector<vk::raii::DeviceMemory> sessionMemories_;
+};
+
+void initializeImages(const std::shared_ptr<Device> &device, vk::Image input, vk::Image reference, vk::Image flow,
+                      uint8_t inputValue, uint8_t referenceValue, uint8_t flowSeedValue) {
+    const vk::CommandPoolCreateInfo commandPoolCreateInfo{{}, device->getPhysicalDevice()->getComputeFamilyIndex()};
+    vk::raii::CommandPool commandPool{&(*device), commandPoolCreateInfo};
+    const vk::CommandBufferAllocateInfo commandBufferAllocInfo{*commandPool, vk::CommandBufferLevel::ePrimary, 1};
+    vk::raii::CommandBuffers commandBuffers{&(*device), commandBufferAllocInfo};
+    auto commandBuffer = std::move(commandBuffers.front());
+
+    commandBuffer.begin({vk::CommandBufferUsageFlagBits::eOneTimeSubmit});
+
+    for (const auto image : {input, reference, flow}) {
+        VkImageMemoryBarrier2 barrier{};
+        barrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER_2;
+        barrier.srcStageMask = VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT;
+        barrier.srcAccessMask = VK_ACCESS_2_NONE;
+        barrier.dstStageMask = VK_PIPELINE_STAGE_2_TRANSFER_BIT;
+        barrier.dstAccessMask = VK_ACCESS_2_TRANSFER_WRITE_BIT;
+        barrier.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        barrier.newLayout = VK_IMAGE_LAYOUT_GENERAL;
+        barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+        barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+        barrier.image = image;
+        barrier.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+
+        VkDependencyInfo depInfo{};
+        depInfo.sType = VK_STRUCTURE_TYPE_DEPENDENCY_INFO;
+        depInfo.imageMemoryBarrierCount = 1;
+        depInfo.pImageMemoryBarriers = &barrier;
+        (&(*device)).getDispatcher()->vkCmdPipelineBarrier2(*commandBuffer, &depInfo);
+    }
+
+    const VkClearColorValue inputColor = {{float(inputValue) / 255.0f, 0.0f, 0.0f, 0.0f}};
+    const VkClearColorValue referenceColor = {{float(referenceValue) / 255.0f, 0.0f, 0.0f, 0.0f}};
+    const VkClearColorValue flowColor = {{float(flowSeedValue) / 255.0f, 0.0f, 0.0f, 0.0f}};
+    const VkImageSubresourceRange subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+
+    (&(*device))
+        .getDispatcher()
+        ->vkCmdClearColorImage(*commandBuffer, input, VK_IMAGE_LAYOUT_GENERAL, &inputColor, 1, &subresourceRange);
+    (&(*device))
+        .getDispatcher()
+        ->vkCmdClearColorImage(*commandBuffer, reference, VK_IMAGE_LAYOUT_GENERAL, &referenceColor, 1,
+                               &subresourceRange);
+    (&(*device))
+        .getDispatcher()
+        ->vkCmdClearColorImage(*commandBuffer, flow, VK_IMAGE_LAYOUT_GENERAL, &flowColor, 1, &subresourceRange);
+
+    commandBuffer.end();
+
+    vk::raii::Queue queue(&(*device), device->getPhysicalDevice()->getComputeFamilyIndex(), 0);
+    vk::raii::Fence fence(&(*device), vk::FenceCreateInfo{});
+    const vk::SubmitInfo submitInfo{0, nullptr, nullptr, 1, &(*commandBuffer), 0, nullptr};
+    queue.submit({1, &submitInfo}, *fence);
+    const auto waitResult = (&(*device)).waitForFences({*fence}, vk::True, uint64_t(-1));
+    if (waitResult != vk::Result::eSuccess) {
+        throw std::runtime_error("Failed waiting for image initialization");
+    }
+}
+
+std::vector<uint8_t> readFlowImage(const std::shared_ptr<Device> &device, vk::Image image, uint32_t width,
+                                   uint32_t height) {
+    const auto byteSize = vk::DeviceSize(width) * vk::DeviceSize(height) * 4;
+    const vk::BufferCreateInfo bufferCreateInfo{
+        {}, byteSize, vk::BufferUsageFlagBits::eTransferDst, vk::SharingMode::eExclusive, 0, nullptr};
+    vk::raii::Buffer stagingBuffer{&(*device), bufferCreateInfo};
+
+    const auto memReq = stagingBuffer.getMemoryRequirements();
+    const auto memoryTypeIndices = device->getPhysicalDevice()->getMemoryTypeIndices(
+        vk::MemoryPropertyFlagBits::eHostVisible | vk::MemoryPropertyFlagBits::eHostCoherent, memReq.memoryTypeBits);
+    if (memoryTypeIndices.empty()) {
+        throw std::runtime_error("Failed to find host visible memory type for readback");
+    }
+
+    vk::raii::DeviceMemory stagingMemory{&(*device), vk::MemoryAllocateInfo{memReq.size, memoryTypeIndices[0]}};
+    stagingBuffer.bindMemory(*stagingMemory, 0);
+
+    const vk::CommandPoolCreateInfo commandPoolCreateInfo{{}, device->getPhysicalDevice()->getComputeFamilyIndex()};
+    vk::raii::CommandPool commandPool{&(*device), commandPoolCreateInfo};
+    const vk::CommandBufferAllocateInfo commandBufferAllocInfo{*commandPool, vk::CommandBufferLevel::ePrimary, 1};
+    vk::raii::CommandBuffers commandBuffers{&(*device), commandBufferAllocInfo};
+    auto commandBuffer = std::move(commandBuffers.front());
+
+    commandBuffer.begin({vk::CommandBufferUsageFlagBits::eOneTimeSubmit});
+
+    VkImageMemoryBarrier2 imageBarrier{};
+    imageBarrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER_2;
+    imageBarrier.srcStageMask = VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT;
+    imageBarrier.srcAccessMask = VK_ACCESS_2_SHADER_WRITE_BIT;
+    imageBarrier.dstStageMask = VK_PIPELINE_STAGE_2_TRANSFER_BIT;
+    imageBarrier.dstAccessMask = VK_ACCESS_2_TRANSFER_READ_BIT;
+    imageBarrier.oldLayout = VK_IMAGE_LAYOUT_GENERAL;
+    imageBarrier.newLayout = VK_IMAGE_LAYOUT_GENERAL;
+    imageBarrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    imageBarrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    imageBarrier.image = image;
+    imageBarrier.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+
+    VkDependencyInfo depInfo{};
+    depInfo.sType = VK_STRUCTURE_TYPE_DEPENDENCY_INFO;
+    depInfo.imageMemoryBarrierCount = 1;
+    depInfo.pImageMemoryBarriers = &imageBarrier;
+    (&(*device)).getDispatcher()->vkCmdPipelineBarrier2(*commandBuffer, &depInfo);
+
+    VkBufferImageCopy region{};
+    region.bufferOffset = 0;
+    region.bufferRowLength = 0;
+    region.bufferImageHeight = 0;
+    region.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+    region.imageOffset = {0, 0, 0};
+    region.imageExtent = {width, height, 1};
+
+    (&(*device))
+        .getDispatcher()
+        ->vkCmdCopyImageToBuffer(*commandBuffer, image, VK_IMAGE_LAYOUT_GENERAL, *stagingBuffer, 1, &region);
+
+    commandBuffer.end();
+
+    vk::raii::Queue queue(&(*device), device->getPhysicalDevice()->getComputeFamilyIndex(), 0);
+    vk::raii::Fence fence(&(*device), vk::FenceCreateInfo{});
+    const vk::SubmitInfo submitInfo{0, nullptr, nullptr, 1, &(*commandBuffer), 0, nullptr};
+    queue.submit({1, &submitInfo}, *fence);
+    const auto waitResult = (&(*device)).waitForFences({*fence}, vk::True, uint64_t(-1));
+    if (waitResult != vk::Result::eSuccess) {
+        throw std::runtime_error("Failed waiting for flow readback");
+    }
+
+    std::vector<uint8_t> out(static_cast<size_t>(byteSize));
+    void *mapped = stagingMemory.mapMemory(0, byteSize);
+    std::memcpy(out.data(), mapped, out.size());
+    stagingMemory.unmapMemory();
+    return out;
+}
+
+uint32_t granularityFromGrid(VkDataGraphOpticalFlowGridSizeFlagsARM gridSize) {
+    switch (gridSize) {
+    case VK_DATA_GRAPH_OPTICAL_FLOW_GRID_SIZE_1X1_BIT_ARM:
+        return 1;
+    case VK_DATA_GRAPH_OPTICAL_FLOW_GRID_SIZE_2X2_BIT_ARM:
+        return 2;
+    case VK_DATA_GRAPH_OPTICAL_FLOW_GRID_SIZE_4X4_BIT_ARM:
+        return 4;
+    case VK_DATA_GRAPH_OPTICAL_FLOW_GRID_SIZE_8X8_BIT_ARM:
+        return 8;
+    default:
+        throw std::runtime_error("Unsupported optical flow grid size");
+    }
+}
+
+void runOpticalFlowAndExpectOutputChange(const std::shared_ptr<Device> &device, const OpticalFlow::Config &cfg,
+                                         std::string_view contextName) {
+    constexpr uint32_t width = 64;
+    constexpr uint32_t height = 64;
+    const uint32_t granularity = granularityFromGrid(cfg.outputGridSize);
+    const uint32_t flowWidth = width / granularity;
+    const uint32_t flowHeight = height / granularity;
+
+    auto srcInput = createImageResource(device, vk::Format::eR8Unorm, width, height,
+                                        vk::ImageUsageFlagBits::eSampled | vk::ImageUsageFlagBits::eStorage |
+                                            vk::ImageUsageFlagBits::eTransferDst);
+    auto srcReference = createImageResource(device, vk::Format::eR8Unorm, width, height,
+                                            vk::ImageUsageFlagBits::eSampled | vk::ImageUsageFlagBits::eStorage |
+                                                vk::ImageUsageFlagBits::eTransferDst);
+    auto dstFlow = createImageResource(device, vk::Format::eR16G16Sfloat, flowWidth, flowHeight,
+                                       vk::ImageUsageFlagBits::eStorage | vk::ImageUsageFlagBits::eSampled |
+                                           vk::ImageUsageFlagBits::eTransferSrc | vk::ImageUsageFlagBits::eTransferDst);
+
+    std::optional<ImageResource> srcHint;
+    std::optional<ImageResource> dstCost;
+
+    if (cfg.enableHint) {
+        srcHint = createImageResource(device, vk::Format::eR16G16Sfloat, flowWidth, flowHeight,
+                                      vk::ImageUsageFlagBits::eSampled | vk::ImageUsageFlagBits::eStorage |
+                                          vk::ImageUsageFlagBits::eTransferDst);
+    }
+    if (cfg.enableCost) {
+        dstCost = createImageResource(device, vk::Format::eR16Uint, flowWidth, flowHeight,
+                                      vk::ImageUsageFlagBits::eStorage | vk::ImageUsageFlagBits::eSampled |
+                                          vk::ImageUsageFlagBits::eTransferDst);
+    }
+
+    initializeImages(device, *srcInput.image, *srcReference.image, *dstFlow.image, 48, 176, 255);
+    if (srcHint.has_value()) {
+        initializeImages(device, *srcHint->image, *srcHint->image, *srcHint->image, 5, 5, 5);
+    }
+    if (dstCost.has_value()) {
+        initializeImages(device, *dstCost->image, *dstCost->image, *dstCost->image, 255, 255, 255);
+    }
+
+    OpticalFlow opticalFlow{device, width, height, cfg};
+    opticalFlow.bindImages(*srcInput.view, *srcReference.view, *dstFlow.view,
+                           srcHint.has_value() ? std::optional<vk::ImageView>{*srcHint->view} : std::nullopt,
+                           dstCost.has_value() ? std::optional<vk::ImageView>{*dstCost->view} : std::nullopt);
+
+    std::vector<vk::Image> images = {*srcInput.image, *srcReference.image, *dstFlow.image};
+    if (srcHint.has_value()) {
+        images.push_back(*srcHint->image);
+    }
+    if (dstCost.has_value()) {
+        images.push_back(*dstCost->image);
+    }
+
+    opticalFlow.dispatchSubmit(images);
+
+    const auto flowOutput = readFlowImage(device, *dstFlow.image, flowWidth, flowHeight);
+    ASSERT_FALSE(flowOutput.empty()) << contextName;
+    ASSERT_TRUE(std::any_of(flowOutput.begin(), flowOutput.end(), [](uint8_t value) { return value != 0xFF; }))
+        << contextName;
+}
+
+TEST(MLEmulationLayerOpticalFlowForVulkan, RGBToY_Smoke_Grid4x4) { // cppcheck-suppress syntaxError
+    const auto device = createDevice();
+    runOpticalFlowAndExpectOutputChange(device, OpticalFlow::Config{}, "RGBToY smoke");
+}
+
+TEST(MLEmulationLayerOpticalFlowForVulkan, RGBToY_Grid1x1) {
+    const auto device = createDevice();
+    OpticalFlow::Config cfg;
+    cfg.outputGridSize = VK_DATA_GRAPH_OPTICAL_FLOW_GRID_SIZE_1X1_BIT_ARM;
+    runOpticalFlowAndExpectOutputChange(device, cfg, "RGBToY class path");
+}
+
+TEST(MLEmulationLayerOpticalFlowForVulkan, Downsample_Grid8x8) {
+    const auto device = createDevice();
+    OpticalFlow::Config cfg;
+    cfg.outputGridSize = VK_DATA_GRAPH_OPTICAL_FLOW_GRID_SIZE_8X8_BIT_ARM;
+    runOpticalFlowAndExpectOutputChange(device, cfg, "Downsample class path");
+}
+
+TEST(MLEmulationLayerOpticalFlowForVulkan, DenseWarp_WithHint) {
+    const auto device = createDevice();
+    OpticalFlow::Config cfg;
+    cfg.enableHint = true;
+    runOpticalFlowAndExpectOutputChange(device, cfg, "DenseWarp class path");
+}
+
+TEST(MLEmulationLayerOpticalFlowForVulkan, MedianFilter_Fast) {
+    const auto device = createDevice();
+    OpticalFlow::Config cfg;
+    cfg.performanceLevel = VK_DATA_GRAPH_OPTICAL_FLOW_PERFORMANCE_LEVEL_FAST_ARM;
+    runOpticalFlowAndExpectOutputChange(device, cfg, "MedianFilter class path");
+}
+
+TEST(MLEmulationLayerOpticalFlowForVulkan, BilateralFilter_Medium) {
+    const auto device = createDevice();
+    OpticalFlow::Config cfg;
+    cfg.performanceLevel = VK_DATA_GRAPH_OPTICAL_FLOW_PERFORMANCE_LEVEL_MEDIUM_ARM;
+    runOpticalFlowAndExpectOutputChange(device, cfg, "BilateralFilter class path");
+}
+
+TEST(MLEmulationLayerOpticalFlowForVulkan, MVReplace_WithHintAndCost) {
+    const auto device = createDevice();
+    OpticalFlow::Config cfg;
+    cfg.enableHint = true;
+    cfg.enableCost = true;
+    runOpticalFlowAndExpectOutputChange(device, cfg, "MVReplace class path");
+}
+
+TEST(MLEmulationLayerOpticalFlowForVulkan, BlockMatch_CostEnabled) {
+    const auto device = createDevice();
+    OpticalFlow::Config cfg;
+    cfg.enableCost = true;
+    runOpticalFlowAndExpectOutputChange(device, cfg, "BlockMatch class path");
+}
+
+} // namespace

--- a/tests/vulkan.cpp
+++ b/tests/vulkan.cpp
@@ -295,6 +295,7 @@ std::shared_ptr<Device> createDevice() {
     std::vector<const char *> extensions = {
         VK_ARM_DATA_GRAPH_EXTENSION_NAME,
         VK_ARM_DATA_GRAPH_INSTRUCTION_SET_TOSA_EXTENSION_NAME,
+        VK_ARM_DATA_GRAPH_OPTICAL_FLOW_EXTENSION_NAME,
         VK_ARM_TENSORS_EXTENSION_NAME,
     };
 
@@ -2058,6 +2059,11 @@ TEST_F(MLEmulationLayerForVulkan, GetPhysicalDeviceQueueFamilyDataGraphEngineOpe
                    VK_PHYSICAL_DEVICE_DATA_GRAPH_OPERATION_TYPE_SPIRV_EXTENDED_INSTRUCTION_SET_ARM;
         });
     ASSERT_NE(tosaProp, properties.end());
+    const auto opticalFlowProp =
+        std::find_if(properties.begin(), properties.end(), [](const VkQueueFamilyDataGraphPropertiesARM &p) {
+            return p.operation.operationType == VK_PHYSICAL_DEVICE_DATA_GRAPH_OPERATION_TYPE_OPTICAL_FLOW_ARM;
+        });
+    ASSERT_NE(opticalFlowProp, properties.end());
 
     VkQueueFamilyDataGraphTOSAPropertiesARM tosaProperties = {};
     tosaProperties.sType = VK_STRUCTURE_TYPE_QUEUE_FAMILY_DATA_GRAPH_TOSA_PROPERTIES_ARM;
@@ -2072,6 +2078,84 @@ TEST_F(MLEmulationLayerForVulkan, GetPhysicalDeviceQueueFamilyDataGraphEngineOpe
     ASSERT_EQ(tosaProperties.extensionCount, 0u);
     ASSERT_EQ(tosaProperties.pExtensions, nullptr);
     ASSERT_EQ(tosaProperties.level, VK_DATA_GRAPH_TOSA_LEVEL_8K_ARM);
+
+    // Query optical flow engine operation properties
+    VkQueueFamilyDataGraphOpticalFlowPropertiesARM ofProps{};
+    ofProps.sType = VK_STRUCTURE_TYPE_QUEUE_FAMILY_DATA_GRAPH_OPTICAL_FLOW_PROPERTIES_ARM;
+
+    const auto ofResult =
+        vkPhysicalDevice.getDispatcher()->vkGetPhysicalDeviceQueueFamilyDataGraphEngineOperationPropertiesARM(
+            *vkPhysicalDevice, queueFamilyIndex, &(*opticalFlowProp), reinterpret_cast<VkBaseOutStructure *>(&ofProps));
+
+    ASSERT_EQ(ofResult, VK_SUCCESS);
+    ASSERT_GT(ofProps.supportedOutputGridSizes, 0u);
+    ASSERT_GT(ofProps.supportedHintGridSizes, 0u);
+    ASSERT_GT(ofProps.maxWidth, 0u);
+    ASSERT_GT(ofProps.maxHeight, 0u);
+}
+
+TEST_F(MLEmulationLayerForVulkan, GetPhysicalDeviceQueueFamilyDataGraphOpticalFlowImageFormatsARM) {
+    const auto device = createDevice();
+    const auto &physicalDevice = device->getPhysicalDevice();
+    const auto &vkPhysicalDevice = &(*physicalDevice);
+    const uint32_t queueFamilyIndex = physicalDevice->getComputeFamilyIndex();
+
+    // Get queue family data graph properties to find an optical flow operation
+    uint32_t count = 0;
+    vkPhysicalDevice.getDispatcher()->vkGetPhysicalDeviceQueueFamilyDataGraphPropertiesARM(
+        *vkPhysicalDevice, queueFamilyIndex, &count, nullptr);
+    ASSERT_GT(count, 0u);
+
+    std::vector<VkQueueFamilyDataGraphPropertiesARM> properties(count);
+    for (auto &p : properties) {
+        p = {};
+        p.sType = VK_STRUCTURE_TYPE_QUEUE_FAMILY_DATA_GRAPH_PROPERTIES_ARM;
+    }
+    uint32_t retrieveCount = count;
+    vkPhysicalDevice.getDispatcher()->vkGetPhysicalDeviceQueueFamilyDataGraphPropertiesARM(
+        *vkPhysicalDevice, queueFamilyIndex, &retrieveCount, properties.data());
+
+    const auto opticalFlowProp =
+        std::find_if(properties.begin(), properties.end(), [](const VkQueueFamilyDataGraphPropertiesARM &p) {
+            return p.operation.operationType == VK_PHYSICAL_DEVICE_DATA_GRAPH_OPERATION_TYPE_OPTICAL_FLOW_ARM;
+        });
+    ASSERT_NE(opticalFlowProp, properties.end());
+
+    VkDataGraphOpticalFlowImageFormatInfoARM formatInfo{};
+    formatInfo.sType = VK_STRUCTURE_TYPE_DATA_GRAPH_OPTICAL_FLOW_IMAGE_FORMAT_INFO_ARM;
+
+    // Phase 1: query input format count
+    formatInfo.usage = VK_DATA_GRAPH_OPTICAL_FLOW_IMAGE_USAGE_INPUT_BIT_ARM;
+    uint32_t inputFormatCount = 0;
+    VkResult result =
+        vkPhysicalDevice.getDispatcher()->vkGetPhysicalDeviceQueueFamilyDataGraphOpticalFlowImageFormatsARM(
+            *vkPhysicalDevice, queueFamilyIndex, &(*opticalFlowProp), &formatInfo, &inputFormatCount, nullptr);
+    ASSERT_EQ(result, VK_SUCCESS);
+    ASSERT_GT(inputFormatCount, 0u);
+
+    // Phase 2: retrieve input formats
+    std::vector<VkDataGraphOpticalFlowImageFormatPropertiesARM> inputFormats(inputFormatCount);
+    for (auto &f : inputFormats) {
+        f = {};
+        f.sType = VK_STRUCTURE_TYPE_DATA_GRAPH_OPTICAL_FLOW_IMAGE_FORMAT_PROPERTIES_ARM;
+    }
+    uint32_t retrievedInputCount = inputFormatCount;
+    result = vkPhysicalDevice.getDispatcher()->vkGetPhysicalDeviceQueueFamilyDataGraphOpticalFlowImageFormatsARM(
+        *vkPhysicalDevice, queueFamilyIndex, &(*opticalFlowProp), &formatInfo, &retrievedInputCount,
+        inputFormats.data());
+    ASSERT_EQ(result, VK_SUCCESS);
+    ASSERT_EQ(retrievedInputCount, inputFormatCount);
+    for (const auto &f : inputFormats) {
+        ASSERT_NE(f.format, VK_FORMAT_UNDEFINED);
+    }
+
+    // Query output (flow vector) formats
+    formatInfo.usage = VK_DATA_GRAPH_OPTICAL_FLOW_IMAGE_USAGE_OUTPUT_BIT_ARM;
+    uint32_t outputFormatCount = 0;
+    result = vkPhysicalDevice.getDispatcher()->vkGetPhysicalDeviceQueueFamilyDataGraphOpticalFlowImageFormatsARM(
+        *vkPhysicalDevice, queueFamilyIndex, &(*opticalFlowProp), &formatInfo, &outputFormatCount, nullptr);
+    ASSERT_EQ(result, VK_SUCCESS);
+    ASSERT_GT(outputFormatCount, 0u);
 }
 #endif
 


### PR DESCRIPTION
- Extending image type support to cover optical flow needs
- Intercept new functions for optical flow and implement them in the graph layer
- Add compute shaders for optical flow processing
- Implement BMv3.2.1
- Disable OF unit tests on Darwin due to CI instability

Change-Id: Icb38ed8db21a86dd41b446358ea14ba2252a8130