### PR TITLE
Add clang-tidy checks for naming

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright 2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-FileCopyrightText: Copyright 2025-2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
 # SPDX-License-Identifier: Apache-2.0
 #
 Checks: >
@@ -41,6 +41,7 @@ Checks: >
     readability-delete-null-pointer,
     readability-duplicate-include,
     readability-else-after-return,
+    readability-identifier-naming,
     readability-isolate-declaration,
     readability-make-member-function-const,
     readability-misleading-indentation,
@@ -66,3 +67,10 @@ Checks: >
 WarningsAsErrors: '*'
 HeaderFilterRegex: '.*'
 FormatStyle: file
+CheckOptions:
+  - key: readability-identifier-naming.ClassCase
+    value: CamelCase
+  - key: readability-identifier-naming.LocalVariableCase
+    value: camelBack
+  - key: readability-identifier-naming.StructCase
+    value: CamelCase

--- a/common/include/mlel/float.hpp
+++ b/common/include/mlel/float.hpp
@@ -18,11 +18,11 @@
  * uint helper classes
  *******************************************************************************/
 
-template <std::size_t SIZE> struct u_int_t {};
-template <> struct u_int_t<8> { using type = uint8_t; };
-template <> struct u_int_t<16> { using type = uint16_t; };
-template <> struct u_int_t<32> { using type = uint32_t; };
-template <> struct u_int_t<64> { using type = uint64_t; };
+template <std::size_t SIZE> struct UIntT {};
+template <> struct UIntT<8> { using type = uint8_t; };
+template <> struct UIntT<16> { using type = uint16_t; };
+template <> struct UIntT<32> { using type = uint32_t; };
+template <> struct UIntT<64> { using type = uint64_t; };
 
 /*******************************************************************************
  * FloatingPoint
@@ -82,7 +82,7 @@ using float64 = FloatingPoint<11, 52>;
  */
 template <std::size_t EXPONENT, std::size_t MANTISSA> class FloatingPoint {
   public:
-    using dtype = typename u_int_t<1 + EXPONENT + MANTISSA>::type;
+    using dtype = typename UIntT<1 + EXPONENT + MANTISSA>::type;
     template <std::size_t, std::size_t> friend class FloatingPoint;
 
     explicit FloatingPoint(const double v = 0) {
@@ -173,12 +173,12 @@ template <std::size_t EXPONENT, std::size_t MANTISSA> class FloatingPoint {
     static constexpr double lowest() { return -max(); }
     static constexpr double max() {
         // Select maximum exponent, 2^(max exponent)
-        double _max = 1 << EXPONENT_BIAS;
+        double max = 1 << EXPONENT_BIAS;
 
         // Multiply with largest possible mantissa
-        _max *= 1 + double(MANTISSA_DIVISOR - 1) / MANTISSA_DIVISOR;
+        max *= 1 + double(MANTISSA_DIVISOR - 1) / MANTISSA_DIVISOR;
 
-        return _max;
+        return max;
     }
 
     template <typename T> void operator+=(const T &other) { *this = double(*this) + other; }
@@ -190,7 +190,7 @@ template <std::size_t EXPONENT, std::size_t MANTISSA> class FloatingPoint {
     template <typename T> void operator/=(const T &other) { *this = double(*this) / other; }
 
   private:
-    struct f {
+    struct F {
         dtype _mantissa : MANTISSA;
         dtype _exponent : EXPONENT;
         dtype _sign : 1;

--- a/graph/image.hpp
+++ b/graph/image.hpp
@@ -126,11 +126,11 @@ class Image {
     std::tuple<VkPipelineStageFlags2, VkAccessFlags2, VkImageLayout> barrierProps(BarrierState state);
 
     std::shared_ptr<VULKAN_HPP_NAMESPACE::detail::DispatchLoaderDynamic> loader_;
-    VkPhysicalDevice physicalDevice_;
-    VkDevice device_;
+    VkPhysicalDevice physicalDevice_{};
+    VkDevice device_{};
 
     Usage usage_ = Usage::BufferStoreLoad;
-    VkExtent3D dim_;
+    VkExtent3D dim_{};
     BarrierState state_ = BarrierState::Undefined;
     VkDeviceSize sizeInBytes_ = 0;
     VkDeviceSize blockSize_ = 1;

--- a/graph/memory_planner.cpp
+++ b/graph/memory_planner.cpp
@@ -149,9 +149,9 @@ std::map<std::shared_ptr<TensorDescriptor>, Tensors> BestFitMemoryPlanner::liveT
     const auto &topological = getTopologicalOrder();
     std::map<ComputePipelineBase *, std::set<std::shared_ptr<VirtualTensor>>> carryOnSet;
     std::map<ComputePipelineBase *, std::vector<std::shared_ptr<VirtualTensor>>> carryOn;
-    std::map<std::shared_ptr<TensorDescriptor>, Tensors> _safeToReuse;
+    std::map<std::shared_ptr<TensorDescriptor>, Tensors> safeTensors;
     for (const auto &tensor : tensors) {
-        _safeToReuse.emplace(tensor, Tensors());
+        safeTensors.emplace(tensor, Tensors());
     }
 
     const auto &input = graphPipeline->getInputs();
@@ -209,15 +209,15 @@ std::map<std::shared_ptr<TensorDescriptor>, Tensors> BestFitMemoryPlanner::liveT
                             continue;
                         }
 
-                        _safeToReuse[descendantTensor].push_back(tensor);
-                        _safeToReuse[tensor].push_back(descendantTensor);
+                        safeTensors[descendantTensor].push_back(tensor);
+                        safeTensors[tensor].push_back(descendantTensor);
                     }
                 }
             }
         }
     }
 
-    return _safeToReuse;
+    return safeTensors;
 }
 
 /*
@@ -275,10 +275,10 @@ Tensors BestFitMemoryPlanner::createInitialTensorOrder() const {
  * fitting match.
  */
 std::map<std::shared_ptr<TensorDescriptor>, Tensors> BestFitMemoryPlanner::createAllAlternatives() const {
-    auto _allAlternatives = std::map<std::shared_ptr<TensorDescriptor>, Tensors>();
+    auto all = std::map<std::shared_ptr<TensorDescriptor>, Tensors>();
 
     for (const auto &tensor : tensors) {
-        auto &alternatives = _allAlternatives[tensor];
+        auto &alternatives = all[tensor];
         const auto tensorSize = tensor->getMemoryRequirementsSize();
 
         for (auto const &safeTensor : safeToReuse.at(tensor)) {
@@ -294,7 +294,7 @@ std::map<std::shared_ptr<TensorDescriptor>, Tensors> BestFitMemoryPlanner::creat
         });
     }
 
