### PR TITLE
Gate update-after-bind on uniform buffer feature support

### DIFF
--- a/graph/graph_layer.cpp
+++ b/graph/graph_layer.cpp
@@ -590,7 +590,8 @@ class GraphLayer : public VulkanLayerImpl {
                 pFeatures->pNext, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DATA_GRAPH_FEATURES_ARM));
         if (pDataGraphFeatures) {
             pDataGraphFeatures->dataGraph = VK_TRUE;
-            pDataGraphFeatures->dataGraphUpdateAfterBind = VK_TRUE;
+            pDataGraphFeatures->dataGraphUpdateAfterBind =
+                supportsDataGraphUpdateAfterBind(physicalDevice, handle) ? VK_TRUE : VK_FALSE;
             pDataGraphFeatures->dataGraphShaderModule = VK_TRUE;
         }
         auto *pPipelineCreationCacheControlFeatures =
@@ -601,6 +602,19 @@ class GraphLayer : public VulkanLayerImpl {
         if (pPipelineCreationCacheControlFeatures) {
             pPipelineCreationCacheControlFeatures->pipelineCreationCacheControl = VK_FALSE;
         }
+    }
+
+    static bool supportsDataGraphUpdateAfterBind(VkPhysicalDevice physicalDevice,
+                                                 const std::shared_ptr<PhysicalDevice> &handle) {
+        VkPhysicalDeviceVulkan12Features vulkan12Features{};
+        vulkan12Features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES;
+        VkPhysicalDeviceFeatures2 features2{};
+        features2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
+        features2.pNext = &vulkan12Features;
+
+        handle->loader->vkGetPhysicalDeviceFeatures2(physicalDevice, &features2);
+
+        return vulkan12Features.descriptorBindingUniformBufferUpdateAfterBind == VK_TRUE;
     }
 
     static VkResult VKAPI_CALL vkCreateDevice(VkPhysicalDevice physicalDevice, const VkDeviceCreateInfo *createInfo,

--- a/tensor/descriptor_binding.hpp
+++ b/tensor/descriptor_binding.hpp
@@ -26,7 +26,8 @@ inline bool hasTensor(const VkDescriptorPoolSize &obj) { return obj.type == VK_D
 
 inline std::vector<VkDescriptorSetLayoutBinding>
 substituteTensorBinding(uint32_t bindingCount, const VkDescriptorSetLayoutBinding *pBindings,
-                        const VkDescriptorSetLayoutBindingFlagsCreateInfo *bindingInfo) {
+                        const VkDescriptorSetLayoutBindingFlagsCreateInfo *bindingInfo,
+                        const bool supportsBufferUpdateAfterBind) {
     std::vector<VkDescriptorSetLayoutBinding> descriptorSetLayoutBindings{pBindings, pBindings + bindingCount};
 
     // Loop over bindings and replace tensors bindings with uniform buffer for tensor descriptor (plus a storage buffer
@@ -48,8 +49,8 @@ substituteTensorBinding(uint32_t bindingCount, const VkDescriptorSetLayoutBindin
             });
 #endif
 
-            // Remove uniform update after bind
-            if (bindingInfo) {
+            // Preserve UPDATE_AFTER_BIND only when rewritten buffer descriptors support it.
+            if (!supportsBufferUpdateAfterBind && bindingInfo && bindingInfo->pBindingFlags) {
                 const_cast<VkDescriptorBindingFlags *>(bindingInfo->pBindingFlags)[i] &=
                     static_cast<VkDescriptorBindingFlags>(~VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT);
             }

--- a/tensor/tensor_layer.cpp
+++ b/tensor/tensor_layer.cpp
@@ -60,6 +60,8 @@ class TensorDevice : public Device {
                  PFN_vkGetInstanceProcAddr _gipr, PFN_vkGetDeviceProcAddr _gdpr,
                  const VkAllocationCallbacks *_callbacks)
         : Device(_physicalDevice, _device, _gipr, _gdpr, _callbacks) {}
+
+    bool uniformBufferUpdateAfterBindEnabled = false;
 };
 
 /*******************************************************************************
@@ -526,12 +528,13 @@ class TensorLayer : public VulkanLayerImpl {
                                                            const VkAllocationCallbacks *pAllocator,
                                                            VkDescriptorSetLayout *pSetLayout) {
         auto handle = VulkanLayerImpl::getHandle(device);
+        const bool supportsBufferUpdateAfterBind = handle->uniformBufferUpdateAfterBindEnabled;
 
         const auto *bindingInfo = findType<VkDescriptorSetLayoutBindingFlagsCreateInfo>(
             pCreateInfo, VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO);
 
-        const auto bindings =
-            descriptor_binding::substituteTensorBinding(pCreateInfo->bindingCount, pCreateInfo->pBindings, bindingInfo);
+        const auto bindings = descriptor_binding::substituteTensorBinding(
+            pCreateInfo->bindingCount, pCreateInfo->pBindings, bindingInfo, supportsBufferUpdateAfterBind);
 
 #ifdef EXPERIMENTAL_MOLTEN_VK_SUPPORT
         std::vector<VkDescriptorBindingFlags> bindingFlags;
@@ -901,6 +904,10 @@ class TensorLayer : public VulkanLayerImpl {
         findAndRemoveType<VkPhysicalDeviceTensorFeaturesARM>(&newCreateInfo,
                                                              VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TENSOR_FEATURES_ARM);
         auto result = VulkanLayerImpl::vkCreateDevice(physicalDevice, &newCreateInfo, allocator, device);
+        if (result == VK_SUCCESS) {
+            auto handle = VulkanLayerImpl::getHandle(*device);
+            handle->uniformBufferUpdateAfterBindEnabled = isUniformBufferUpdateAfterBindEnabled(createInfo);
+        }
 
         loadVkStructureList(const_cast<VkDeviceCreateInfo *>(createInfo), originCreateInfoChain);
         return result;
@@ -974,6 +981,23 @@ class TensorLayer : public VulkanLayerImpl {
     static inline std::unordered_map<std::size_t, std::vector<uint32_t>> spirvCache;
 
     static inline MemoryAliasing memoryAliasing;
+    static bool isUniformBufferUpdateAfterBindEnabled(const VkDeviceCreateInfo *createInfo) {
+        if (const auto *vulkan12Features = findType<VkPhysicalDeviceVulkan12Features>(
+                createInfo, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES)) {
+            if (vulkan12Features->descriptorBindingUniformBufferUpdateAfterBind) {
+                return true;
+            }
+        }
+
+        if (const auto *descriptorIndexingFeatures = findType<VkPhysicalDeviceDescriptorIndexingFeatures>(
+                createInfo, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES)) {
+            if (descriptorIndexingFeatures->descriptorBindingUniformBufferUpdateAfterBind) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 };
 } // namespace mlsdk::el::layer
 


### PR DESCRIPTION
  - Enable dataGraphUpdateAfterBind only when the physical device supports descriptorBindingUniformBufferUpdateAfterBind.
  - Track whether uniform-buffer update-after-bind was enabled at device creation.
  - Clear UPDATE_AFTER_BIND on rewritten tensor bindings when buffer descriptors do not support it, avoiding invalid descriptor semantics.


Change-Id: I3fb2ce54a89ec187449ade7d8217d082be032ede