### PR TITLE
Fix conv3d traversal for padded and dilated cases

### DIFF
--- a/graph/compute_graph_op.cpp
+++ b/graph/compute_graph_op.cpp
@@ -1085,7 +1085,9 @@ SpirvBinary Conv3D::createSpirv(const std::shared_ptr<PipelineCache> &_pipelineC
                                   {
                                       {"%warpX%", std::to_string(warp1D)},
                                       {"%in_t%", inType->glslType()},
+                                      {"%in_t_type%", inType->toInt()},
                                       {"%out_t%", outType->glslType()},
+                                      {"%out_t_type%", outType->toInt()},
                                       {"%weight_t%", weightType->glslType()},
                                       {"%acc_t_type%", accTypeType->toInt()},
                                       {"%acc_t%", accTypeType->glslType()},

--- a/graph/shaders/graph_op/tosa/conv3d.comp
+++ b/graph/shaders/graph_op/tosa/conv3d.comp
@@ -13,14 +13,6 @@
 
 DEFINE_CONV_ACC_CASTS(ACC_T, OUT_T, TYPE_IN, TYPE_OUT)
 
-#if TYPE_ACC == TYPE_INT64
-    #define VEC4 dvec4
-#elif TYPE_ACC == TYPE_INT32
-    #define VEC4 ivec4
-#else
-    #define VEC4 vec4
-#endif
-
 layout(local_size_x = %warpX%) in;
 
 layout(push_constant) uniform PushConstants {
@@ -48,44 +40,56 @@ void main() {
     uint ox = index[3];
     uint oc = index[4];
 
-    uint id = od * pushConstants.stride[0] - pushConstants.pad[0];
-    uint iy = oy * pushConstants.stride[1] - pushConstants.pad[2];
-    uint ix = ox * pushConstants.stride[2] - pushConstants.pad[4];
+    int id = int(od) * pushConstants.stride[0] - pushConstants.pad[0];
+    int iy = int(oy) * pushConstants.stride[1] - pushConstants.pad[2];
+    int ix = int(ox) * pushConstants.stride[2] - pushConstants.pad[4];
 
-    uint KD = tensorSizeARM(weightsData, 1);
-    uint KH = tensorSizeARM(weightsData, 2);
-    uint KW = tensorSizeARM(weightsData, 3);
-    uint IC = tensorSizeARM(weightsData, 4);
+    int KD = int(tensorSizeARM(weightsData, 1));
+    int KH = int(tensorSizeARM(weightsData, 2));
+    int KW = int(tensorSizeARM(weightsData, 3));
+    int IC = int(tensorSizeARM(weightsData, 4));
 
-    uint ID = tensorSizeARM(inputData, 1);
-    uint IH = tensorSizeARM(inputData, 2);
-    uint IW = tensorSizeARM(inputData, 3);
+    int ID = int(tensorSizeARM(inputData, 1));
+    int IH = int(tensorSizeARM(inputData, 2));
+    int IW = int(tensorSizeARM(inputData, 3));
 
-    for (uint kd = 0; kd < KD; kd++) {
-        for (uint ky = 0; ky < KH; ky++) {
-            for (uint kx = 0; kx < KW; kx++) {
-                uint d = id + kd * pushConstants.dilation[0];
-                uint y = iy + ky * pushConstants.dilation[1];
-                uint x = ix + kx * pushConstants.dilation[2];
+    int dStart = id;
+    int kdStart = 0;
+    if (dStart < 0) {
+        int delta = -dStart;
+        kdStart = (delta + pushConstants.dilation[0] - 1) / pushConstants.dilation[0];
+        dStart = id + kdStart * pushConstants.dilation[0];
+    }
 
-                if (d < ID && y < IH && x < IW) {
-                    for (uint ic = 0; ic < IC; ic += 4) {
-                        IN_T tempValue[4];
-                        tensorReadARM(inputData, uint[](n, d, y, x, ic), tempValue);
-                        VEC4 value = VEC4(to_acc(tempValue[0]), to_acc(tempValue[1]), to_acc(tempValue[2]), to_acc(tempValue[3]));
+    int yStart = iy;
+    int kyStart = 0;
+    if (yStart < 0) {
+        int delta = -yStart;
+        kyStart = (delta + pushConstants.dilation[1] - 1) / pushConstants.dilation[1];
+        yStart = iy + kyStart * pushConstants.dilation[1];
+    }
 
-                        WEIGHT_T tempWeight[4];
-                        tensorReadARM(weightsData, uint[](oc, kd, ky, kx, ic), tempWeight);
-                        VEC4 weight = VEC4(to_acc(tempWeight[0]), to_acc(tempWeight[1]), to_acc(tempWeight[2]), to_acc(tempWeight[3]));
+    int xStart = ix;
+    int kxStart = 0;
+    if (xStart < 0) {
+        int delta = -xStart;
+        kxStart = (delta + pushConstants.dilation[2] - 1) / pushConstants.dilation[2];
+        xStart = ix + kxStart * pushConstants.dilation[2];
+    }
 
-                        VEC4 outValue = VEC4(value[0], value[1], value[2], value[3]) - pushConstants.inputZeroPoint;
-                        VEC4 outWeight = VEC4(weight[0], weight[1], weight[2], weight[3]) - pushConstants.weightZeroPoint;
-                        VEC4 mul = outValue * outWeight;
+    for (int d = dStart, kd = kdStart; kd < KD && d < ID; ++kd, d += pushConstants.dilation[0]) {
+        for (int y = yStart, ky = kyStart; ky < KH && y < IH; ++ky, y += pushConstants.dilation[1]) {
+            for (int x = xStart, kx = kxStart; kx < KW && x < IW; ++kx, x += pushConstants.dilation[2]) {
+                for (int ic = 0; ic < IC; ++ic) {
+                    IN_T inputValue;
+                    tensorReadARM(inputData, uint[](n, uint(d), uint(y), uint(x), uint(ic)), inputValue);
 
-                        for (uint idx = 0; idx < 4 && ic + idx < IC; ++idx) {
-                            acc += ACC_T(mul[idx]);
-                        }
-                    }
+                    WEIGHT_T weightValue;
+                    tensorReadARM(weightsData, uint[](oc, uint(kd), uint(ky), uint(kx), uint(ic)), weightValue);
+
+                    ACC_T val = to_acc(inputValue) - ACC_T(pushConstants.inputZeroPoint);
+                    ACC_T wt = to_acc(weightValue) - ACC_T(pushConstants.weightZeroPoint);
+                    acc += val * wt;
                 }
             }
         }

--- a/tests/shader/conv3d_large_stride.spvasm
+++ b/tests/shader/conv3d_large_stride.spvasm
@@ -1,0 +1,69 @@
+;
+; SPDX-FileCopyrightText: Copyright 2023-2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+; SPDX-License-Identifier: Apache-2.0
+;
+               OpCapability VulkanMemoryModel
+               OpCapability Shader
+               OpCapability Int8
+               OpCapability TensorsARM
+               OpCapability GraphARM
+               OpCapability Matrix
+               OpExtension "SPV_ARM_tensors"
+               OpExtension "SPV_ARM_graph"
+               OpExtension "SPV_KHR_vulkan_memory_model"
+       %tosa = OpExtInstImport "TOSA.001000.1"
+               OpMemoryModel Logical Vulkan
+               OpName %conv3d_arg_0 "conv3d_arg_0"
+               OpName %conv3d_res_0 "conv3d_res_0"
+               OpDecorate %conv3d_arg_0 Binding 0
+               OpDecorate %conv3d_arg_0 DescriptorSet 0
+               OpDecorate %conv3d_res_0 Binding 1
+               OpDecorate %conv3d_res_0 DescriptorSet 0
+      %uchar = OpTypeInt 8 0
+       %uint = OpTypeInt 32 0
+       %bool = OpTypeBool
+     %uint_0 = OpConstant %uint 0
+     %uint_1 = OpConstant %uint 1
+     %uint_2 = OpConstant %uint 2
+     %uint_3 = OpConstant %uint 3
+     %uint_4 = OpConstant %uint 4
+     %uint_5 = OpConstant %uint 5
+     %uint_6 = OpConstant %uint 6
+  %uint_8190 = OpConstant %uint 8190
+  %uint_8192 = OpConstant %uint 8192
+    %uchar_9 = OpConstant %uchar 9
+      %false = OpConstantFalse %bool
+%shape_rank_1 = OpTypeArray %uint %uint_1
+%shape_rank_3 = OpTypeArray %uint %uint_3
+%shape_rank_5 = OpTypeArray %uint %uint_5
+%input_shape = OpConstantComposite %shape_rank_5 %uint_1 %uint_3 %uint_2 %uint_2 %uint_4
+%input_tensor = OpTypeTensorARM %uchar %uint_5 %input_shape
+%ptr_input_tensor = OpTypePointer UniformConstant %input_tensor
+%conv3d_arg_0 = OpVariable %ptr_input_tensor UniformConstant
+%output_shape = OpConstantComposite %shape_rank_5 %uint_1 %uint_3 %uint_2 %uint_2 %uint_3
+%output_tensor = OpTypeTensorARM %uint %uint_5 %output_shape
+%ptr_output_tensor = OpTypePointer UniformConstant %output_tensor
+%conv3d_res_0 = OpVariable %ptr_output_tensor UniformConstant
+%graph_type = OpTypeGraphARM 1 %input_tensor %output_tensor
+%weights_shape = OpConstantComposite %shape_rank_5 %uint_3 %uint_2 %uint_2 %uint_8192 %uint_4
+%weights_tensor = OpTypeTensorARM %uchar %uint_5 %weights_shape
+%weights_const = OpGraphConstantARM %weights_tensor 0
+%scalar_shape = OpConstantComposite %shape_rank_1 %uint_1
+%bias_tensor = OpTypeTensorARM %uint %uint_1 %scalar_shape
+%null_bias = OpConstantNull %bias_tensor
+%zero_point_tensor = OpTypeTensorARM %uchar %uint_1 %scalar_shape
+%input_zero_point = OpConstantComposite %zero_point_tensor %uchar_9
+%weight_zero_point = OpConstantNull %zero_point_tensor
+%pad_shape = OpConstantComposite %shape_rank_1 %uint_6
+%pad_tensor = OpTypeTensorARM %uint %uint_1 %pad_shape
+%pad = OpConstantComposite %pad_tensor %uint_1 %uint_0 %uint_1 %uint_0 %uint_8190 %uint_8192
+%vec3_shape = OpConstantComposite %shape_rank_1 %uint_3
+%vec3_tensor = OpTypeTensorARM %uint %uint_1 %vec3_shape
+%stride = OpConstantComposite %vec3_tensor %uint_1 %uint_1 %uint_8192
+%dilation = OpConstantComposite %vec3_tensor %uint_1 %uint_1 %uint_1
+               OpGraphEntryPointARM %conv3d_graph "conv3d_large_stride" %conv3d_arg_0 %conv3d_res_0
+%conv3d_graph = OpGraphARM %graph_type
+%input = OpGraphInputARM %input_tensor %uint_0
+%output = OpExtInst %output_tensor %tosa CONV3D %pad %stride %dilation %uint_1 %false %input %weights_const %null_bias %input_zero_point %weight_zero_point
+               OpGraphSetOutputARM %output %uint_0
+               OpGraphEndARM

--- a/tests/vulkan.cpp
+++ b/tests/vulkan.cpp
@@ -20,6 +20,7 @@
 #include <spirv-tools/libspirv.hpp>
 #include <vulkan/vulkan.hpp>
 
+#include <cstdint>
 #include <cstring>
 #include <exception>
 #include <filesystem>
@@ -809,6 +810,91 @@ TEST_F(MLEmulationLayerForVulkan, Conv2D) {
     };
 
     ASSERT_TRUE(outputTensor->compare(reinterpret_cast<const int32_t *>(&ref[0][0][0][0]), sizeof(ref)))
+        << "Output mismatch";
+}
+
+TEST_F(MLEmulationLayerForVulkan, Conv3DLargeStridePadRegression) {
+    constexpr int64_t kBatch = 1;
+    constexpr int64_t kInputDepth = 3;
+    constexpr int64_t kInputHeight = 2;
+    constexpr int64_t kInputWidth = 2;
+    constexpr int64_t kInputChannels = 4;
+    constexpr int64_t kOutputChannels = 3;
+    constexpr int64_t kKernelDepth = 2;
+    constexpr int64_t kKernelHeight = 2;
+    constexpr int64_t kKernelWidth = 8192;
+    constexpr int64_t kOutputDepth = 3;
+    constexpr int64_t kOutputHeight = 2;
+    constexpr int64_t kOutputWidth = 2;
+
+    auto device = createDevice();
+
+    auto inputTensor = std::make_shared<Tensor>(
+        device, Shape{vk::Format::eR8Sint,
+                      std::vector<int64_t>{kBatch, kInputDepth, kInputHeight, kInputWidth, kInputChannels}});
+    auto outputTensor = std::make_shared<Tensor>(
+        device, Shape{vk::Format::eR32Sint,
+                      std::vector<int64_t>{kBatch, kOutputDepth, kOutputHeight, kOutputWidth, kOutputChannels}});
+
+    const GraphPipeline::DescriptorMap descriptorMap = {{
+        {0, {inputTensor}},
+        {1, {outputTensor}},
+    }};
+
+    const std::array<int8_t, 48> inputValues = {
+        -128, -128, -128, -128, -128, -128, -128, -128, -128, -128, -128, -128, -128, -128, -128, -128,
+        -128, -128, -128, -128, -128, -128, -128, -128, -128, -128, -128, -128, -128, -128, -128, -128,
+        -128, -128, -128, -128, -128, -128, -128, -128, -128, -128, -128, -128, -128, -128, -128, -128,
+    };
+    const std::array<int32_t, 36> expectedValues = {
+        0,    -548, 137, 0, 0, 0, 548,   -685, -411, 0, 0, 0, -1233, 274,  685, 0, 0, 0,
+        -822, -411, 274, 0, 0, 0, -1233, 274,  685,  0, 0, 0, -822,  -411, 274, 0, 0, 0,
+    };
+    const std::array<int8_t, 96> relevantWeights = {
+        1, -1, 2,  -1, 1,  0,  -1, 0,  1, 2, 2, -1, 2, 2, 0, 1,  1,  -2, -1, -2, 0,  2,  -2, 0,
+        1, 1,  -2, 1,  0,  -2, 2,  -1, 1, 0, 0, 2,  2, 0, 0, -1, 0,  0,  -1, -1, -1, 0,  -1, -2,
+        1, 1,  -2, 2,  -1, 1,  1,  -2, 0, 0, 1, 2,  1, 2, 0, -2, 0,  2,  1,  -2, 1,  -1, -1, -1,
+        0, -2, 2,  -2, 0,  -1, 0,  -1, 0, 2, 0, -2, 2, 1, 1, 0,  -1, 0,  1,  -2, -2, 2,  1,  0,
+    };
+    std::vector<int8_t> weightValues(
+        static_cast<size_t>(kOutputChannels * kKernelDepth * kKernelHeight * kKernelWidth * kInputChannels), 0);
+    GraphConstants graphConstants;
+
+    ASSERT_EQ(inputValues.size(), inputTensor->size());
+    ASSERT_EQ(expectedValues.size(), outputTensor->size() / sizeof(expectedValues[0]));
+
+    std::memcpy(inputTensor->data(), inputValues.data(), inputValues.size() * sizeof(inputValues[0]));
+
+    const auto setWeight = [&](int64_t oc, int64_t kd, int64_t kh, int64_t kx, int64_t ic, int8_t value) {
+        const auto flatIndex = static_cast<size_t>(
+            ((((oc * kKernelDepth) + kd) * kKernelHeight + kh) * kKernelWidth + kx) * kInputChannels + ic);
+        weightValues[flatIndex] = value;
+    };
+
+    for (size_t oc = 0; oc < static_cast<size_t>(kOutputChannels); ++oc) {
+        for (size_t kd = 0; kd < static_cast<size_t>(kKernelDepth); ++kd) {
+            for (size_t kh = 0; kh < static_cast<size_t>(kKernelHeight); ++kh) {
+                const size_t blockBase =
+                    ((oc * static_cast<size_t>(kKernelDepth) + kd) * static_cast<size_t>(kKernelHeight) + kh) * 8;
+                for (size_t ic = 0; ic < static_cast<size_t>(kInputChannels); ++ic) {
+                    setWeight(static_cast<int64_t>(oc), static_cast<int64_t>(kd), static_cast<int64_t>(kh), 8190,
+                              static_cast<int64_t>(ic), relevantWeights[blockBase + ic]);
+                    setWeight(static_cast<int64_t>(oc), static_cast<int64_t>(kd), static_cast<int64_t>(kh), 8191,
+                              static_cast<int64_t>(ic), relevantWeights[blockBase + 4 + ic]);
+                }
+            }
+        }
+    }
+
+    graphConstants.makeGraphPipelineConstantTensor(
+        0, Shape{vk::Format::eR8Sint, {kOutputChannels, kKernelDepth, kKernelHeight, kKernelWidth, kInputChannels}},
+        weightValues);
+
+    const auto spirv = assembleSpirv(fileToString("conv3d_large_stride.spvasm"));
+    auto graphPipeline = std::make_shared<GraphPipeline>(device, descriptorMap, graphConstants, spirv);
+    graphPipeline->dispatchSubmit();
+
+    ASSERT_TRUE(outputTensor->compare(expectedValues.data(), expectedValues.size() * sizeof(expectedValues[0])))
         << "Output mismatch";
 }
 


### PR DESCRIPTION
Conv3d shader computed the output-to-input origin as unsigned coordinates and had issues in bounds checks while iterating kernel positions. For padded outputs this could wrap negative origins to large positive values, on certain platforms.

The problem was exposed on the older Mesa stack(23.2.1) with llvmpipe linux_x86_cpu test jobs. It did not reproduce on Mesa 25.0.7, still the behaviour was not guaranteed.

To fix, use signed coordinates and compute the first valid input position, then walk input and kernel coordinates in lock-step.

Also add a regression test covering the large-stride padded case.


Change-Id: I89da0e565f1964c3707d261b882350771daea5a3