### PR TITLE
Use const ref for return types to not make temporary objects

### DIFF
--- a/graph/compute_graph_op.cpp
+++ b/graph/compute_graph_op.cpp
@@ -215,7 +215,7 @@ VkPipelineLayout ComputePipelineLayout::getVkPipelineLayout() const { return pip
 
 const DescriptorMap &ComputePipelineLayout::getDescriptorMap() const { return descriptorMap; }
 
-std::shared_ptr<TensorDescriptor> ComputePipelineLayout::getTensor(const uint32_t set) {
+const std::shared_ptr<TensorDescriptor> &ComputePipelineLayout::getTensorForSet(const uint32_t set) const {
     for (const auto &descriptor : descriptorMap) {
         if (descriptor.id.set == set && descriptor.direction == Output) {
             return descriptor.tensor;
@@ -504,7 +504,9 @@ ComputePipelineBase::~ComputePipelineBase() = default;
 
 void ComputePipelineBase::cmdBindAndDispatch(VkCommandBuffer, const ComputeDescriptorSetMap &) {}
 
-std::shared_ptr<ComputePipelineLayout> ComputePipelineBase::getComputePipelineLayout() const { return pipelineLayout; }
+const std::shared_ptr<ComputePipelineLayout> &ComputePipelineBase::getComputePipelineLayout() const {
+    return pipelineLayout;
+}
 
 const std::vector<std::shared_ptr<VirtualTensor>> &ComputePipelineBase::getParents() const { return parents; }
 
@@ -556,7 +558,7 @@ void ComputePipeline::cmdBindAndDispatch(VkCommandBuffer commandBuffer,
 
 void ComputePipeline::cmdDispatch(VkCommandBuffer commandBuffer) {
     // Get first output tensor
-    const auto &tensor = pipelineLayout->getTensor(0);
+    const auto &tensor = pipelineLayout->getTensorForSet(0);
     const auto &size = uint32_t(tensor->getShapeSize());
 
     const auto groupCountX = static_cast<uint32_t>(std::ceil(std::sqrt(double(divideRoundUp(size, warp1D)))));
@@ -890,7 +892,7 @@ DescriptorMap Concat::createDescriptorMap(const std::shared_ptr<TensorDescriptor
 }
 
 void Concat::cmdDispatch(VkCommandBuffer commandBuffer) {
-    const auto &tensor = pipelineLayout->getTensor(1);
+    const auto &tensor = pipelineLayout->getTensorForSet(1);
     const auto &size = uint32_t(tensor->getShapeSize());
 
     const auto groupCountX = static_cast<uint32_t>(std::ceil(std::sqrt(double(divideRoundUp(size, warp1D)))));
@@ -1000,7 +1002,7 @@ SpirvBinary Conv2D::createSpirv(const std::shared_ptr<PipelineCache> &_pipelineC
 
 void Conv2D::cmdDispatch(VkCommandBuffer commandBuffer) {
     // Get first output tensor
-    const auto &tensor = pipelineLayout->getTensor(0);
+    const auto &tensor = pipelineLayout->getTensorForSet(0);
     const auto &dimensions = tensor->getDimensions();
     loader->vkCmdDispatch(commandBuffer, divideRoundUp(static_cast<uint32_t>(dimensions[0] * dimensions[2]), warpX),
                           divideRoundUp(static_cast<uint32_t>(dimensions[1]), warpY),
@@ -2346,7 +2348,7 @@ SpecConstants BlockMatch::createSpecConstants(const std::vector<uint32_t> &kerne
 }
 
 void BlockMatch::cmdDispatch(VkCommandBuffer commandBuffer) {
-    const auto &tensor = pipelineLayout->getTensor(0);
+    const auto &tensor = pipelineLayout->getTensorForSet(0);
     const auto &dimensions = tensor->getDimensions();
     loader->vkCmdDispatch(commandBuffer, divideRoundUp(static_cast<uint32_t>(dimensions[3]), warpX),
                           divideRoundUp(static_cast<uint32_t>(dimensions[2]), warpY), 1);
@@ -2407,13 +2409,7 @@ ComputeDescriptorSetMap GraphPipeline::makeConstantsDescriptorSets() const {
         filter[tensor->getTensorDescriptor()] = tensor;
     }
 
-    ComputeDescriptorSetMap mapping;
-    for (const auto &pipeline : pipelines) {
-        const auto &pipelineLayout = pipeline->getComputePipelineLayout();
-        pipelineLayout->makeDescriptorSets(mapping, filter);
-    }
-
-    return mapping;
+    return getComputeDescriptorSetMap(filter);
 }
 
 void GraphPipeline::makeDescriptorSetBinding(const uint32_t set, const uint32_t binding, const uint32_t arrayIndex,
@@ -2454,13 +2450,7 @@ ComputeDescriptorSetMap GraphPipeline::makeSessionRamDescriptorSets() const {
         filter[tensorDescriptor] = TensorDescriptor::makeTensor(tensorDescriptor);
     }
 
-    ComputeDescriptorSetMap mapping;
-    for (const auto &pipeline : pipelines) {
-        const auto &pipelineLayout = pipeline->getComputePipelineLayout();
-        pipelineLayout->makeDescriptorSets(mapping, filter);
-    }
-
-    return mapping;
+    return getComputeDescriptorSetMap(filter);
 }
 
 ComputeDescriptorSetMap GraphPipeline::makeExternalDescriptorSets(const uint32_t set) const {
@@ -2469,13 +2459,15 @@ ComputeDescriptorSetMap GraphPipeline::makeExternalDescriptorSets(const uint32_t
         return {};
     }
 
-    const auto &filter = filterIt->second;
+    return getComputeDescriptorSetMap(filterIt->second);
+}
+
+ComputeDescriptorSetMap GraphPipeline::getComputeDescriptorSetMap(const TensorDescriptorMap &filter) const {
     ComputeDescriptorSetMap mapping;
     for (const auto &pipeline : pipelines) {
         const auto &pipelineLayout = pipeline->getComputePipelineLayout();
         pipelineLayout->makeDescriptorSets(mapping, filter);
     }
-
     return mapping;
 }
 

--- a/graph/compute_graph_op.hpp
+++ b/graph/compute_graph_op.hpp
@@ -124,7 +124,7 @@ class ComputePipelineLayout {
 
     VkPipelineLayout getVkPipelineLayout() const;
     const DescriptorMap &getDescriptorMap() const;
-    std::shared_ptr<TensorDescriptor> getTensor(uint32_t set);
+    const std::shared_ptr<TensorDescriptor> &getTensorForSet(uint32_t set) const;
 
     void makeDescriptorSets(ComputeDescriptorSetMap &mapping, const TensorDescriptorMap &filter) const;
     void cmdBindAndDispatch(VkCommandBuffer commandBuffer, const ComputeDescriptorSetMap &descriptorSetMap);
@@ -161,7 +161,7 @@ class ComputePipelineBase {
 
     virtual void cmdBindAndDispatch(VkCommandBuffer commandBuffer, const ComputeDescriptorSetMap &descriptorSetMap);
 
-    std::shared_ptr<ComputePipelineLayout> getComputePipelineLayout() const;
+    const std::shared_ptr<ComputePipelineLayout> &getComputePipelineLayout() const;
 
     const std::vector<std::shared_ptr<VirtualTensor>> &getParents() const;
     void pushParent(const std::shared_ptr<VirtualTensor> &tensor);
@@ -1497,6 +1497,8 @@ class GraphPipeline {
         auto pipeline = std::make_shared<PipelineT>(loader, device, pipelineCache, std::forward<Args>(args)...);
         pipelines.emplace_back(std::move(pipeline));
     }
+
+    ComputeDescriptorSetMap getComputeDescriptorSetMap(const TensorDescriptorMap &filter) const;
 
     std::shared_ptr<VULKAN_HPP_NAMESPACE::detail::DispatchLoaderDynamic> loader;
     VkPhysicalDevice physicalDevice;

--- a/graph/tensor.cpp
+++ b/graph/tensor.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2024-2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2024-2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
  * SPDX-License-Identifier: Apache-2.0
  *
  */
@@ -40,7 +40,7 @@ Tensor::~Tensor() {
     }
 }
 
-std::shared_ptr<TensorDescriptor> Tensor::getTensorDescriptor() const { return tensorDescriptor; }
+const std::shared_ptr<TensorDescriptor> &Tensor::getTensorDescriptor() const { return tensorDescriptor; }
 
 VkTensorARM Tensor::getVkTensorARM() const { return tensorARM; }
 
@@ -350,7 +350,7 @@ bool VirtualTensor::getVisited() const { return visited; }
 
 void VirtualTensor::setVisited(const bool _visited) { visited = _visited; }
 
-std::shared_ptr<TensorDescriptor> VirtualTensor::getTensor() const { return tensor; }
+const std::shared_ptr<TensorDescriptor> &VirtualTensor::getTensor() const { return tensor; }
 
 ComputePipelineBase *VirtualTensor::getParentPipeline() const { return parent; }
 

--- a/graph/tensor.hpp
+++ b/graph/tensor.hpp
@@ -35,7 +35,7 @@ class Tensor {
 
     ~Tensor();
 
-    std::shared_ptr<TensorDescriptor> getTensorDescriptor() const;
+    const std::shared_ptr<TensorDescriptor> &getTensorDescriptor() const;
     VkTensorARM getVkTensorARM() const;
     VkTensorViewARM getVkTensorViewARM() const;
 
@@ -127,7 +127,7 @@ class VirtualTensor {
     bool getVisited() const;
     void setVisited(bool _visited);
 
-    std::shared_ptr<TensorDescriptor> getTensor() const;
+    const std::shared_ptr<TensorDescriptor> &getTensor() const;
     ComputePipelineBase *getParentPipeline() const;
     ComputePipelineBase *getDescendantPipeline() const;
 

--- a/tensor/tensor_arm.cpp
+++ b/tensor/tensor_arm.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2023-2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2023-2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
  * SPDX-License-Identifier: Apache-2.0
  *
  */
@@ -340,7 +340,7 @@ VkPipelineLayout TensorCopyPipeline::createPipelineLayout() const {
 }
 
 VkPipeline TensorCopyPipeline::createPipeline(const TensorARM &srcTensor) const {
-    uint32_t rank = uint32_t(srcTensor.getTensorInfo().dimensions.size());
+    const auto rank = static_cast<uint32_t>(srcTensor.getTensorInfo().dimensions.size());
     const VkSpecializationMapEntry entry = {
         0,               // constantID
         0,               // offset

--- a/tensor/tensor_arm.hpp
+++ b/tensor/tensor_arm.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2023-2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2023-2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
  * SPDX-License-Identifier: Apache-2.0
  *
  */
@@ -43,7 +43,7 @@ class TensorARM {
     TensorARM &operator=(const TensorARM &) = delete;
 
     VkBuffer getTensorBuffer() const { return m_tensorBuffer; };
-    TensorInfo getTensorInfo() const { return m_info; };
+    const TensorInfo &getTensorInfo() const { return m_info; };
 
     VkResult create(const Device &dev, const VkTensorCreateInfoARM &createInfo, const VkAllocationCallbacks *allocator);
     void destroy(const Device &dev, const VkAllocationCallbacks *pAllocator);

--- a/tensor/tensor_descriptor.cpp
+++ b/tensor/tensor_descriptor.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2023-2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2023-2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
  * SPDX-License-Identifier: Apache-2.0
  *
  */
@@ -55,7 +55,7 @@ VkResult TensorDescriptor::create(const Device &dev, const VkTensorViewCreateInf
 
 VkBuffer TensorDescriptor::getTensorDescriptorBuffer(const Device &dev, VkTensorARM tensorHandle) {
     auto *tensor = reinterpret_cast<TensorARM *>(tensorHandle);
-    const auto info = tensor->getTensorInfo();
+    const auto &info = tensor->getTensorInfo();
 
     DescriptorBuffer *descriptor;
     VkResult result =

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -35,6 +35,7 @@ if(NOT APPLE)
         TARGET mlel_unit_tests
         SOURCES
             optical_flow_tests.cpp
+            common_tests.cpp
             vulkan.cpp
         DEFINITIONS
             SHADER_SOURCE_DIR=${SHADER_SOURCE_DIR}
@@ -54,6 +55,7 @@ else()
     mlel_add_test(
         TARGET mlel_unit_tests
         SOURCES
+            common_tests.cpp
             vulkan.cpp
         DEFINITIONS
             SHADER_SOURCE_DIR=${SHADER_SOURCE_DIR}

--- a/tests/common_tests.cpp
+++ b/tests/common_tests.cpp
@@ -1,0 +1,207 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+#include <gtest/gtest.h>
+
+#include "mlel/float.hpp"
+#include "mlel/log.hpp"
+#include "mlel/utils.hpp"
+
+#include <cmath>
+#include <cstdint>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <vulkan/vulkan.h>
+
+using namespace mlsdk::el::log;
+using namespace mlsdk::el::utils;
+
+namespace {
+
+TEST(MLEmulationLayerLog, DefaultLogLevelHighSeverity) {
+    Log testLog("VMEL_TEST_SEVERITY", "TestLog");
+
+    testLog(Severity::Debug) << "Serverity is Debug(3)\n";
+}
+
+TEST(MLEmulationLayerLog, DefaultLogLevelLowSeverity) { // cppcheck-suppress syntaxError
+    Log testLog("VMEL_TEST_SEVERITY", "TestLog");
+
+    testLog(Severity::Error) << "Serverity is Error(0)\n";
+}
+
+TEST(MLEmulationLayerLog, StdFunctions) {
+    Log testLog("VMEL_TEST_SEVERITY", "TestLog");
+
+    testLog(Severity::Error) << "Serverity is Error(0)" << std::endl;
+    testLog(Severity::Info) << "Serverity is Info(2)" << std::endl;
+    testLog(Severity::Error) << "Serverity is Error(0)" << std::endl;
+}
+
+TEST(MLEmulationLayerLog, Vectors) {
+    Log testLog("VMEL_TEST_SEVERITY", "TestLog");
+    const std::vector<std::string> strVector{"Hello", "World", "!"};
+    const std::vector<int> intVector{1, 2, 3, 4, 5};
+
+    testLog(Severity::Error) << strVector << "\n";
+    testLog(Severity::Error) << intVector << "\n";
+}
+
+TEST(MLEmulationLayerLog, LineNumbers) {
+    Log testLog("VMEL_TEST_SEVERITY", "TestLog");
+    const std::string str("Hello world\nThis is line 2\nFinal line");
+
+    testLog(Severity::Error) << StringLineNumber(str) << std::endl;
+}
+
+TEST(MLEmulationLayerLog, HexDump) {
+    Log testLog("VMEL_TEST_SEVERITY", "TestLog");
+    const uint8_t testchar[]{"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor "
+                             "incididunt ut labore et dolore magna "
+                             "aliqua."};
+    const auto *charPointer{testchar};
+
+    testLog(Severity::Error) << HexDump(charPointer, sizeof(testchar));
+}
+
+template <typename T> void checkFloat(T v) {
+    float8_e4m3 f8{v};
+    float16 f16{v};
+    float32 f32{v};
+    float64 f64{v};
+
+    EXPECT_NEAR(double(f8), double(v), 0.5);
+    ASSERT_EQ(double(f16), v);
+    ASSERT_EQ(double(f32), v);
+    ASSERT_EQ(double(f64), v);
+
+    v += 1;
+    f8 = v;
+    f16 = v;
+    f32 = v;
+    f64 = v;
+
+    EXPECT_NEAR(double(f8), double(v), 0.5);
+    ASSERT_EQ(double(f16), v);
+    ASSERT_EQ(double(f32), v);
+    ASSERT_EQ(double(f64), v);
+}
+
+TEST(MLEmulationLayerFloat, Formats) {
+    ASSERT_EQ(sizeof(float8_e4m3), 1);
+    ASSERT_EQ(sizeof(float16), 2);
+    ASSERT_EQ(sizeof(float32), 4);
+    ASSERT_EQ(sizeof(float64), 8);
+
+    checkFloat(float(-10.5));
+    checkFloat(float(-0.5));
+    checkFloat(float(0));
+    checkFloat(float(0.5));
+    checkFloat(float(10.0));
+
+    checkFloat(int8_t(1));
+    checkFloat(uint8_t(2));
+    checkFloat(int16_t(3));
+    checkFloat(uint16_t(4));
+    checkFloat(int32_t(5));
+    checkFloat(uint32_t(6));
+    checkFloat(int64_t(7));
+    checkFloat(uint64_t(8));
+
+    checkFloat(float8_e4m3(10.5));
+    checkFloat(float16(11.5));
+    checkFloat(float32(12.5));
+    checkFloat(float64(13.5));
+
+    auto f = float(float16(10.5));
+    ASSERT_EQ(double(f), 10.5);
+
+    float16 f16;
+
+    f16 = f16 + 10;
+    ASSERT_EQ(double(f16), 10);
+
+    f16 += 10;
+    ASSERT_EQ(double(f16), 20);
+
+    f16 = f16 - 5;
+    ASSERT_EQ(double(f16), 15);
+
+    f16 -= 5;
+    ASSERT_EQ(double(f16), 10);
+
+    f16 = f16 * 2;
+    ASSERT_EQ(double(f16), 20);
+
+    f16 *= 2;
+    ASSERT_EQ(double(f16), 40);
+
+    f16 = f16 / 4;
+    ASSERT_EQ(double(f16), 10);
+
+    f16 /= 4;
+    ASSERT_EQ(double(f16), 2.5);
+
+    ASSERT_TRUE(f16 < 5);
+    ASSERT_FALSE(5 < f16);
+
+    ASSERT_TRUE(f16 <= 5);
+    ASSERT_FALSE(5 <= f16);
+
+    ASSERT_FALSE(f16 > 5);
+    ASSERT_TRUE(5 > f16);
+
+    ASSERT_FALSE(f16 >= 5);
+    ASSERT_TRUE(5 >= f16);
+
+    ASSERT_FALSE(f16 == 5);
+    ASSERT_TRUE(f16 == 2.5);
+
+    ASSERT_TRUE(f16 != 5);
+    ASSERT_FALSE(f16 != 2.5);
+
+    uint32_t overflow = 0U << 31 | 250 << 23 | 1 << 22;
+    void *overflowPtr = &overflow;
+    f16 = *reinterpret_cast<float *>(overflowPtr);
+    ASSERT_FALSE(f16.isnan());
+    ASSERT_TRUE(f16.isinf());
+    ASSERT_FALSE(std::isnan(f16));
+    ASSERT_TRUE(std::isinf(f16));
+    ASSERT_FALSE(std::isnormal(float(f16)));
+
+    uint32_t nan = 0xffffffff;
+    void *nanPtr = &nan;
+    f16 = *reinterpret_cast<float *>(nanPtr);
+    ASSERT_TRUE(f16.isnan());
+    ASSERT_FALSE(f16.isinf());
+    ASSERT_TRUE(std::isnan(f16));
+    ASSERT_FALSE(std::isinf(f16));
+    ASSERT_FALSE(std::isnormal(float(f16)));
+
+    uint32_t pinf = 0U << 31 | 0xffU << 23 | 0;
+    void *pinfPtr = &pinf;
+    f16 = *reinterpret_cast<float *>(pinfPtr);
+    ASSERT_FALSE(f16.isnan());
+    ASSERT_TRUE(f16.isinf());
+    ASSERT_FALSE(std::isnan(f16));
+    ASSERT_TRUE(std::isinf(f16));
+    ASSERT_FALSE(std::isnormal(float(f16)));
+
+    uint32_t ninf = 1U << 31 | 0xffU << 23 | 0;
+    void *ninfPtr = &ninf;
+    f16 = *reinterpret_cast<float *>(ninfPtr);
+    ASSERT_FALSE(f16.isnan());
+    ASSERT_TRUE(f16.isinf());
+    ASSERT_FALSE(std::isnan(f16));
+    ASSERT_TRUE(std::isinf(f16));
+    ASSERT_FALSE(std::isnormal(float(f16)));
+}
+
+} // namespace

--- a/tests/vulkan.cpp
+++ b/tests/vulkan.cpp
@@ -11,8 +11,6 @@
 #include <gtest/gtest.h>
 
 #include "mlel/device.hpp"
-#include "mlel/float.hpp"
-#include "mlel/log.hpp"
 #include "mlel/pipeline.hpp"
 #include "mlel/tensor.hpp"
 #include "mlel/utils.hpp"
@@ -1500,58 +1498,6 @@ TEST_F(MLEmulationLayerForVulkan, CreateTensorComputePipeline) {
 }
 #endif
 
-TEST_F(MLEmulationLayerForVulkan, LoggerDefaultLogLevelHighSeverity) {
-    using namespace mlsdk::el::log;
-    Log testLog("VMEL_TEST_SEVERITY", "TestLog");
-
-    testLog(Severity::Debug) << "Serverity is Debug(3)\n";
-}
-
-TEST_F(MLEmulationLayerForVulkan, LoggerDefaultLogLevelLowSeverity) {
-    using namespace mlsdk::el::log;
-    Log testLog("VMEL_TEST_SEVERITY", "TestLog");
-
-    testLog(Severity::Error) << "Serverity is Error(0)\n";
-}
-
-TEST_F(MLEmulationLayerForVulkan, LoggerStdFunctions) {
-    using namespace mlsdk::el::log;
-    Log testLog("VMEL_TEST_SEVERITY", "TestLog");
-
-    testLog(Severity::Error) << "Serverity is Error(0)" << std::endl;
-    testLog(Severity::Info) << "Serverity is Info(2)" << std::endl;
-    testLog(Severity::Error) << "Serverity is Error(0)" << std::endl;
-}
-
-TEST_F(MLEmulationLayerForVulkan, LoggerVectors) {
-    using namespace mlsdk::el::log;
-    Log testLog("VMEL_TEST_SEVERITY", "TestLog");
-    const std::vector<std::string> strVector{"Hello", "World", "!"};
-    const std::vector<int> intVector{1, 2, 3, 4, 5};
-
-    testLog(Severity::Error) << strVector << "\n";
-    testLog(Severity::Error) << intVector << "\n";
-}
-
-TEST_F(MLEmulationLayerForVulkan, LoggerLineNumbers) {
-    using namespace mlsdk::el::log;
-    Log testLog("VMEL_TEST_SEVERITY", "TestLog");
-    const std::string str("Hello world\nThis is line 2\nFinal line");
-
-    testLog(Severity::Error) << StringLineNumber(str) << std::endl;
-}
-
-TEST_F(MLEmulationLayerForVulkan, LoggerHexDump) {
-    using namespace mlsdk::el::log;
-    Log testLog("VMEL_TEST_SEVERITY", "TestLog");
-    const uint8_t testchar[]{"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor "
-                             "incididunt ut labore et dolore magna "
-                             "aliqua."};
-    const auto *charPointer{testchar};
-
-    testLog(Severity::Error) << HexDump(charPointer, sizeof(testchar));
-}
-
 TEST_F(MLEmulationLayerForVulkan, CopyLargeNonPackedTensor) {
     auto device = createDevice();
     const std::vector<int64_t> dimensions{1, 1920, 1080, 3};
@@ -1620,139 +1566,6 @@ TEST_F(MLEmulationLayerForVulkan, CopyLargeNonPackedTensor) {
               << " ms" << std::endl;
 
     ASSERT_TRUE((outputTensor->stridedCompare<int8_t, int8_t>(*inputTensor))) << "Output mismatch";
-}
-
-template <typename T> void checkFloat(T v) {
-    float8_e4m3 f8{v};
-    float16 f16{v};
-    float32 f32{v};
-    float64 f64{v};
-
-    EXPECT_NEAR(double(f8), double(v), 0.5);
-    ASSERT_EQ(double(f16), v);
-    ASSERT_EQ(double(f32), v);
-    ASSERT_EQ(double(f64), v);
-
-    v += 1;
-    f8 = v;
-    f16 = v;
-    f32 = v;
-    f64 = v;
-
-    EXPECT_NEAR(double(f8), double(v), 0.5);
-    ASSERT_EQ(double(f16), v);
-    ASSERT_EQ(double(f32), v);
-    ASSERT_EQ(double(f64), v);
-}
-
-TEST_F(MLEmulationLayerForVulkan, Float) {
-    ASSERT_EQ(sizeof(float8_e4m3), 1);
-    ASSERT_EQ(sizeof(float16), 2);
-    ASSERT_EQ(sizeof(float32), 4);
-    ASSERT_EQ(sizeof(float64), 8);
-
-    checkFloat(float(-10.5));
-    checkFloat(float(-0.5));
-    checkFloat(float(0));
-    checkFloat(float(0.5));
-    checkFloat(float(10.0));
-
-    checkFloat(int8_t(1));
-    checkFloat(uint8_t(2));
-    checkFloat(int16_t(3));
-    checkFloat(uint16_t(4));
-    checkFloat(int32_t(5));
-    checkFloat(uint32_t(6));
-    checkFloat(int64_t(7));
-    checkFloat(uint64_t(8));
-
-    checkFloat(float8_e4m3(10.5));
-    checkFloat(float16(11.5));
-    checkFloat(float32(12.5));
-    checkFloat(float64(13.5));
-
-    auto f = float(float16(10.5));
-    ASSERT_EQ(double(f), 10.5);
-
-    float16 f16;
-
-    f16 = f16 + 10;
-    ASSERT_EQ(double(f16), 10);
-
-    f16 += 10;
-    ASSERT_EQ(double(f16), 20);
-
-    f16 = f16 - 5;
-    ASSERT_EQ(double(f16), 15);
-
-    f16 -= 5;
-    ASSERT_EQ(double(f16), 10);
-
-    f16 = f16 * 2;
-    ASSERT_EQ(double(f16), 20);
-
-    f16 *= 2;
-    ASSERT_EQ(double(f16), 40);
-
-    f16 = f16 / 4;
-    ASSERT_EQ(double(f16), 10);
-
-    f16 /= 4;
-    ASSERT_EQ(double(f16), 2.5);
-
-    ASSERT_TRUE(f16 < 5);
-    ASSERT_FALSE(5 < f16);
-
-    ASSERT_TRUE(f16 <= 5);
-    ASSERT_FALSE(5 <= f16);
-
-    ASSERT_FALSE(f16 > 5);
-    ASSERT_TRUE(5 > f16);
-
-    ASSERT_FALSE(f16 >= 5);
-    ASSERT_TRUE(5 >= f16);
-
-    ASSERT_FALSE(f16 == 5);
-    ASSERT_TRUE(f16 == 2.5);
-
-    ASSERT_TRUE(f16 != 5);
-    ASSERT_FALSE(f16 != 2.5);
-
-    uint32_t overflow = 0U << 31 | 250 << 23 | 1 << 22;
-    void *overflowPtr = &overflow;
-    f16 = *reinterpret_cast<float *>(overflowPtr);
-    ASSERT_FALSE(f16.isnan());
-    ASSERT_TRUE(f16.isinf());
-    ASSERT_FALSE(std::isnan(f16));
-    ASSERT_TRUE(std::isinf(f16));
-    ASSERT_FALSE(std::isnormal(float(f16)));
-
-    uint32_t nan = 0xffffffff;
-    void *nanPtr = &nan;
-    f16 = *reinterpret_cast<float *>(nanPtr);
-    ASSERT_TRUE(f16.isnan());
-    ASSERT_FALSE(f16.isinf());
-    ASSERT_TRUE(std::isnan(f16));
-    ASSERT_FALSE(std::isinf(f16));
-    ASSERT_FALSE(std::isnormal(float(f16)));
-
-    uint32_t pinf = 0U << 31 | 0xffU << 23 | 0;
-    void *pinfPtr = &pinf;
-    f16 = *reinterpret_cast<float *>(pinfPtr);
-    ASSERT_FALSE(f16.isnan());
-    ASSERT_TRUE(f16.isinf());
-    ASSERT_FALSE(std::isnan(f16));
-    ASSERT_TRUE(std::isinf(f16));
-    ASSERT_FALSE(std::isnormal(float(f16)));
-
-    uint32_t ninf = 1U << 31 | 0xffU << 23 | 0;
-    void *ninfPtr = &ninf;
-    f16 = *reinterpret_cast<float *>(ninfPtr);
-    ASSERT_FALSE(f16.isnan());
-    ASSERT_TRUE(f16.isinf());
-    ASSERT_FALSE(std::isnan(f16));
-    ASSERT_TRUE(std::isinf(f16));
-    ASSERT_FALSE(std::isnormal(float(f16)));
 }
 
 TEST_F(MLEmulationLayerForVulkan, MultiSessionsInOneCommandBuffer) {


### PR DESCRIPTION
Create small helper function.
Add unit tests file for common.

Change-Id: I7f76e1c1de513b6e2e45f8fc4c531f5502a4c770