### PR TITLE
Make paremeters const where applicable

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -31,6 +31,7 @@ Checks: >
     performance-trivially-destructible,
     performance-type-promotion-in-math-fn,
     performance-unnecessary-copy-initialization,
+    performance-unnecessary-value-param,
     readability-avoid-const-params-in-decls,
     readability-braces-around-statements,
     readability-const-return-type,

--- a/graph/compute_optical_flow.cpp
+++ b/graph/compute_optical_flow.cpp
@@ -261,31 +261,25 @@ void ComputePipeline::dispatchPipeline(VkCommandBuffer cmdBuf) {
 
 RGBToY::RGBToY(const std::shared_ptr<VULKAN_HPP_NAMESPACE::detail::DispatchLoaderDynamic> &loader,
                const VkDevice device, const std::shared_ptr<PipelineCache> &pipelineCache,
-               std::shared_ptr<Image> srcRGBImage, std::shared_ptr<Image> dstDownsampledImage,
+               std::shared_ptr<Image> srcRGBImage, const std::shared_ptr<Image> &dstDownsampledImage,
                std::shared_ptr<Image> dstFullImage, bool outputDownsample, bool outputFullRes, float downsampleScale,
                const std::string &debugName)
     : ComputePipeline(loader, device, pipelineCache, shaderName, descriptorConfigs_,
                       {&specConstants_, sizeof(specConstants_)}, 0,
                       {dstDownsampledImage->width(), dstDownsampledImage->height()}, debugName),
-      srcImage_(srcRGBImage), dstYDownsampled_(dstDownsampledImage), dstYFull_(dstFullImage),
-      outputDS_(outputDownsample), outputFull_(outputFullRes),
-      scale_(downsampleScale), specConstants_{makeSpecConstants(srcRGBImage, dstDownsampledImage, dstFullImage,
-                                                                outputDownsample, outputFullRes, scale_)},
+      srcImage_(std::move(srcRGBImage)), dstYDownsampled_(dstDownsampledImage), dstYFull_(std::move(dstFullImage)),
+      outputDS_(outputDownsample), outputFull_(outputFullRes), specConstants_{makeSpecConstants(downsampleScale)},
       linearSampler_{createSampler(VK_FILTER_LINEAR, VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE)} {}
 
-RGBToY::SpecConstants RGBToY::makeSpecConstants(const std::shared_ptr<Image> &srcRGBImage,
-                                                const std::shared_ptr<Image> &dstDownsampledImage,
-                                                const std::shared_ptr<Image> &dstFullImage, bool outputDownsample,
-                                                bool outputFullRes, float downsampleScale) const {
-    VkBool32 isLumaInput = srcRGBImage->componentCount() == 1;
+RGBToY::SpecConstants RGBToY::makeSpecConstants(float downsampleScale) const {
+    VkBool32 isLumaInput = srcImage_->componentCount() == 1;
     VkBool32 isImageStore = true;
-    if (outputDownsample) {
-        isImageStore = dstDownsampledImage->isImageStore() == true;
-    } else if (outputFullRes) {
-        isImageStore = dstFullImage->isImageStore() == true;
+    if (outputDS_) {
+        isImageStore = dstYDownsampled_->isImageStore() == true;
+    } else if (outputFull_) {
+        isImageStore = dstYFull_->isImageStore() == true;
     }
-    assert((outputDownsample & outputFullRes) ? dstFullImage->isImageStore() == dstDownsampledImage->isImageStore()
-                                              : true);
+    assert((outputDS_ & outputFull_) ? dstYFull_->isImageStore() == dstYDownsampled_->isImageStore() : true);
 
     SpecConstants specConstants = {
         32,
@@ -293,17 +287,17 @@ RGBToY::SpecConstants RGBToY::makeSpecConstants(const std::shared_ptr<Image> &sr
         1,
         1,
         isLumaInput,
-        outputDownsample,
-        outputFullRes,
+        outputDS_,
+        outputFull_,
         isImageStore,
         downsampleScale,
         downsampleScale,
-        outputDownsample ? dstDownsampledImage->width() : 1,
-        outputDownsample ? dstDownsampledImage->height() : 1,
-        outputDownsample ? dstDownsampledImage->stride() : 1,
-        outputFullRes ? dstFullImage->width() : 1,
-        outputFullRes ? dstFullImage->height() : 1,
-        outputFullRes ? dstFullImage->stride() : 1,
+        outputDS_ ? dstYDownsampled_->width() : 1,
+        outputDS_ ? dstYDownsampled_->height() : 1,
+        outputDS_ ? dstYDownsampled_->stride() : 1,
+        outputFull_ ? dstYFull_->width() : 1,
+        outputFull_ ? dstYFull_->height() : 1,
+        outputFull_ ? dstYFull_->stride() : 1,
     };
     return specConstants;
 }
@@ -332,25 +326,24 @@ void RGBToY::bindAndDispatch(VkCommandBuffer cmdBuf) {
 
 Downsample::Downsample(const std::shared_ptr<VULKAN_HPP_NAMESPACE::detail::DispatchLoaderDynamic> &loader,
                        const VkDevice device, const std::shared_ptr<PipelineCache> &pipelineCache,
-                       std::shared_ptr<Image> src, std::shared_ptr<Image> dst, const std::string &debugName)
+                       std::shared_ptr<Image> src, const std::shared_ptr<Image> &dst, const std::string &debugName)
     : ComputePipeline(loader, device, pipelineCache, shaderName, descriptorConfigs_,
                       {&specConstants_, sizeof(specConstants_)}, 0, {dst->width(), dst->height()}, debugName),
-      srcImage_(src), dstImage_(dst), specConstants_{makeSpecConstants(src, dst)},
+      srcImage_(std::move(src)), dstImage_(dst), specConstants_{makeSpecConstants()},
       linearSampler_{createSampler(VK_FILTER_LINEAR, VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE)} {}
 
-Downsample::SpecConstants Downsample::makeSpecConstants(const std::shared_ptr<Image> &src,
-                                                        const std::shared_ptr<Image> &dst) const {
+Downsample::SpecConstants Downsample::makeSpecConstants() const {
     SpecConstants specConstants = {
         32,
         8,
         1,
         1,
-        dst->isImageStore(),
-        src->width() != dst->width() * 2,
-        src->height() != dst->height() * 2,
-        dst->width(),
-        dst->height(),
-        dst->stride(),
+        dstImage_->isImageStore(),
+        srcImage_->width() != dstImage_->width() * 2,
+        srcImage_->height() != dstImage_->height() * 2,
+        dstImage_->width(),
+        dstImage_->height(),
+        dstImage_->stride(),
     };
     return specConstants;
 }
@@ -370,30 +363,29 @@ void Downsample::bindAndDispatch(VkCommandBuffer cmdBuf) {
 MVProcessAndWarp::MVProcessAndWarp(const std::shared_ptr<VULKAN_HPP_NAMESPACE::detail::DispatchLoaderDynamic> &loader,
                                    const VkDevice device, const std::shared_ptr<PipelineCache> &pipelineCache,
                                    std::shared_ptr<Image> srcImage, std::shared_ptr<Image> srcFlow,
-                                   std::shared_ptr<Image> dstImage, std::shared_ptr<Image> dstFlow,
+                                   const std::shared_ptr<Image> &dstImage, std::shared_ptr<Image> dstFlow,
                                    const std::string &debugName)
     : ComputePipeline(loader, device, pipelineCache, shaderName, descriptorConfigs_,
                       {&specConstants_, sizeof(specConstants_)}, 0, {dstImage->width(), dstImage->height()}, debugName),
-      srcSearch_(srcImage), srcFlow_(srcFlow), dstWarped_(dstImage),
-      dstFlow_(dstFlow), specConstants_{makeSpecConstants(dstImage, dstFlow)},
+      srcSearch_(std::move(srcImage)), srcFlow_(std::move(srcFlow)), dstWarped_(dstImage),
+      dstFlow_(std::move(dstFlow)), specConstants_{makeSpecConstants()},
       linearSampler_{createSampler(VK_FILTER_LINEAR, VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE)} {}
 
-MVProcessAndWarp::SpecConstants MVProcessAndWarp::makeSpecConstants(const std::shared_ptr<Image> &dstImage,
-                                                                    const std::shared_ptr<Image> &dstFlow) const {
+MVProcessAndWarp::SpecConstants MVProcessAndWarp::makeSpecConstants() const {
     SpecConstants specConstants = {
         32,
         8,
         1,
         1,
-        dstImage->isImageStore(),
+        dstWarped_->isImageStore(),
         2.0f,
         2.0f,
         0.5f,
         0.5f,
-        dstFlow->width(),
-        dstFlow->height(),
-        dstImage->stride(),
-        dstFlow->stride(),
+        dstFlow_->width(),
+        dstFlow_->height(),
+        dstWarped_->stride(),
+        dstFlow_->stride(),
     };
     return specConstants;
 }
@@ -414,27 +406,26 @@ void MVProcessAndWarp::bindAndDispatch(VkCommandBuffer cmdBuf) {
 
 DenseWarp::DenseWarp(const std::shared_ptr<VULKAN_HPP_NAMESPACE::detail::DispatchLoaderDynamic> &loader,
                      const VkDevice device, const std::shared_ptr<PipelineCache> &pipelineCache,
-                     std::shared_ptr<Image> srcImage, std::shared_ptr<Image> srcFlow, std::shared_ptr<Image> dstImage,
-                     float inputFlowScale, const std::string &debugName)
+                     std::shared_ptr<Image> srcImage, std::shared_ptr<Image> srcFlow,
+                     const std::shared_ptr<Image> &dstImage, float inputFlowScale, const std::string &debugName)
     : ComputePipeline(loader, device, pipelineCache, shaderName, descriptorConfigs_,
                       {&specConstants_, sizeof(specConstants_)}, 0, {dstImage->width(), dstImage->height()}, debugName),
-      srcSearch_(srcImage), srcFlow_(srcFlow),
-      dstWarped_(dstImage), specConstants_{makeSpecConstants(dstImage, inputFlowScale)},
+      srcSearch_(std::move(srcImage)), srcFlow_(std::move(srcFlow)),
+      dstWarped_(dstImage), specConstants_{makeSpecConstants(inputFlowScale)},
       linearSampler_{createSampler(VK_FILTER_LINEAR, VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE)},
       nearestSampler_{createSampler(VK_FILTER_NEAREST, VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE)} {}
 
-DenseWarp::SpecConstants DenseWarp::makeSpecConstants(const std::shared_ptr<Image> &dstImage,
-                                                      float inputFlowScale) const {
+DenseWarp::SpecConstants DenseWarp::makeSpecConstants(float inputFlowScale) const {
     SpecConstants specConstants = {
         32,
         8,
         1,
         1,
-        dstImage->isImageStore(),
+        dstWarped_->isImageStore(),
         inputFlowScale,
-        dstImage->width(),
-        dstImage->height(),
-        dstImage->stride(),
+        dstWarped_->width(),
+        dstWarped_->height(),
+        dstWarped_->stride(),
     };
     return specConstants;
 }
@@ -459,25 +450,24 @@ void DenseWarp::bindAndDispatch(VkCommandBuffer cmdBuf) {
 
 MedianFilter::MedianFilter(const std::shared_ptr<VULKAN_HPP_NAMESPACE::detail::DispatchLoaderDynamic> &loader,
                            const VkDevice device, const std::shared_ptr<PipelineCache> &pipelineCache,
-                           std::shared_ptr<Image> srcImage, std::shared_ptr<Image> dstImage, float outputFlowScale,
-                           const std::string &debugName)
+                           std::shared_ptr<Image> srcImage, const std::shared_ptr<Image> &dstImage,
+                           float outputFlowScale, const std::string &debugName)
     : ComputePipeline(loader, device, pipelineCache, shaderName, descriptorConfigs_,
                       {&specConstants_, sizeof(specConstants_)}, 0, {dstImage->width(), dstImage->height()}, debugName),
-      srcFlow_(srcImage), dstFlow_(dstImage), specConstants_{makeSpecConstants(dstImage, outputFlowScale)},
+      srcFlow_(std::move(srcImage)), dstFlow_(dstImage), specConstants_{makeSpecConstants(outputFlowScale)},
       nearestSampler_{createSampler(VK_FILTER_NEAREST, VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE)} {}
 
-MedianFilter::SpecConstants MedianFilter::makeSpecConstants(const std::shared_ptr<Image> &dstImage,
-                                                            float outputFlowScale) const {
+MedianFilter::SpecConstants MedianFilter::makeSpecConstants(float outputFlowScale) const {
     SpecConstants specConstants = {
         32,
         8,
         1,
         1,
-        dstImage->isImageStore(),
+        dstFlow_->isImageStore(),
         outputFlowScale,
-        dstImage->width(),
-        dstImage->height(),
-        dstImage->stride(),
+        dstFlow_->width(),
+        dstFlow_->height(),
+        dstFlow_->stride(),
     };
     return specConstants;
 }
@@ -502,17 +492,25 @@ void MedianFilter::bindAndDispatch(VkCommandBuffer cmdBuf) {
 BilateralFilter::BilateralFilter(const std::shared_ptr<VULKAN_HPP_NAMESPACE::detail::DispatchLoaderDynamic> &loader,
                                  const VkDevice device, const std::shared_ptr<PipelineCache> &pipelineCache,
                                  std::shared_ptr<Image> srcImage, std::shared_ptr<Image> srcFlow,
-                                 std::shared_ptr<Image> dstFlow, float outputFlowScale, const std::string &debugName)
+                                 const std::shared_ptr<Image> &dstFlow, float outputFlowScale,
+                                 const std::string &debugName)
     : ComputePipeline(loader, device, pipelineCache, shaderName, descriptorConfigs_,
                       {&specConstants_, sizeof(specConstants_)}, 0, {dstFlow->width(), dstFlow->height()}, debugName),
-      srcTemplate_(srcImage), srcFlow_(srcFlow),
-      dstFlow_(dstFlow), specConstants_{makeSpecConstants(dstFlow, outputFlowScale)},
+      srcTemplate_(std::move(srcImage)), srcFlow_(std::move(srcFlow)),
+      dstFlow_(dstFlow), specConstants_{makeSpecConstants(outputFlowScale)},
       nearestSampler_{createSampler(VK_FILTER_NEAREST, VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE)} {}
 
-BilateralFilter::SpecConstants BilateralFilter::makeSpecConstants(const std::shared_ptr<Image> &dstFlow,
-                                                                  float outputFlowScale) const {
+BilateralFilter::SpecConstants BilateralFilter::makeSpecConstants(float outputFlowScale) const {
     SpecConstants specConstants = {
-        32, 8, 1, 1, dstFlow->isImageStore(), outputFlowScale, dstFlow->width(), dstFlow->height(), dstFlow->stride(),
+        32,
+        8,
+        1,
+        1,
+        dstFlow_->isImageStore(),
+        outputFlowScale,
+        dstFlow_->width(),
+        dstFlow_->height(),
+        dstFlow_->stride(),
     };
     return specConstants;
 }
@@ -539,31 +537,28 @@ SubpixelME::SubpixelME(const std::shared_ptr<VULKAN_HPP_NAMESPACE::detail::Dispa
                        const VkDevice device, const std::shared_ptr<PipelineCache> &pipelineCache,
                        std::shared_ptr<Image> srcImageSearch, std::shared_ptr<Image> srcImageTemplate,
                        std::shared_ptr<Image> srcFlow, std::shared_ptr<Image> prevLevelFlow,
-                       std::shared_ptr<Image> dstFlow, bool doAccumulate, const std::string &debugName)
+                       const std::shared_ptr<Image> &dstFlow, bool doAccumulate, const std::string &debugName)
     : ComputePipeline(loader, device, pipelineCache, shaderName, descriptorConfigs_,
                       {&specConstants_, sizeof(specConstants_)}, 0, {dstFlow->width(), dstFlow->height()}, debugName),
-      srcSearch_(srcImageSearch), srcTemplate_(srcImageTemplate), srcFlow_(srcFlow), srcPrevLevelFlow_(prevLevelFlow),
-      dstFlow_(dstFlow), specConstants_{makeSpecConstants(srcFlow, prevLevelFlow, dstFlow, doAccumulate)},
+      srcSearch_(std::move(srcImageSearch)), srcTemplate_(std::move(srcImageTemplate)), srcFlow_(std::move(srcFlow)),
+      srcPrevLevelFlow_(std::move(prevLevelFlow)), dstFlow_(dstFlow), specConstants_{makeSpecConstants(doAccumulate)},
       nearestZeroPadSampler_{createSampler(VK_FILTER_NEAREST, VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER)},
       nearestRepeatPadSampler_{createSampler(VK_FILTER_NEAREST, VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE)} {}
 
-SubpixelME::SpecConstants SubpixelME::makeSpecConstants(const std::shared_ptr<Image> &srcFlow,
-                                                        const std::shared_ptr<Image> &prevLevelFlow,
-                                                        const std::shared_ptr<Image> &dstFlow,
-                                                        bool doAccumulate) const {
+SubpixelME::SpecConstants SubpixelME::makeSpecConstants(bool doAccumulate) const {
     SpecConstants specConstants = {
         32,
         8,
         1,
         1,
         doAccumulate,
-        doAccumulate ? prevLevelFlow->isBufferLoad() : false,
-        dstFlow->isImageStore(),
-        dstFlow->width(),
-        dstFlow->height(),
-        srcFlow->stride(),
-        doAccumulate ? prevLevelFlow->stride() : 1,
-        dstFlow->stride(),
+        doAccumulate ? srcPrevLevelFlow_->isBufferLoad() : false,
+        dstFlow_->isImageStore(),
+        dstFlow_->width(),
+        dstFlow_->height(),
+        srcFlow_->stride(),
+        doAccumulate ? srcPrevLevelFlow_->stride() : 1,
+        dstFlow_->stride(),
     };
     return specConstants;
 }
@@ -592,31 +587,29 @@ MVReplace::MVReplace(const std::shared_ptr<VULKAN_HPP_NAMESPACE::detail::Dispatc
                      const VkDevice device, const std::shared_ptr<PipelineCache> &pipelineCache,
                      std::shared_ptr<Image> mvInput, std::shared_ptr<Image> flowBlockMatch,
                      std::shared_ptr<Image> costAtInput, std::shared_ptr<Image> minCostBlockMatch,
-                     std::shared_ptr<Image> dstFlow, std::shared_ptr<Image> dstCost, bool outputCost,
+                     const std::shared_ptr<Image> &dstFlow, std::shared_ptr<Image> dstCost, bool outputCost,
                      const std::string &debugName)
     : ComputePipeline(loader, device, pipelineCache, shaderName, descriptorConfigs_,
                       {&specConstants_, sizeof(specConstants_)}, 0, {dstFlow->width(), dstFlow->height()}, debugName),
-      srcInputMV_(mvInput), srcBlockMatchFlow_(flowBlockMatch), srcInputMVCost_(costAtInput),
-      srcBlockMatchCost_(minCostBlockMatch), dstFlow_(dstFlow), dstCost_(dstCost),
-      outputCost_(outputCost), specConstants_{makeSpecConstants(costAtInput, dstFlow, dstCost, outputCost)},
+      srcInputMV_(std::move(mvInput)), srcBlockMatchFlow_(std::move(flowBlockMatch)),
+      srcInputMVCost_(std::move(costAtInput)), srcBlockMatchCost_(std::move(minCostBlockMatch)), dstFlow_(dstFlow),
+      dstCost_(std::move(dstCost)), outputCost_(outputCost), specConstants_{makeSpecConstants()},
       nearestSampler_{createSampler(VK_FILTER_NEAREST, VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE)} {}
 
-MVReplace::SpecConstants MVReplace::makeSpecConstants(const std::shared_ptr<Image> &costAtInput,
-                                                      const std::shared_ptr<Image> &dstFlow,
-                                                      const std::shared_ptr<Image> &dstCost, bool outputCost) const {
+MVReplace::SpecConstants MVReplace::makeSpecConstants() const {
     SpecConstants specConstants = {
         32,
         8,
         1,
         1,
-        outputCost,
-        costAtInput->isBufferLoad(),
-        dstFlow->isImageStore(),
-        dstFlow->width(),
-        dstFlow->height(),
-        costAtInput->stride(),
-        dstFlow->stride(),
-        outputCost ? dstCost->stride() : 1,
+        outputCost_,
+        srcInputMVCost_->isBufferLoad(),
+        dstFlow_->isImageStore(),
+        dstFlow_->width(),
+        dstFlow_->height(),
+        srcInputMVCost_->stride(),
+        dstFlow_->stride(),
+        outputCost_ ? dstCost_->stride() : 1,
     };
     return specConstants;
 }
@@ -657,16 +650,15 @@ void MVReplace::bindAndDispatch(VkCommandBuffer cmdBuf) {
 
 BlockMatch::BlockMatch(const std::shared_ptr<VULKAN_HPP_NAMESPACE::detail::DispatchLoaderDynamic> &loader,
                        const VkDevice device, const std::shared_ptr<PipelineCache> &pipelineCache,
-                       SearchType searchType, int32_t maxSearchRange, std::shared_ptr<Image> srcSearch,
+                       SearchType searchType, int32_t maxSearchRange, const std::shared_ptr<Image> &srcSearch,
                        std::shared_ptr<Image> srcTemplate, std::shared_ptr<Image> dstFlow,
                        std::shared_ptr<Image> dstCost, const std::string &debugName)
     : ComputePipeline(loader, device, pipelineCache, shaderName, descriptorConfigs_,
                       {&specConstants_, sizeof(specConstants_)}, sizeof(PushConstants),
                       {srcSearch->width(), srcSearch->height()}, debugName),
-      srcSearch_(srcSearch), srcTemplate_(srcTemplate), dstFlow_(dstFlow), dstCost_(dstCost), searchType_(searchType),
-      maxSearchRange_(maxSearchRange),
-      searchRangeLimit_(maxSearchRange), specConstants_{makeSpecConstants(searchType_, maxSearchRange_, dstFlow_,
-                                                                          dstCost_)},
+      srcSearch_(srcSearch), srcTemplate_(std::move(srcTemplate)), dstFlow_(std::move(dstFlow)),
+      dstCost_(std::move(dstCost)), searchType_(searchType), maxSearchRange_(maxSearchRange),
+      searchRangeLimit_(maxSearchRange), specConstants_{makeSpecConstants()},
       nearestSampler_{createSampler(VK_FILTER_NEAREST, VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER)} {
     // MIN_SAD* assumes maxSearchRange > 0
     assert(!(searchType_ != SearchType::RAW_SAD && maxSearchRange_ == 0));
@@ -674,21 +666,19 @@ BlockMatch::BlockMatch(const std::shared_ptr<VULKAN_HPP_NAMESPACE::detail::Dispa
     assert(!(searchType_ == SearchType::RAW_SAD && maxSearchRange_ != 0));
 }
 
-BlockMatch::SpecConstants BlockMatch::makeSpecConstants(SearchType searchType, int32_t maxSearchRange,
-                                                        const std::shared_ptr<Image> &dstFlow,
-                                                        const std::shared_ptr<Image> &dstCost) const {
+BlockMatch::SpecConstants BlockMatch::makeSpecConstants() const {
     SpecConstants specConstants = {
         32,
         8,
         1,
         1,
-        static_cast<int32_t>(searchType),
-        maxSearchRange,
-        hasFlowOutput() ? dstFlow->width() : dstCost->width(),
-        hasFlowOutput() ? dstFlow->height() : dstCost->height(),
-        hasFlowOutput() ? dstFlow->stride() : 0,
-        hasCostOutput() ? dstCost->stride() : 0,
-        hasCostOutput() && dstCost->isImageStore(),
+        static_cast<int32_t>(searchType_),
+        maxSearchRange_,
+        hasFlowOutput() ? dstFlow_->width() : dstCost_->width(),
+        hasFlowOutput() ? dstFlow_->height() : dstCost_->height(),
+        hasFlowOutput() ? dstFlow_->stride() : 0,
+        hasCostOutput() ? dstCost_->stride() : 0,
+        hasCostOutput() && dstCost_->isImageStore(),
     };
     return specConstants;
 }

--- a/graph/compute_optical_flow.hpp
+++ b/graph/compute_optical_flow.hpp
@@ -120,8 +120,8 @@ class RGBToY : public ComputePipeline {
   public:
     RGBToY(const std::shared_ptr<VULKAN_HPP_NAMESPACE::detail::DispatchLoaderDynamic> &loader, VkDevice device,
            const std::shared_ptr<PipelineCache> &pipelineCache, std::shared_ptr<Image> srcRGBImage,
-           std::shared_ptr<Image> dstDownsampledImage, std::shared_ptr<Image> dstFullImage, bool outputDownsample,
-           bool outputFullRes, float downsampleScale, const std::string &debugName);
+           const std::shared_ptr<Image> &dstDownsampledImage, std::shared_ptr<Image> dstFullImage,
+           bool outputDownsample, bool outputFullRes, float downsampleScale, const std::string &debugName);
     ~RGBToY() override = default;
 
     struct SpecConstants {
@@ -143,10 +143,7 @@ class RGBToY : public ComputePipeline {
         uint32_t fullImageStride;
     };
 
-    SpecConstants makeSpecConstants(const std::shared_ptr<Image> &srcRGBImage,
-                                    const std::shared_ptr<Image> &dstDownsampledImage,
-                                    const std::shared_ptr<Image> &dstFullImage, bool outputDownsample,
-                                    bool outputFullRes, float downsampleScale) const;
+    SpecConstants makeSpecConstants(float downsampleScale) const;
     void setInput(std::shared_ptr<Image> src);
     void bindAndDispatch(VkCommandBuffer cmdBuf) override;
 
@@ -157,7 +154,6 @@ class RGBToY : public ComputePipeline {
     std::shared_ptr<Image> dstYFull_;
     bool outputDS_;
     bool outputFull_;
-    float scale_ = 1.f;
     SpecConstants specConstants_;
     VkSampler linearSampler_;
 
@@ -178,7 +174,7 @@ class Downsample : public ComputePipeline {
   public:
     Downsample(const std::shared_ptr<VULKAN_HPP_NAMESPACE::detail::DispatchLoaderDynamic> &loader, VkDevice device,
                const std::shared_ptr<PipelineCache> &pipelineCache, std::shared_ptr<Image> src,
-               std::shared_ptr<Image> dst, const std::string &debugName);
+               const std::shared_ptr<Image> &dst, const std::string &debugName);
     ~Downsample() override = default;
 
     struct SpecConstants {
@@ -194,8 +190,7 @@ class Downsample : public ComputePipeline {
         uint32_t outputImageStride;
     };
 
-    SpecConstants makeSpecConstants(const std::shared_ptr<Image> &srcImage,
-                                    const std::shared_ptr<Image> &dstImage) const;
+    SpecConstants makeSpecConstants() const;
 
     void bindAndDispatch(VkCommandBuffer cmdBuf) override;
 
@@ -221,8 +216,9 @@ class MVProcessAndWarp : public ComputePipeline {
   public:
     MVProcessAndWarp(const std::shared_ptr<VULKAN_HPP_NAMESPACE::detail::DispatchLoaderDynamic> &loader,
                      VkDevice device, const std::shared_ptr<PipelineCache> &pipelineCache,
-                     std::shared_ptr<Image> srcImage, std::shared_ptr<Image> _srcFlow, std::shared_ptr<Image> dstImage,
-                     std::shared_ptr<Image> _dstFlow, const std::string &debugName);
+                     std::shared_ptr<Image> srcImage, std::shared_ptr<Image> _srcFlow,
+                     const std::shared_ptr<Image> &dstImage, std::shared_ptr<Image> _dstFlow,
+                     const std::string &debugName);
     ~MVProcessAndWarp() override = default;
 
     struct SpecConstants {
@@ -241,8 +237,7 @@ class MVProcessAndWarp : public ComputePipeline {
         uint32_t outputFlowStride;
     };
 
-    SpecConstants makeSpecConstants(const std::shared_ptr<Image> &dstImage,
-                                    const std::shared_ptr<Image> &dstFlow) const;
+    SpecConstants makeSpecConstants() const;
     void bindAndDispatch(VkCommandBuffer cmdBuf) override;
 
   private:
@@ -272,7 +267,7 @@ class DenseWarp : public ComputePipeline {
   public:
     DenseWarp(const std::shared_ptr<VULKAN_HPP_NAMESPACE::detail::DispatchLoaderDynamic> &loader, VkDevice device,
               const std::shared_ptr<PipelineCache> &pipelineCache, std::shared_ptr<Image> srcImage,
-              std::shared_ptr<Image> _srcFlow, std::shared_ptr<Image> dstImage, float inputFlowScale,
+              std::shared_ptr<Image> _srcFlow, const std::shared_ptr<Image> &dstImage, float inputFlowScale,
               const std::string &debugName);
     ~DenseWarp() override = default;
 
@@ -288,7 +283,7 @@ class DenseWarp : public ComputePipeline {
         uint32_t outputImageStride;
     };
 
-    SpecConstants makeSpecConstants(const std::shared_ptr<Image> &dstImage, float inputFlowScale) const;
+    SpecConstants makeSpecConstants(float inputFlowScale) const;
 
     void setInputFlow(std::shared_ptr<Image> _srcFlow);
 
@@ -319,7 +314,7 @@ class MedianFilter : public ComputePipeline {
   public:
     MedianFilter(const std::shared_ptr<VULKAN_HPP_NAMESPACE::detail::DispatchLoaderDynamic> &loader, VkDevice device,
                  const std::shared_ptr<PipelineCache> &pipelineCache, std::shared_ptr<Image> srcImage,
-                 std::shared_ptr<Image> dstImage, float outputFlowScale, const std::string &debugName);
+                 const std::shared_ptr<Image> &dstImage, float outputFlowScale, const std::string &debugName);
     ~MedianFilter() override = default;
 
     struct SpecConstants {
@@ -334,7 +329,7 @@ class MedianFilter : public ComputePipeline {
         uint32_t outputImageStride;
     };
 
-    SpecConstants makeSpecConstants(const std::shared_ptr<Image> &dstImage, float outputFlowScale) const;
+    SpecConstants makeSpecConstants(float outputFlowScale) const;
 
     void setOutput(std::shared_ptr<Image> dstImage);
     void bindAndDispatch(VkCommandBuffer cmdBuf) override;
@@ -361,7 +356,7 @@ class BilateralFilter : public ComputePipeline {
   public:
     BilateralFilter(const std::shared_ptr<VULKAN_HPP_NAMESPACE::detail::DispatchLoaderDynamic> &loader, VkDevice device,
                     const std::shared_ptr<PipelineCache> &pipelineCache, std::shared_ptr<Image> srcImage,
-                    std::shared_ptr<Image> srcFlow, std::shared_ptr<Image> dstFlow, float outputFlowScale,
+                    std::shared_ptr<Image> srcFlow, const std::shared_ptr<Image> &dstFlow, float outputFlowScale,
                     const std::string &debugName);
     ~BilateralFilter() override = default;
 
@@ -377,7 +372,7 @@ class BilateralFilter : public ComputePipeline {
         uint32_t outputImageStride;
     };
 
-    SpecConstants makeSpecConstants(const std::shared_ptr<Image> &dstFlow, float outputFlowScale) const;
+    SpecConstants makeSpecConstants(float outputFlowScale) const;
 
     void setOutput(std::shared_ptr<Image> _dstFlow);
     void bindAndDispatch(VkCommandBuffer cmdBuf) override;
@@ -407,7 +402,7 @@ class SubpixelME : public ComputePipeline {
     SubpixelME(const std::shared_ptr<VULKAN_HPP_NAMESPACE::detail::DispatchLoaderDynamic> &loader, VkDevice device,
                const std::shared_ptr<PipelineCache> &pipelineCache, std::shared_ptr<Image> srcImageSearch,
                std::shared_ptr<Image> srcImageTemplate, std::shared_ptr<Image> srcFlow,
-               std::shared_ptr<Image> prevLevelFlow, std::shared_ptr<Image> dstFlow, bool doAccumulate,
+               std::shared_ptr<Image> prevLevelFlow, const std::shared_ptr<Image> &dstFlow, bool doAccumulate,
                const std::string &debugName);
     ~SubpixelME() override = default;
 
@@ -426,8 +421,7 @@ class SubpixelME : public ComputePipeline {
         uint32_t outputFlowStride;
     };
 
-    SpecConstants makeSpecConstants(const std::shared_ptr<Image> &srcFlow, const std::shared_ptr<Image> &prevLevelFlow,
-                                    const std::shared_ptr<Image> &dstFlow, bool doAccumulate) const;
+    SpecConstants makeSpecConstants(bool doAccumulate) const;
 
     void setOutput(std::shared_ptr<Image> _dstFlow);
     void bindAndDispatch(VkCommandBuffer cmdBuf) override;
@@ -463,8 +457,8 @@ class MVReplace : public ComputePipeline {
     MVReplace(const std::shared_ptr<VULKAN_HPP_NAMESPACE::detail::DispatchLoaderDynamic> &loader, VkDevice device,
               const std::shared_ptr<PipelineCache> &pipelineCache, std::shared_ptr<Image> mvInput,
               std::shared_ptr<Image> flowBlockMatch, std::shared_ptr<Image> costAtInput,
-              std::shared_ptr<Image> minCostBlockMatch, std::shared_ptr<Image> dstFlow, std::shared_ptr<Image> dstCost,
-              bool outputCost, const std::string &debugName);
+              std::shared_ptr<Image> minCostBlockMatch, const std::shared_ptr<Image> &dstFlow,
+              std::shared_ptr<Image> dstCost, bool outputCost, const std::string &debugName);
     ~MVReplace() override = default;
 
     struct SpecConstants {
@@ -482,8 +476,7 @@ class MVReplace : public ComputePipeline {
         uint32_t outputCostStride;
     };
 
-    SpecConstants makeSpecConstants(const std::shared_ptr<Image> &costAtInput, const std::shared_ptr<Image> &dstFlow,
-                                    const std::shared_ptr<Image> &dstCost, bool outputCost) const;
+    SpecConstants makeSpecConstants() const;
 
     void setInputMv(std::shared_ptr<Image> srcMV);
     void setOutputFlow(std::shared_ptr<Image> dstFlow);
@@ -527,8 +520,8 @@ class BlockMatch : public ComputePipeline {
 
     BlockMatch(const std::shared_ptr<VULKAN_HPP_NAMESPACE::detail::DispatchLoaderDynamic> &loader, VkDevice device,
                const std::shared_ptr<PipelineCache> &pipelineCache, SearchType searchType, int32_t maxSearchRange,
-               std::shared_ptr<Image> srcSearch, std::shared_ptr<Image> srcTemplate, std::shared_ptr<Image> dstFlow,
-               std::shared_ptr<Image> dstCost, const std::string &debugName);
+               const std::shared_ptr<Image> &srcSearch, std::shared_ptr<Image> srcTemplate,
+               std::shared_ptr<Image> dstFlow, std::shared_ptr<Image> dstCost, const std::string &debugName);
     ~BlockMatch() override = default;
 
     struct SpecConstants {
@@ -549,8 +542,7 @@ class BlockMatch : public ComputePipeline {
         int32_t searchIndexLimit;
     };
 
-    SpecConstants makeSpecConstants(SearchType searchType, int32_t maxSearchRange,
-                                    const std::shared_ptr<Image> &dstFlow, const std::shared_ptr<Image> &dstCost) const;
+    SpecConstants makeSpecConstants() const;
     bool hasFlowOutput() const;
     bool hasCostOutput() const;
 

--- a/graph/graph_layer.cpp
+++ b/graph/graph_layer.cpp
@@ -1484,7 +1484,7 @@ class GraphLayer : public VulkanLayerImpl {
                     // Create compute descriptor sets
                     auto descriptorSetMapTemp = graphPipeline->makeExternalDescriptorSets(set);
                     auto &computeDescriptorSetMap = externalDescriptorSets[{vkPipeline, set}];
-                    computeDescriptorSetMap.insert(descriptorSetMapTemp.begin(), descriptorSetMapTemp.end());
+                    computeDescriptorSetMap.merge(descriptorSetMapTemp);
 
                     for (const auto &[binding, tensorViews] : descriptorSet->tensorViews) {
                         for (uint32_t arrayIndex = 0; arrayIndex < tensorViews.size(); arrayIndex++) {

--- a/graph/optical_flow.cpp
+++ b/graph/optical_flow.cpp
@@ -28,7 +28,7 @@ namespace mlsdk::el::compute::optical_flow {
 OpticalFlow::OpticalFlow(std::shared_ptr<VULKAN_HPP_NAMESPACE::detail::DispatchLoaderDynamic> loader,
                          VkPhysicalDevice physicalDevice, VkDevice device,
                          const std::shared_ptr<PipelineCache> &pipelineCache)
-    : loader_(loader), physicalDevice_(physicalDevice), device_(device), pipelineCache_(pipelineCache) {}
+    : loader_(std::move(loader)), physicalDevice_(physicalDevice), device_(device), pipelineCache_(pipelineCache) {}
 
 void OpticalFlow::init(const Config &config) {
     // Check configuration is supported
@@ -101,22 +101,19 @@ void OpticalFlow::init(const Config &config) {
     }
 }
 
-void OpticalFlow::setInputSearch(std::shared_ptr<Image> input) {
-    inputSearchRGB_ = input;
+void OpticalFlow::setInputSearch() const {
     if (rgbToYSearch_) {
         rgbToYSearch_->setInput(inputSearchRGB_);
     }
 }
 
-void OpticalFlow::setInputTemplate(std::shared_ptr<Image> input) {
-    inputTemplateRGB_ = input;
+void OpticalFlow::setInputTemplate() const {
     if (rgbToYTemplate_) {
         rgbToYTemplate_->setInput(inputTemplateRGB_);
     }
 }
 
-void OpticalFlow::setInputMV(std::shared_ptr<Image> input) {
-    inputMV_ = input;
+void OpticalFlow::setInputMV() const {
     if (warpByMvInput_) {
         warpByMvInput_->setInputFlow(inputMV_);
     }
@@ -125,9 +122,7 @@ void OpticalFlow::setInputMV(std::shared_ptr<Image> input) {
     }
 }
 
-void OpticalFlow::setOutputFlow(std::shared_ptr<Image> output) {
-    outputFlow_ = output;
-
+void OpticalFlow::setOutputFlow() {
     if (config_.useMvInput) {
         mvReplaceFlowOut_ = outputFlow_;
         if (mvReplace_) {
@@ -150,9 +145,7 @@ void OpticalFlow::setOutputFlow(std::shared_ptr<Image> output) {
     }
 }
 
-void OpticalFlow::setOutputCost(std::shared_ptr<Image> output) {
-    outputCost_ = output;
-
+void OpticalFlow::setOutputCost() {
     if (config_.useMvInput) {
         mvReplaceCostOut_ = outputCost_;
         if (mvReplace_) {
@@ -221,8 +214,8 @@ void OpticalFlow::makeDownsamplePyramid(std::vector<DownsampleBlock> &blocks, st
 void OpticalFlow::makeMotionEstimationBlocks() {
     MEBlocks_.resize(pyramidLevels_);
 
-    setOutputFlow(outputFlow_);
-    setOutputCost(outputCost_);
+    setOutputFlow();
+    setOutputCost();
 
     // Start at the bottom of the pyramid and work up.
     const auto first = pyramidLevels_ - 1;
@@ -414,26 +407,26 @@ void OpticalFlow::updateDescriptorSets(const OpticalFlowDescriptorMap &descripto
 
     std::tie(vkDescriptorSet, vkImageView) = getDescriptorSetAndImageView(config_.srcSearch);
     inputSearchRGB_->setExternalDescriptor(vkDescriptorSet, config_.srcSearch.binding, vkImageView);
-    setInputSearch(inputSearchRGB_);
+    setInputSearch();
 
     std::tie(vkDescriptorSet, vkImageView) = getDescriptorSetAndImageView(config_.srcTemplate);
     inputTemplateRGB_->setExternalDescriptor(vkDescriptorSet, config_.srcTemplate.binding, vkImageView);
-    setInputTemplate(inputTemplateRGB_);
+    setInputTemplate();
 
     if (config_.useMvInput) {
         std::tie(vkDescriptorSet, vkImageView) = getDescriptorSetAndImageView(config_.srcFlow);
         inputMV_->setExternalDescriptor(vkDescriptorSet, config_.srcFlow.binding, vkImageView);
-        setInputMV(inputMV_);
+        setInputMV();
     }
 
     std::tie(vkDescriptorSet, vkImageView) = getDescriptorSetAndImageView(config_.dstFlow);
     outputFlow_->setExternalDescriptor(vkDescriptorSet, config_.dstFlow.binding, vkImageView);
-    setOutputFlow(outputFlow_);
+    setOutputFlow();
 
     if (config_.outputCost) {
         std::tie(vkDescriptorSet, vkImageView) = getDescriptorSetAndImageView(config_.dstCost);
         outputCost_->setExternalDescriptor(vkDescriptorSet, config_.dstCost.binding, vkImageView);
-        setOutputCost(outputCost_);
+        setOutputCost();
     }
 }
 

--- a/graph/optical_flow.hpp
+++ b/graph/optical_flow.hpp
@@ -95,11 +95,11 @@ class OpticalFlow {
 
     void init(const Config &config);
 
-    void setInputSearch(std::shared_ptr<Image> input);
-    void setInputTemplate(std::shared_ptr<Image> input);
-    void setInputMV(std::shared_ptr<Image> input);
-    void setOutputFlow(std::shared_ptr<Image> output);
-    void setOutputCost(std::shared_ptr<Image> output);
+    void setInputSearch() const;
+    void setInputTemplate() const;
+    void setInputMV() const;
+    void setOutputFlow();
+    void setOutputCost();
 
     VkMemoryRequirements getTransientMemoryRequirements() const;
     VkMemoryRequirements getCacheMemoryRequirements() const;

--- a/graph/pipeline_cache.cpp
+++ b/graph/pipeline_cache.cpp
@@ -107,7 +107,7 @@ VkPipelineCache PipelineCache::getPipelineCache() const { return pipelineCache; 
 std::string PipelineCache::makeKey(std::string_view shaderName, const KeyList &keys) {
     return std::accumulate(
         keys.begin(), keys.end(), std::string(shaderName),
-        [](const std::string &acc, const std::string_view &key) { return acc + "_" + std::string(key); });
+        [](const std::string &acc, const std::string_view &key) { return acc + '_' + std::string(key); });
 }
 
 std::vector<uint32_t> PipelineCache::replaceCompileGlsl(std::string_view glslSource, const ReplaceList &replaceList) {

--- a/graph/spirv_pass_tosaspv_v100.cpp
+++ b/graph/spirv_pass_tosaspv_v100.cpp
@@ -560,10 +560,9 @@ void GraphPassTosaSpv100::handleDepthwiseConv2D(const Instruction *opExtInst, co
 
 void GraphPassTosaSpv100::handleElementwiseBinary(
     const Instruction *opExtInst, const std::string &debugName,
-    std::function<void(GraphPipeline *, const std::shared_ptr<TensorDescriptor> &,
-                       const std::shared_ptr<TensorDescriptor> &, const std::shared_ptr<TensorDescriptor> &,
-                       const std::string &)>
-        function) {
+    const std::function<void(GraphPipeline *, const std::shared_ptr<TensorDescriptor> &,
+                             const std::shared_ptr<TensorDescriptor> &, const std::shared_ptr<TensorDescriptor> &,
+                             const std::string &)> &function) {
     // OpExtInst <result id> <OpExtInstImport id> OPERATION input1 input2
     assert(opExtInst->NumInOperands() == 4);
 
@@ -579,9 +578,8 @@ void GraphPassTosaSpv100::handleElementwiseBinary(
 
 void GraphPassTosaSpv100::handleElementwiseUnary(
     const Instruction *opExtInst, const std::string &debugName,
-    std::function<void(GraphPipeline *, const std::shared_ptr<TensorDescriptor> &,
-                       const std::shared_ptr<TensorDescriptor> &, const std::string &)>
-        function) {
+    const std::function<void(GraphPipeline *, const std::shared_ptr<TensorDescriptor> &,
+                             const std::shared_ptr<TensorDescriptor> &, const std::string &)> &function) {
     // OpExtInst <result id> <OpExtInstImport id> OPERATION input1
     assert(opExtInst->NumInOperands() == 3);
 
@@ -831,9 +829,9 @@ void GraphPassTosaSpv100::handleRescale(const Instruction *opExtInst, const std:
 
 void GraphPassTosaSpv100::handleReduce(
     const Instruction *opExtInst, const std::string &debugName,
-    std::function<void(GraphPipeline *, const std::shared_ptr<TensorDescriptor> &,
-                       const std::shared_ptr<TensorDescriptor> &, const uint32_t, const std::string &)>
-        function) {
+    const std::function<void(GraphPipeline *, const std::shared_ptr<TensorDescriptor> &,
+                             const std::shared_ptr<TensorDescriptor> &, const uint32_t, const std::string &)>
+        &function) {
     // OpExtInst <result id> <OpExtInstImport id> REDUCE_* axis input
     assert(opExtInst->NumInOperands() == 4);
 

--- a/graph/spirv_pass_tosaspv_v100.hpp
+++ b/graph/spirv_pass_tosaspv_v100.hpp
@@ -45,15 +45,15 @@ class GraphPassTosaSpv100 final : public GraphPassBase {
     void handleDepthwiseConv2D(const Instruction *opExtInst, const std::string &debugName);
     void handleElementwiseBinary(
         const Instruction *opExtInst, const std::string &debugName,
-        std::function<void(GraphPipeline *, const std::shared_ptr<mlsdk::el::compute::TensorDescriptor> &,
-                           const std::shared_ptr<mlsdk::el::compute::TensorDescriptor> &,
-                           const std::shared_ptr<mlsdk::el::compute::TensorDescriptor> &, const std::string &)>
-            function);
+        const std::function<void(GraphPipeline *, const std::shared_ptr<mlsdk::el::compute::TensorDescriptor> &,
+                                 const std::shared_ptr<mlsdk::el::compute::TensorDescriptor> &,
+                                 const std::shared_ptr<mlsdk::el::compute::TensorDescriptor> &, const std::string &)>
+            &function);
     void handleElementwiseUnary(
         const Instruction *opExtInst, const std::string &debugName,
-        std::function<void(GraphPipeline *, const std::shared_ptr<mlsdk::el::compute::TensorDescriptor> &,
-                           const std::shared_ptr<mlsdk::el::compute::TensorDescriptor> &, const std::string &)>
-            function);
+        const std::function<void(GraphPipeline *, const std::shared_ptr<mlsdk::el::compute::TensorDescriptor> &,
+                                 const std::shared_ptr<mlsdk::el::compute::TensorDescriptor> &, const std::string &)>
+            &function);
     void handleFft2D(const Instruction *opExtInst, const std::string &debugName);
     void handleGather(const Instruction *opExtInst, const std::string &debugName);
     void handleMatmul(const Instruction *opExtInst, const std::string &debugName);
@@ -62,11 +62,11 @@ class GraphPassTosaSpv100 final : public GraphPassBase {
     void handleMinimum(const Instruction *opExtInst, const std::string &debugName);
     void handleMul(const Instruction *opExtInst, const std::string &debugName);
     void handleNegate(const Instruction *opExtInst, const std::string &debugName);
-    void handleReduce(const Instruction *opExtInst, const std::string &debugName,
-                      std::function<void(GraphPipeline *, const std::shared_ptr<mlsdk::el::compute::TensorDescriptor> &,
-                                         const std::shared_ptr<mlsdk::el::compute::TensorDescriptor> &, const uint32_t,
-                                         const std::string &)>
-                          function);
+    void handleReduce(
+        const Instruction *opExtInst, const std::string &debugName,
+        const std::function<void(GraphPipeline *, const std::shared_ptr<mlsdk::el::compute::TensorDescriptor> &,
+                                 const std::shared_ptr<mlsdk::el::compute::TensorDescriptor> &, const uint32_t,
+                                 const std::string &)> &function);
     void handleReduceMax(const Instruction *opExtInst, const std::string &debugName);
     void handleReduceMin(const Instruction *opExtInst, const std::string &debugName);
     void handlePad(const Instruction *opExtInst, const std::string &debugName);

--- a/utilities/include/mlel/pipeline.hpp
+++ b/utilities/include/mlel/pipeline.hpp
@@ -141,7 +141,7 @@ class GraphPipeline : public PipelineBase {
     std::shared_ptr<vk::raii::DeviceMemory> bindGraphPipelineSessionMemory(
         const vk::raii::DataGraphPipelineSessionARM &graphPipelineSession,
         const std::map<vk::DataGraphPipelineSessionBindPointARM, vk::MemoryRequirements> &memoryRequirements) const;
-    void *mapGraphPipelineSessionMemory(std::shared_ptr<vk::raii::DeviceMemory> deviceMemory) const;
+    void *mapGraphPipelineSessionMemory(const std::shared_ptr<vk::raii::DeviceMemory> &deviceMemory) const;
 
     const GraphConstants &graphConstants;
     bool hostMemory = false;

--- a/utilities/pipeline.cpp
+++ b/utilities/pipeline.cpp
@@ -486,7 +486,7 @@ std::shared_ptr<vk::raii::DeviceMemory> GraphPipeline::bindGraphPipelineSessionM
     return deviceMemory;
 }
 
-void *GraphPipeline::mapGraphPipelineSessionMemory(std::shared_ptr<vk::raii::DeviceMemory> deviceMemory) const {
+void *GraphPipeline::mapGraphPipelineSessionMemory(const std::shared_ptr<vk::raii::DeviceMemory> &deviceMemory) const {
     if (deviceMemory == nullptr || !hostMemory) {
         return nullptr;
     }


### PR DESCRIPTION
Fix function parameters.
Use char instead of single character string.
Merge maps instead of insert to avoid making multiple copies of the same data. Remove redundant parameters.
Enable clang-tidy check

Change-Id: Ide259986f265505ee582bb055f6df9bc55f384b0