### PR TITLE
Simplify layer implementation by avoiding redundant types

### DIFF
--- a/common/include/mlel/vulkan_layer.hpp
+++ b/common/include/mlel/vulkan_layer.hpp
@@ -259,7 +259,7 @@ class Instance : public Loader {
 
 class PhysicalDevice : public Loader {
   public:
-    explicit PhysicalDevice(std::shared_ptr<Instance> _instance, VkPhysicalDevice _physicalDevice)
+    explicit PhysicalDevice(const std::shared_ptr<Instance> &_instance, VkPhysicalDevice _physicalDevice)
         : Loader(*_instance), instance{_instance}, physicalDevice{_physicalDevice} {}
 
     std::shared_ptr<Instance> instance;
@@ -272,8 +272,9 @@ class PhysicalDevice : public Loader {
 
 class Device : public Loader {
   public:
-    explicit Device(std::shared_ptr<PhysicalDevice> _physicalDevice, VkDevice _device, PFN_vkGetInstanceProcAddr _gipr,
-                    PFN_vkGetDeviceProcAddr _gdpr, const VkAllocationCallbacks *_callbacks)
+    explicit Device(const std::shared_ptr<PhysicalDevice> &_physicalDevice, VkDevice _device,
+                    PFN_vkGetInstanceProcAddr _gipr, PFN_vkGetDeviceProcAddr _gdpr,
+                    const VkAllocationCallbacks *_callbacks)
         : Loader(_callbacks, _physicalDevice->instance->instance, _gipr, _device, _gdpr),
           physicalDevice{_physicalDevice}, device{_device}, callbacks{_callbacks} {}
 
@@ -288,7 +289,8 @@ class Device : public Loader {
 
 class CommandBuffer : public Loader {
   public:
-    explicit CommandBuffer(std::shared_ptr<Device> _device, VkCommandBuffer _commandBuffer, VkCommandPool _commandPool)
+    explicit CommandBuffer(const std::shared_ptr<Device> &_device, VkCommandBuffer _commandBuffer,
+                           VkCommandPool _commandPool)
         : Loader(_device->loader), device{_device}, commandBuffer{_commandBuffer}, commandPool{_commandPool} {}
 
     virtual ~CommandBuffer() {
@@ -404,7 +406,7 @@ class DescriptorSet {
  *****************************************************************************/
 
 template <const auto &layerProperties, const auto &extensions, const auto &requiredExtensions,
-          typename InstanceImpl = Instance, typename PhysicalDeviceImpl = PhysicalDevice, typename DeviceImpl = Device>
+          typename DeviceImpl = Device>
 class VulkanLayer {
   public:
     VulkanLayer() = delete;
@@ -617,8 +619,8 @@ class VulkanLayer {
         {
             scopedMutex l(globalMutex);
             instanceMap[*instance] =
-                std::allocate_shared<InstanceImpl>(Allocator<InstanceImpl>{allocator}, *instance, getInstanceProcAddr,
-                                                   allocator, getInstanceProcAddr, getNextPhysicalDeviceProcAddr);
+                std::allocate_shared<Instance>(Allocator<Instance>{allocator}, *instance, getInstanceProcAddr,
+                                               allocator, getInstanceProcAddr, getNextPhysicalDeviceProcAddr);
         }
         return VK_SUCCESS;
     }
@@ -657,8 +659,8 @@ class VulkanLayer {
 
             if (physicalDevices != nullptr) {
                 for (uint32_t i = 0; i < *physicalDeviceCount; i++) {
-                    physicalDeviceMap[physicalDevices[i]] = std::allocate_shared<PhysicalDeviceImpl>(
-                        Allocator<PhysicalDeviceImpl>{handle->callbacks}, handle, physicalDevices[i]);
+                    physicalDeviceMap[physicalDevices[i]] = std::allocate_shared<PhysicalDevice>(
+                        Allocator<PhysicalDevice>{handle->callbacks}, handle, physicalDevices[i]);
                 }
             }
         }
@@ -1004,12 +1006,12 @@ class VulkanLayer {
     }
 
   protected:
-    static std::shared_ptr<InstanceImpl> getHandle(const VkInstance handle) {
+    static std::shared_ptr<Instance> getHandle(const VkInstance handle) {
         scopedMutex l(globalMutex);
         return instanceMap[handle];
     }
 
-    static std::shared_ptr<PhysicalDeviceImpl> getHandle(const VkPhysicalDevice handle) {
+    static std::shared_ptr<PhysicalDevice> getHandle(const VkPhysicalDevice handle) {
         scopedMutex l(globalMutex);
         return physicalDeviceMap[handle];
     }
@@ -1060,51 +1062,15 @@ class VulkanLayer {
         return nullptr;
     }
 
-    static std::recursive_mutex globalMutex;
+    static inline std::recursive_mutex globalMutex;
     using scopedMutex = std::lock_guard<std::recursive_mutex>;
 
-    static std::map<VkInstance, std::shared_ptr<InstanceImpl>> instanceMap;
-    static std::map<VkPhysicalDevice, std::shared_ptr<PhysicalDeviceImpl>> physicalDeviceMap;
-    static std::map<VkDevice, std::shared_ptr<DeviceImpl>> deviceMap;
-    static std::map<VkDescriptorSetLayout, std::shared_ptr<DescriptorSetLayout>> descriptorSetLayoutMap;
-    static std::map<VkQueue, std::shared_ptr<DeviceImpl>> queueMap;
-    static std::map<VkCommandBuffer, std::shared_ptr<CommandBuffer>> commandBufferMap;
+    static inline std::map<VkInstance, std::shared_ptr<Instance>> instanceMap;
+    static inline std::map<VkPhysicalDevice, std::shared_ptr<PhysicalDevice>> physicalDeviceMap;
+    static inline std::map<VkDevice, std::shared_ptr<DeviceImpl>> deviceMap;
+    static inline std::map<VkDescriptorSetLayout, std::shared_ptr<DescriptorSetLayout>> descriptorSetLayoutMap;
+    static inline std::map<VkQueue, std::shared_ptr<DeviceImpl>> queueMap;
+    static inline std::map<VkCommandBuffer, std::shared_ptr<CommandBuffer>> commandBufferMap;
 };
-
-template <const auto &layerProperties, const auto &extensions, const auto &requiredExtensions, typename InstanceImpl,
-          typename PhysicalDeviceImpl, typename DeviceImpl>
-std::recursive_mutex VulkanLayer<layerProperties, extensions, requiredExtensions, InstanceImpl, PhysicalDeviceImpl,
-                                 DeviceImpl>::globalMutex;
-
-template <const auto &layerProperties, const auto &extensions, const auto &requiredExtensions, typename InstanceImpl,
-          typename PhysicalDeviceImpl, typename DeviceImpl>
-std::map<VkInstance, std::shared_ptr<InstanceImpl>> VulkanLayer<
-    layerProperties, extensions, requiredExtensions, InstanceImpl, PhysicalDeviceImpl, DeviceImpl>::instanceMap;
-
-template <const auto &layerProperties, const auto &extensions, const auto &requiredExtensions, typename InstanceImpl,
-          typename PhysicalDeviceImpl, typename DeviceImpl>
-std::map<VkPhysicalDevice, std::shared_ptr<PhysicalDeviceImpl>> VulkanLayer<
-    layerProperties, extensions, requiredExtensions, InstanceImpl, PhysicalDeviceImpl, DeviceImpl>::physicalDeviceMap;
-
-template <const auto &layerProperties, const auto &extensions, const auto &requiredExtensions, typename InstanceImpl,
-          typename PhysicalDeviceImpl, typename DeviceImpl>
-std::map<VkDevice, std::shared_ptr<DeviceImpl>> VulkanLayer<layerProperties, extensions, requiredExtensions,
-                                                            InstanceImpl, PhysicalDeviceImpl, DeviceImpl>::deviceMap;
-
-template <const auto &layerProperties, const auto &extensions, const auto &requiredExtensions, typename InstanceImpl,
-          typename PhysicalDeviceImpl, typename DeviceImpl>
-std::map<VkDescriptorSetLayout, std::shared_ptr<DescriptorSetLayout>>
-    VulkanLayer<layerProperties, extensions, requiredExtensions, InstanceImpl, PhysicalDeviceImpl,
-                DeviceImpl>::descriptorSetLayoutMap;
-
-template <const auto &layerProperties, const auto &extensions, const auto &requiredExtensions, typename InstanceImpl,
-          typename PhysicalDeviceImpl, typename DeviceImpl>
-std::map<VkQueue, std::shared_ptr<DeviceImpl>> VulkanLayer<layerProperties, extensions, requiredExtensions,
-                                                           InstanceImpl, PhysicalDeviceImpl, DeviceImpl>::queueMap;
-
-template <const auto &layerProperties, const auto &extensions, const auto &requiredExtensions, typename InstanceImpl,
-          typename PhysicalDeviceImpl, typename DeviceImpl>
-std::map<VkCommandBuffer, std::shared_ptr<CommandBuffer>> VulkanLayer<
-    layerProperties, extensions, requiredExtensions, InstanceImpl, PhysicalDeviceImpl, DeviceImpl>::commandBufferMap;
 
 } // namespace mlsdk::el::layer

--- a/graph/graph_layer.cpp
+++ b/graph/graph_layer.cpp
@@ -40,28 +40,6 @@ namespace {
 constexpr char graphPipelineCreatedLog[] = "Graph pipeline created";
 }
 
-/*****************************************************************************
- * Instance
- *****************************************************************************/
-
-class GraphInstance : public Instance {
-  public:
-    explicit GraphInstance(VkInstance _instance, PFN_vkGetInstanceProcAddr _gipr,
-                           const VkAllocationCallbacks *_callbacks, PFN_vkGetInstanceProcAddr nextGetInstanceProcAddr,
-                           PFN_GetPhysicalDeviceProcAddr nextGetPhysicalDeviceProcAddr)
-        : Instance(_instance, _gipr, _callbacks, nextGetInstanceProcAddr, nextGetPhysicalDeviceProcAddr) {}
-};
-
-/*****************************************************************************
- * PhysicalDevice
- *****************************************************************************/
-
-class GraphPhysicalDevice : public PhysicalDevice {
-  public:
-    explicit GraphPhysicalDevice(const std::shared_ptr<Instance> &_instance, VkPhysicalDevice _physicalDevice)
-        : PhysicalDevice(_instance, _physicalDevice) {}
-};
-
 /**************************************************************************
  * DataGraphDescriptorSet
  **************************************************************************/
@@ -335,8 +313,7 @@ constexpr VkLayerProperties layerProperties = {
     "ML Graph Emulation Layer",
 };
 
-using VulkanLayerImpl =
-    VulkanLayer<layerProperties, extensions, requiredExtensions, Instance, PhysicalDevice, GraphDevice>;
+using VulkanLayerImpl = VulkanLayer<layerProperties, extensions, requiredExtensions, GraphDevice>;
 
 class GraphLayer : public VulkanLayerImpl {
   public:
@@ -977,18 +954,16 @@ class GraphLayer : public VulkanLayerImpl {
         auto handle = VulkanLayerImpl::getHandle(physicalDevice);
         handle->loader->vkGetPhysicalDeviceFeatures2(physicalDevice, pFeatures);
 
-        auto *pDataGraphFeatures =
-            const_cast<VkPhysicalDeviceDataGraphFeaturesARM *>(findType<VkPhysicalDeviceDataGraphFeaturesARM>(
-                pFeatures->pNext, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DATA_GRAPH_FEATURES_ARM));
+        auto *pDataGraphFeatures = findTypeMutable<VkPhysicalDeviceDataGraphFeaturesARM>(
+            pFeatures->pNext, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DATA_GRAPH_FEATURES_ARM);
         if (pDataGraphFeatures) {
             pDataGraphFeatures->dataGraph = VK_TRUE;
             pDataGraphFeatures->dataGraphUpdateAfterBind = VK_TRUE;
             pDataGraphFeatures->dataGraphShaderModule = VK_TRUE;
         }
         auto *pPipelineCreationCacheControlFeatures =
-            const_cast<VkPhysicalDevicePipelineCreationCacheControlFeatures *>(
-                findType<VkPhysicalDevicePipelineCreationCacheControlFeatures>(
-                    pFeatures->pNext, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_CREATION_CACHE_CONTROL_FEATURES));
+            findTypeMutable<VkPhysicalDevicePipelineCreationCacheControlFeatures>(
+                pFeatures->pNext, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_CREATION_CACHE_CONTROL_FEATURES);
         // Pipeline caching is currently not supported
         if (pPipelineCreationCacheControlFeatures) {
             pPipelineCreationCacheControlFeatures->pipelineCreationCacheControl = VK_FALSE;
@@ -1073,7 +1048,7 @@ class GraphLayer : public VulkanLayerImpl {
     static VkResult VKAPI_CALL vkGetDataGraphPipelineSessionBindPointRequirementsARM(
         VkDevice, const VkDataGraphPipelineSessionBindPointRequirementsInfoARM *info,
         uint32_t *bindPointRequirementCount, VkDataGraphPipelineSessionBindPointRequirementARM *bindPointRequirements) {
-        auto *const session = reinterpret_cast<DataGraphPipelineSessionARM *>(info->session);
+        const auto *const session = reinterpret_cast<DataGraphPipelineSessionARM *>(info->session);
 
         const auto needsTransient = session->needsTransientRequirements();
         const auto needsOpticalFlowCache = session->needsOpticalFlowCacheRequirements();
@@ -1123,7 +1098,7 @@ class GraphLayer : public VulkanLayerImpl {
     static void VKAPI_CALL vkGetDataGraphPipelineSessionMemoryRequirementsARM(
         VkDevice, const VkDataGraphPipelineSessionMemoryRequirementsInfoARM *info,
         VkMemoryRequirements2 *requirements) {
-        auto *const session = reinterpret_cast<DataGraphPipelineSessionARM *>(info->session);
+        const auto *const session = reinterpret_cast<DataGraphPipelineSessionARM *>(info->session);
 
         // Calculate how much memory pipelines hidden layers require
         requirements->memoryRequirements = session->getGraphPipelineMemoryRequirements(info->bindPoint);
@@ -1465,13 +1440,13 @@ class GraphLayer : public VulkanLayerImpl {
                                                      VkDataGraphPipelineSessionARM _session,
                                                      const VkDataGraphPipelineDispatchInfoARM *pInfo) {
         auto handle = VulkanLayerImpl::getHandle(commandBuffer);
-        auto *session = reinterpret_cast<DataGraphPipelineSessionARM *>(_session);
-        auto pipeline = session->pipeline;
+        const auto *session = reinterpret_cast<DataGraphPipelineSessionARM *>(_session);
+        const auto &pipeline = session->pipeline;
         auto *vkPipeline = reinterpret_cast<VkPipeline>(pipeline.get());
         auto deviceHandle = VulkanLayerImpl::getHandle(handle->device->device);
 
         if (pipeline->isGraph()) {
-            auto graphPipeline = pipeline->graphPipeline;
+            const auto &graphPipeline = pipeline->graphPipeline;
             /*
              * Merge descriptor sets, they can have three different origins:
              * - Constants owned by the pipeline
@@ -1629,7 +1604,7 @@ class GraphLayer : public VulkanLayerImpl {
             return VK_ERROR_UNKNOWN;
         }
         if (isGraph.value()) {
-            std::shared_ptr<ShaderModule> shaderModule = std::make_shared<ShaderModule>(pCreateInfo);
+            auto shaderModule = std::make_shared<ShaderModule>(pCreateInfo);
             *pShaderModule = reinterpret_cast<VkShaderModule>(shaderModule.get());
             {
                 scopedMutex l(globalMutex);

--- a/tensor/tensor_layer.cpp
+++ b/tensor/tensor_layer.cpp
@@ -29,28 +29,6 @@ using namespace mlsdk::el::log;
 namespace mlsdk::el::layer {
 
 /*******************************************************************************
- * Instance
- *******************************************************************************/
-
-class TensorInstance : public Instance {
-  public:
-    TensorInstance(VkInstance instance, PFN_vkGetInstanceProcAddr gipr, const VkAllocationCallbacks *callbacks,
-                   PFN_vkGetInstanceProcAddr nextGetInstanceProcAddr,
-                   PFN_GetPhysicalDeviceProcAddr nextGetPhysicalDeviceProcAddr)
-        : Instance(instance, gipr, callbacks, nextGetInstanceProcAddr, nextGetPhysicalDeviceProcAddr) {}
-};
-
-/*******************************************************************************
- * PhysicalDevice
- *******************************************************************************/
-
-class TensorPhysicalDevice : public PhysicalDevice {
-  public:
-    TensorPhysicalDevice(const std::shared_ptr<Instance> &_instance, VkPhysicalDevice _physicalDevice)
-        : PhysicalDevice(_instance, _physicalDevice) {}
-};
-
-/*******************************************************************************
  * Device
  *******************************************************************************/
 
@@ -60,16 +38,6 @@ class TensorDevice : public Device {
                  PFN_vkGetInstanceProcAddr _gipr, PFN_vkGetDeviceProcAddr _gdpr,
                  const VkAllocationCallbacks *_callbacks)
         : Device(_physicalDevice, _device, _gipr, _gdpr, _callbacks) {}
-};
-
-/*******************************************************************************
- * DeviceMemory
- *******************************************************************************/
-
-class DeviceMemory {
-  public:
-    VkImage boundImage = VK_NULL_HANDLE;
-    VkTensorARM boundTensor = VK_NULL_HANDLE;
 };
 
 /*******************************************************************************
@@ -143,8 +111,7 @@ constexpr VkLayerProperties layerProperties = {
     "ML Tensor Emulation Layer",
 };
 
-using VulkanLayerImpl =
-    VulkanLayer<layerProperties, extensions, requiredExtensions, TensorInstance, TensorPhysicalDevice, TensorDevice>;
+using VulkanLayerImpl = VulkanLayer<layerProperties, extensions, requiredExtensions, TensorDevice>;
 
 class TensorLayer : public VulkanLayerImpl {
   public:
@@ -812,8 +779,8 @@ class TensorLayer : public VulkanLayerImpl {
     static void VKAPI_CALL vkGetPhysicalDeviceFormatProperties2(VkPhysicalDevice physicalDevice, VkFormat format,
                                                                 VkFormatProperties2 *pFormatProperties) {
         auto handle = VulkanLayerImpl::getHandle(physicalDevice);
-        auto *pTensorFormatProp = const_cast<VkTensorFormatPropertiesARM *>(findType<VkTensorFormatPropertiesARM>(
-            pFormatProperties->pNext, VK_STRUCTURE_TYPE_TENSOR_FORMAT_PROPERTIES_ARM));
+        auto *pTensorFormatProp = findTypeMutable<VkTensorFormatPropertiesARM>(
+            pFormatProperties->pNext, VK_STRUCTURE_TYPE_TENSOR_FORMAT_PROPERTIES_ARM);
         handle->loader->vkGetPhysicalDeviceFormatProperties2(physicalDevice, format, pFormatProperties);
         if (pTensorFormatProp) {
             pTensorFormatProp->optimalTilingTensorFeatures =
@@ -826,9 +793,8 @@ class TensorLayer : public VulkanLayerImpl {
     static void VKAPI_CALL vkGetPhysicalDeviceFeatures2(VkPhysicalDevice physicalDevice,
                                                         VkPhysicalDeviceFeatures2 *pFeatures) {
         auto handle = VulkanLayerImpl::getHandle(physicalDevice);
-        auto *pTensorFeatures =
-            const_cast<VkPhysicalDeviceTensorFeaturesARM *>(findType<VkPhysicalDeviceTensorFeaturesARM>(
-                pFeatures->pNext, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TENSOR_FEATURES_ARM));
+        auto *pTensorFeatures = findTypeMutable<VkPhysicalDeviceTensorFeaturesARM>(
+            pFeatures->pNext, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TENSOR_FEATURES_ARM);
         handle->loader->vkGetPhysicalDeviceFeatures2(physicalDevice, pFeatures);
         if (pTensorFeatures) {
             // query buffer feature


### PR DESCRIPTION
Use base Instance and PhysicalDevice classes.
Find mutable structs in pNext chains instead of const_cast. Use const for pointers and references where possible.

Change-Id: Ibc55b71c43658048104ae8fadd7108e70e646a15