-    return _allAlternatives;
+    return all;
 }
 
 /*

--- a/tensor/descriptor_binding.hpp
+++ b/tensor/descriptor_binding.hpp
@@ -81,9 +81,9 @@ substituteTensorWriteDescriptorSet(const Device &dev, uint32_t descriptorWriteCo
                 write.pImageInfo->imageView, // imageView
                 VK_IMAGE_LAYOUT_GENERAL,     // imageLayout
             });
-            auto write_copy = write;
-            write_copy.pImageInfo = &imageInfos.back();
-            writes.emplace_back(write_copy);
+            auto writeCopy = write;
+            writeCopy.pImageInfo = &imageInfos.back();
+            writes.emplace_back(writeCopy);
             continue;
         }
 

--- a/tests/vulkan.cpp
+++ b/tests/vulkan.cpp
@@ -942,12 +942,9 @@ TEST_F(MLEmulationLayerForVulkan, NOPOutputs) {
     auto device = createDevice();
 
     auto inputTensor = std::make_shared<Tensor>(device, Shape{vk::Format::eR8Sint, std::vector<int64_t>{1, 8, 8, 3}});
-    auto outputTensor_0 =
-        std::make_shared<Tensor>(device, Shape{vk::Format::eR8Sint, std::vector<int64_t>{1, 2, 2, 2}});
-    auto outputTensor_1 =
-        std::make_shared<Tensor>(device, Shape{vk::Format::eR8Sint, std::vector<int64_t>{1, 8, 8, 3}});
-    auto outputTensor_2 =
-        std::make_shared<Tensor>(device, Shape{vk::Format::eR8Sint, std::vector<int64_t>{1, 8, 8, 3}});
+    auto outputTensor0 = std::make_shared<Tensor>(device, Shape{vk::Format::eR8Sint, std::vector<int64_t>{1, 2, 2, 2}});
+    auto outputTensor1 = std::make_shared<Tensor>(device, Shape{vk::Format::eR8Sint, std::vector<int64_t>{1, 8, 8, 3}});
+    auto outputTensor2 = std::make_shared<Tensor>(device, Shape{vk::Format::eR8Sint, std::vector<int64_t>{1, 8, 8, 3}});
 
     const GraphPipeline::DescriptorMap descriptorMap = {
         {
@@ -957,16 +954,16 @@ TEST_F(MLEmulationLayerForVulkan, NOPOutputs) {
                 {inputTensor}, // tensor
             },
             {
-                1,                // binding
-                {outputTensor_0}, // tensor
+                1,               // binding
+                {outputTensor0}, // tensor
             },
             {
-                2,                // binding
-                {outputTensor_1}, // tensor
+                2,               // binding
+                {outputTensor1}, // tensor
             },
             {
-                3,                // binding
-                {outputTensor_2}, // tensor
+                3,               // binding
+                {outputTensor2}, // tensor
             },
         },
     };
@@ -1005,24 +1002,24 @@ TEST_F(MLEmulationLayerForVulkan, NOPOutputs) {
     inputTensor->print();
 
     std::cout << "OUTPUT_0 from Slice" << std::endl;
-    outputTensor_0->print();
+    outputTensor0->print();
 
     std::cout << "OUTPUT_1 from Input" << std::endl;
-    outputTensor_1->print();
+    outputTensor1->print();
 
     std::cout << "CONST TENSOR" << std::endl;
     graphConstants[0].print();
 
     std::cout << "OUTPUT_2 from Const Tensor" << std::endl;
-    outputTensor_2->print();
+    outputTensor2->print();
 
-    ASSERT_TRUE(outputTensor_0->compare(reinterpret_cast<const int8_t *>(&ref[0][0][0][0]), sizeof(ref)))
+    ASSERT_TRUE(outputTensor0->compare(reinterpret_cast<const int8_t *>(&ref[0][0][0][0]), sizeof(ref)))
         << "Output mismatch in OUTPUT_0";
 
-    ASSERT_TRUE(outputTensor_1->compare(reinterpret_cast<const int8_t *>(inputTensor->data()), inputTensor->size()))
+    ASSERT_TRUE(outputTensor1->compare(reinterpret_cast<const int8_t *>(inputTensor->data()), inputTensor->size()))
         << "Output mismatch in OUTPUT_1";
     ASSERT_TRUE(
-        outputTensor_2->compare(reinterpret_cast<const int8_t *>(graphConstants[0].data()), graphConstants[0].size()))
+        outputTensor2->compare(reinterpret_cast<const int8_t *>(graphConstants[0].data()), graphConstants[0].size()))
         << "Output mismatch in OUTPUT_2";
 }
 
@@ -1281,14 +1278,14 @@ TEST_F(MLEmulationLayerForVulkan, SIN) {
     std::cout << std::endl;
 
     float64 reference = 0.00011173184588586903;
-    float64 error_bound = 7.715463482888105e-08;
-    float64 ref_min = reference - error_bound;
-    float64 ref_max = reference + error_bound;
+    float64 errorBound = 7.715463482888105e-08;
+    float64 refMin = reference - errorBound;
+    float64 refMax = reference + errorBound;
 
     float64 output = *(reinterpret_cast<float32 *>(outputTensor->data()));
 
-    ASSERT_GE(output, ref_min);
-    ASSERT_LE(output, ref_max);
+    ASSERT_GE(output, refMin);
+    ASSERT_LE(output, refMax);
 }
 
 #ifndef EXPERIMENTAL_MOLTEN_VK_SUPPORT


### PR DESCRIPTION
Fix type naming
Fix variable naming, avoid shadowing class members Initialize class members

Change-Id: I56c609a613be5d2de0162ac26927d40a52036ad5