### PR TITLE
Enable clang-tidy banned function checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -4,6 +4,7 @@
 #
 Checks: >
     -*,
+    bugprone-unsafe-functions,
     bugprone-use-after-move,
     cppcoreguidelines-pro-type-cstyle-cast,
     cppcoreguidelines-virtual-class-destructor,
@@ -68,6 +69,21 @@ WarningsAsErrors: '*'
 HeaderFilterRegex: '.*'
 FormatStyle: file
 CheckOptions:
+  - key: bugprone-unsafe-functions.ReportDefaultFunctions
+    value: 'true'
+  - key: bugprone-unsafe-functions.ReportMoreUnsafeFunctions
+    value: 'true'
+  - key: bugprone-unsafe-functions.CustomFunctions
+    value: >
+      ^alloca$,malloc or new,is considered unsafe;
+      ^readdir$,,>is considered unsafe; use a safer wrapper or explicit directory iteration API;
+      ^_tscanf$,,>is considered unsafe; use fgets-based parsing instead;
+      ^_stscanf$,,>is considered unsafe; use fgets-based parsing instead;
+      ^StrCpy$,strcpy_s,is considered unsafe;
+      ^lstrcpy$,strcpy_s,is considered unsafe;
+      ^StrCpyN$,strncpy_s,is considered unsafe;
+      ^StrNCpy$,strncpy_s,is considered unsafe;
+      ^lstrcpyn$,strncpy_s,is considered unsafe
   - key: readability-identifier-naming.ClassCase
     value: CamelCase
   - key: readability-identifier-naming.LocalVariableCase

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -278,6 +278,7 @@ class Builder:
 
                 clang_tidy_cmd = [
                     "run-clang-tidy",
+                    "-quiet",
                     f"-j{self.threads}",
                     f"-p{self.build_dir}",
                 ] + source_dirs


### PR DESCRIPTION
Add clang-tidy unsafe-function checking to the existing lint configuration by enabling bugprone-unsafe-functions and adding the project-specific banned function list. Also enable ReportMoreUnsafeFunctions for broader default coverage.

Update the lint build scripts to run clang-tidy in quiet mode so CI output stays focused on actionable diagnostics.
