### PR TITLE
Avoid temporary objects

### DIFF
--- a/common/include/mlel/utils.hpp
+++ b/common/include/mlel/utils.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2024-2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2024-2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
  * SPDX-License-Identifier: Apache-2.0
  *
  */
@@ -11,6 +11,7 @@
  *******************************************************************************/
 #include <memory>
 #include <string>
+#include <string_view>
 #include <vector>
 #include <vulkan/vulkan.hpp>
 
@@ -30,21 +31,19 @@ inline uint32_t divideRoundUp(const uint32_t value, const uint32_t divide) { ret
 
 std::vector<uint32_t> glslToSpirv(const std::string &glsl);
 
-class FormatBase {
-  public:
-    virtual ~FormatBase() {}
-
-    virtual bool isInteger() const = 0;
-    virtual bool isSigned() const = 0;
-    virtual std::string lowest() const = 0;
-    virtual std::string max() const = 0;
-    virtual std::string glslType() const = 0;
-    virtual std::string toInt() const = 0;
+struct FormatInfo {
+    bool isInteger;
+    bool isSigned;
+    std::string_view lowest;
+    std::string_view max;
+    std::string_view glslType;
+    std::string_view typeId;
+    std::string_view compType;
 };
 
-std::shared_ptr<FormatBase> makeFormat(VkFormat format);
+const FormatInfo *getFormatInfo(VkFormat format);
 
-std::shared_ptr<FormatBase> makeFormat(VkFormat format, bool isUnsigned);
+const FormatInfo *getFormatInfo(VkFormat format, bool isUnsigned);
 
 template <typename T> class Span {
   private:

--- a/common/utils.cpp
+++ b/common/utils.cpp
@@ -9,12 +9,10 @@
  *******************************************************************************/
 
 #include "mlel/utils.hpp"
-#include "mlel/float.hpp"
 #include "mlel/log.hpp"
 #include <functional>
 #include <glslang/Include/glslang_c_interface.h>
 #include <glslang/Public/resource_limits_c.h>
-#include <limits>
 
 using namespace mlsdk::el::log;
 
@@ -96,133 +94,113 @@ std::vector<uint32_t> glslToSpirv(const std::string &glsl) {
     return spirv;
 }
 
-template <typename T> class Format : public FormatBase {
-  public:
-    explicit Format(const std::string &_glslType, const std::string &_literalSuffix = "")
-        : _glslType{_glslType}, charType{getCharType()}, literalSuffix{_literalSuffix} {}
+namespace {
+// Type tags are local shader constants defined in graph/shaders/graph_op/common.comp.
+// They are encoded as two ASCII bytes: kind ('b', 'i', 'u', 'f') followed by byte size or reduced-float subtype.
+constexpr FormatInfo int8Format{true, true, "-128", "127", "int8_t", "0x6931", "int8_t"};
+constexpr FormatInfo uint8Format{true, false, "0u", "255u", "uint8_t", "0x7531", "uint8_t"};
+constexpr FormatInfo boolFormat{true, false, "0", "1", "bool", "0x6231", "bool"};
+constexpr FormatInfo int16Format{true, true, "-32768", "32767", "int16_t", "0x6932", "int16_t"};
+constexpr FormatInfo uint16Format{true, false, "0u", "65535u", "uint16_t", "0x7532", "uint16_t"};
+constexpr FormatInfo float16Format{false, true, "-65504.000000", "65504.000000", "float16_t", "0x6632", "float16_t"};
+constexpr FormatInfo bfloat16Format{false,    true,   "-3.3895313892515355e+38", "3.3895313892515355e+38", "bfloat16_t",
+                                    "0x6642", "float"};
+constexpr FormatInfo float8e5m2Format{false, true, "-57344", "57344", "float8_e5m2_t", "0x664D", "float16_t"};
+constexpr FormatInfo float8e4m3Format{false, true, "-448", "448", "float8_e4m3_t", "0x664E", "float16_t"};
+constexpr FormatInfo int32Format{true, true, "-2147483648", "2147483647", "int", "0x6934", "int"};
+constexpr FormatInfo uint32Format{true, false, "0u", "4294967295u", "uint32_t", "0x7534", "uint32_t"};
+constexpr FormatInfo float32Format{false,
+                                   true,
+                                   "-340282346638528859811704183484516925440.000000",
+                                   "340282346638528859811704183484516925440.000000",
+                                   "float",
+                                   "0x6634",
+                                   "float"};
+constexpr FormatInfo int64Format{true,     true,     "-9223372036854775808ll", "9223372036854775807ll", "int64_t",
+                                 "0x6938", "int64_t"};
+constexpr FormatInfo uint64Format{true, false, "0ull", "18446744073709551615ull", "uint64_t", "0x7538", "uint64_t"};
+constexpr FormatInfo doubleFormat{false,
+                                  true,
+                                  "-179769313486231570814527423731704356798070567525844996598917476803"
+                                  "157260780028538760589558632766878171540458953514382464234321326889"
+                                  "464182768467546703537516986049910576551282076245490090389328944075"
+                                  "868508455133942304583236903222948165808559332123348274797826204144"
+                                  "723168738177180919299881250404026184124858368.000000ll",
+                                  "179769313486231570814527423731704356798070567525844996598917476803"
+                                  "157260780028538760589558632766878171540458953514382464234321326889"
+                                  "464182768467546703537516986049910576551282076245490090389328944075"
+                                  "868508455133942304583236903222948165808559332123348274797826204144"
+                                  "723168738177180919299881250404026184124858368.000000ll",
+                                  "double",
+                                  "0x6638",
+                                  "double"};
+} // namespace
 
-    bool isInteger() const override { return std::numeric_limits<T>::is_integer; }
-    bool isSigned() const override { return std::numeric_limits<T>::is_signed; }
-    std::string lowest() const override { return std::to_string(std::numeric_limits<T>::lowest()) + literalSuffix; }
-    std::string max() const override { return std::to_string(std::numeric_limits<T>::max()) + literalSuffix; }
-    std::string glslType() const override { return _glslType; }
-    std::string toInt() const override { return std::to_string(uint64_t(charType) << 8 | ('0' + sizeof(T))); }
-
-  private:
-    const std::string _glslType;
-    const int charType;
-    const std::string literalSuffix;
-
-    static constexpr int getCharType() {
-        if constexpr (std::numeric_limits<T>::is_integer) {
-            if constexpr (std::numeric_limits<T>::digits == 1) {
-                return 'b';
-            } else if constexpr (std::numeric_limits<T>::is_signed) {
-                return 'i';
-            } else {
-                return 'u';
-            }
-        } else {
-            return 'f';
-        }
-    }
-};
-
-class BFloat16Format final : public FormatBase {
-  public:
-    bool isInteger() const override { return false; } // semantic float
-    bool isSigned() const override { return true; }
-    std::string lowest() const override { return "-3.3895313892515355e+38"; }
-    std::string max() const override { return "3.3895313892515355e+38"; }
-    std::string glslType() const override { return "bfloat16_t"; } // BF16 payload storage
-    std::string toInt() const override { return "0x6642"; }        // "fB"
-};
-
-class Float8E5M2Format final : public FormatBase {
-  public:
-    bool isInteger() const override { return false; } // semantic float
-    bool isSigned() const override { return true; }
-    std::string lowest() const override { return "-57344"; }          // IEEE-like f8e5m2 finite minimum
-    std::string max() const override { return "57344"; }              // IEEE-like f8e5m2 finite maximum
-    std::string glslType() const override { return "float8_e5m2_t"; } // FP8 payload storage
-    std::string toInt() const override { return "0x664D"; }           // "fM"
-};
-
-class Float8E4M3Format final : public FormatBase {
-  public:
-    bool isInteger() const override { return false; } // semantic float
-    bool isSigned() const override { return true; }
-    std::string lowest() const override { return "-448"; }            // IEEE-like f8e4m3 finite minimum
-    std::string max() const override { return "448"; }                // IEEE-like f8e4m3 finite maximum
-    std::string glslType() const override { return "float8_e4m3_t"; } // FP8 payload storage
-    std::string toInt() const override { return "0x664E"; }           // "fN"
-};
-
-std::shared_ptr<FormatBase> makeFormat(const VkFormat format) {
+const FormatInfo *getFormatInfo(const VkFormat format) {
     switch (format) {
     case VK_FORMAT_R8_SINT:
-        return std::make_shared<Format<int8_t>>("int8_t");
+        return &int8Format;
     case VK_FORMAT_R8_UINT:
     case VK_FORMAT_S8_UINT:
-        return std::make_shared<Format<uint8_t>>("uint8_t", "u");
+        return &uint8Format;
     case VK_FORMAT_R8_BOOL_ARM:
-        return std::make_shared<Format<bool>>("bool");
+        return &boolFormat;
     case VK_FORMAT_R16_SINT:
-        return std::make_shared<Format<int16_t>>("int16_t");
+        return &int16Format;
     case VK_FORMAT_R16_UINT:
-        return std::make_shared<Format<uint16_t>>("uint16_t", "u");
+        return &uint16Format;
     case VK_FORMAT_R16_SFLOAT:
-        return std::make_shared<Format<float16>>("float16_t");
+        return &float16Format;
     case VK_FORMAT_R16_SFLOAT_FPENCODING_BFLOAT16_ARM:
-        return std::make_shared<BFloat16Format>();
+        return &bfloat16Format;
     case VK_FORMAT_R8_SFLOAT_FPENCODING_FLOAT8E5M2_ARM:
-        return std::make_shared<Float8E5M2Format>();
+        return &float8e5m2Format;
     case VK_FORMAT_R8_SFLOAT_FPENCODING_FLOAT8E4M3_ARM:
-        return std::make_shared<Float8E4M3Format>();
+        return &float8e4m3Format;
     case VK_FORMAT_R32_SINT:
-        return std::make_shared<Format<int32_t>>("int");
+        return &int32Format;
     case VK_FORMAT_R32_UINT:
-        return std::make_shared<Format<uint32_t>>("uint32_t", "u");
+        return &uint32Format;
     case VK_FORMAT_R32_SFLOAT:
-        return std::make_shared<Format<float>>("float");
+        return &float32Format;
     case VK_FORMAT_R64_SINT:
-        return std::make_shared<Format<int64_t>>("int64_t", "ll");
+        return &int64Format;
     case VK_FORMAT_R64_UINT:
-        return std::make_shared<Format<uint64_t>>("uint64_t", "ull");
+        return &uint64Format;
     case VK_FORMAT_R64_SFLOAT:
-        return std::make_shared<Format<double>>("double", "ll");
+        return &doubleFormat;
     default:
         throw std::runtime_error("Unsupported tensor buffer format: " + std::to_string(format));
     }
 }
 
-std::shared_ptr<FormatBase> makeFormat(const VkFormat format, const bool isUnsigned) {
+const FormatInfo *getFormatInfo(const VkFormat format, const bool isUnsigned) {
     if (isUnsigned) {
         switch (format) {
         case VK_FORMAT_R8_SINT:
-            return makeFormat(VK_FORMAT_R8_UINT);
+            return getFormatInfo(VK_FORMAT_R8_UINT);
         case VK_FORMAT_R16_SINT:
-            return makeFormat(VK_FORMAT_R16_UINT);
+            return getFormatInfo(VK_FORMAT_R16_UINT);
         case VK_FORMAT_R32_SINT:
-            return makeFormat(VK_FORMAT_R32_UINT);
+            return getFormatInfo(VK_FORMAT_R32_UINT);
         case VK_FORMAT_R64_SINT:
-            return makeFormat(VK_FORMAT_R64_UINT);
+            return getFormatInfo(VK_FORMAT_R64_UINT);
         default:
-            return makeFormat(format);
+            return getFormatInfo(format);
         }
     } else {
         switch (format) {
         case VK_FORMAT_R8_UINT:
         case VK_FORMAT_S8_UINT:
-            return makeFormat(VK_FORMAT_R8_SINT);
+            return getFormatInfo(VK_FORMAT_R8_SINT);
         case VK_FORMAT_R16_UINT:
-            return makeFormat(VK_FORMAT_R16_SINT);
+            return getFormatInfo(VK_FORMAT_R16_SINT);
         case VK_FORMAT_R32_UINT:
-            return makeFormat(VK_FORMAT_R32_SINT);
+            return getFormatInfo(VK_FORMAT_R32_SINT);
         case VK_FORMAT_R64_UINT:
-            return makeFormat(VK_FORMAT_R64_SINT);
+            return getFormatInfo(VK_FORMAT_R64_SINT);
         default:
-            return makeFormat(format);
+            return getFormatInfo(format);
         }
     }
 }

--- a/graph/compute_graph_op.cpp
+++ b/graph/compute_graph_op.cpp
@@ -15,6 +15,7 @@
 #include <cmath>
 #include <numeric>
 #include <regex>
+#include <string_view>
 
 using namespace mlsdk::el::log;
 using namespace mlsdk::el::utils;
@@ -51,7 +52,7 @@ VkFormat accTypeVkFormat(uint32_t accType) {
     }
 }
 
-std::string accTypeString(uint32_t accType) {
+std::string_view accTypeString(uint32_t accType) {
     switch (accType) {
     case 1:
         return "int32_t";
@@ -64,19 +65,6 @@ std::string accTypeString(uint32_t accType) {
     default:
         throw std::runtime_error("Unsupported AVG_POOL2D acc type " + std::to_string(accType));
     }
-}
-
-std::string compTypeString(const std::shared_ptr<FormatBase> &type) {
-    if (type->toInt() == "0x6642") {
-        return "float";
-    }
-    if (type->toInt() == "0x664D") {
-        return "float16_t";
-    }
-    if (type->toInt() == "0x664E") {
-        return "float16_t";
-    }
-    return type->glslType();
 }
 
 } // namespace
@@ -540,6 +528,7 @@ ComputePipeline::ComputePipeline(const std::shared_ptr<VULKAN_HPP_NAMESPACE::det
     : ComputePipelineBase(createPipelineLayout(_loader, _device, std::move(descriptorMap), pushConstant)),
       loader{_loader}, device{_device}, pipelineCache{_pipelineCache},
       shaderModule{createShaderModule(_spirv)}, pipeline{createComputePipeline(_constants)} {
+    assert(std::to_string(warpID) == warpIdSv);
     connectPipelines();
     setDebugUtilsObjectName(loader, device, VK_OBJECT_TYPE_PIPELINE, reinterpret_cast<uint64_t>(pipeline), debugName);
 }
@@ -632,18 +621,18 @@ DescriptorMap Argmax::createDescriptorMap(const std::shared_ptr<TensorDescriptor
 
 SpirvBinary Argmax::createSpirv(const std::shared_ptr<PipelineCache> &_pipelineCache,
                                 const std::shared_ptr<TensorDescriptor> &input) const {
-    auto inType = makeFormat(input->getFormat());
+    const auto *inType = getFormatInfo(input->getFormat());
 
     return _pipelineCache->lookup(shaderName,
                                   {
-                                      inType->glslType(),
+                                      inType->glslType,
                                   },
                                   {
-                                      {"%warpX%", std::to_string(warp1D)},
-                                      {"%in_t_type%", inType->toInt()},
-                                      {"%in_t_lowest%", inType->lowest()},
-                                      {"%in_t%", inType->glslType()},
-                                      {"%in_t_comp%", compTypeString(inType)},
+                                      {"%warpX%", warpIdSv},
+                                      {"%in_t_type%", inType->typeId},
+                                      {"%in_t_lowest%", inType->lowest},
+                                      {"%in_t%", inType->glslType},
+                                      {"%in_t_comp%", inType->compType},
                                   });
 }
 
@@ -683,15 +672,15 @@ DescriptorMap ArithmeticRightShift::createDescriptorMap(const std::shared_ptr<Te
 
 SpirvBinary ArithmeticRightShift::createSpirv(const std::shared_ptr<PipelineCache> &_pipelineCache,
                                               const std::shared_ptr<TensorDescriptor> &output) const {
-    auto inOutType = makeFormat(output->getFormat());
+    const auto *inOutType = getFormatInfo(output->getFormat());
 
     return _pipelineCache->lookup(shaderName,
                                   {
-                                      inOutType->glslType(),
+                                      inOutType->glslType,
                                   },
                                   {
-                                      {"%warpX%", std::to_string(warp1D)},
-                                      {"%in_out_t%", inOutType->glslType()},
+                                      {"%warpX%", warpIdSv},
+                                      {"%in_out_t%", inOutType->glslType},
                                   });
 }
 
@@ -748,22 +737,22 @@ DescriptorMap AvgPool2D::createDescriptorMap(const std::shared_ptr<TensorDescrip
 
 SpirvBinary AvgPool2D::createSpirv(const std::shared_ptr<PipelineCache> &_pipelineCache,
                                    const std::shared_ptr<TensorDescriptor> &output, const uint32_t accType) const {
-    auto inOutType = makeFormat(output->getFormat());
+    const auto *inOutType = getFormatInfo(output->getFormat());
 
-    const auto &accTypeStr = accTypeString(accType);
+    const auto accTypeStr = accTypeString(accType);
     return _pipelineCache->lookup(shaderName,
                                   {
-                                      inOutType->glslType(),
+                                      inOutType->glslType,
                                       accTypeStr,
                                   },
                                   {
-                                      {"%warpX%", std::to_string(warp1D)},
+                                      {"%warpX%", warpIdSv},
                                       {"%acc_t%", accTypeStr},
-                                      {"%in_out_t_lowest%", inOutType->lowest()},
-                                      {"%in_out_t_max%", inOutType->max()},
-                                      {"%in_out_t%", inOutType->glslType()},
-                                      {"%in_out_t_type%", inOutType->toInt()},
-                                      {"%in_out_t_comp%", compTypeString(inOutType)},
+                                      {"%in_out_t_lowest%", inOutType->lowest},
+                                      {"%in_out_t_max%", inOutType->max},
+                                      {"%in_out_t%", inOutType->glslType},
+                                      {"%in_out_t_type%", inOutType->typeId},
+                                      {"%in_out_t_comp%", inOutType->compType},
                                   });
 }
 
@@ -791,24 +780,24 @@ DescriptorMap Cast::createDescriptorMap(const std::shared_ptr<TensorDescriptor> 
 SpirvBinary Cast::createSpirv(const std::shared_ptr<PipelineCache> &_pipelineCache,
                               const std::shared_ptr<TensorDescriptor> &input,
                               const std::shared_ptr<TensorDescriptor> &output) const {
-    auto inType = makeFormat(input->getFormat());
-    auto outType = makeFormat(output->getFormat());
+    const auto *inType = getFormatInfo(input->getFormat());
+    const auto *outType = getFormatInfo(output->getFormat());
 
     return _pipelineCache->lookup(shaderName,
                                   {
-                                      inType->glslType(),
-                                      outType->glslType(),
+                                      inType->glslType,
+                                      outType->glslType,
                                   },
                                   {
-                                      {"%warpX%", std::to_string(warp1D)},
-                                      {"%in_t_type%", inType->toInt()},
-                                      {"%out_t_type%", outType->toInt()},
-                                      {"%in_t_lowest%", inType->lowest()},
-                                      {"%in_t_max%", inType->max()},
-                                      {"%out_t_lowest%", outType->lowest()},
-                                      {"%out_t_max%", outType->max()},
-                                      {"%in_t%", inType->glslType()},
-                                      {"%out_t%", outType->glslType()},
+                                      {"%warpX%", warpIdSv},
+                                      {"%in_t_type%", inType->typeId},
+                                      {"%out_t_type%", outType->typeId},
+                                      {"%in_t_lowest%", inType->lowest},
+                                      {"%in_t_max%", inType->max},
+                                      {"%out_t_lowest%", outType->lowest},
+                                      {"%out_t_max%", outType->max},
+                                      {"%in_t%", inType->glslType},
+                                      {"%out_t%", outType->glslType},
                                   });
 }
 
@@ -846,17 +835,17 @@ DescriptorMap Clamp::createDescriptorMap(const std::shared_ptr<TensorDescriptor>
 
 SpirvBinary Clamp::createSpirv(const std::shared_ptr<PipelineCache> &_pipelineCache,
                                const std::shared_ptr<TensorDescriptor> &output) const {
-    auto inOutType = makeFormat(output->getFormat());
+    const auto *inOutType = getFormatInfo(output->getFormat());
 
     return _pipelineCache->lookup(shaderName,
                                   {
-                                      inOutType->glslType(),
+                                      inOutType->glslType,
                                   },
                                   {
-                                      {"%warpX%", std::to_string(warp1D)},
-                                      {"%in_out_t%", inOutType->glslType()},
-                                      {"%in_out_t_type%", inOutType->toInt()},
-                                      {"%in_out_t_comp%", compTypeString(inOutType)},
+                                      {"%warpX%", warpIdSv},
+                                      {"%in_out_t%", inOutType->glslType},
+                                      {"%in_out_t_type%", inOutType->typeId},
+                                      {"%in_out_t_comp%", inOutType->compType},
                                   });
 }
 
@@ -903,15 +892,15 @@ void Concat::cmdDispatch(VkCommandBuffer commandBuffer) {
 
 SpirvBinary Concat::createSpirv(const std::shared_ptr<PipelineCache> &_pipelineCache,
                                 const std::shared_ptr<TensorDescriptor> &output) const {
-    auto inOutType = makeFormat(output->getFormat());
+    const auto *inOutType = getFormatInfo(output->getFormat());
 
     return _pipelineCache->lookup(shaderName,
                                   {
-                                      inOutType->glslType(),
+                                      inOutType->glslType,
                                   },
                                   {
-                                      {"%warpX%", std::to_string(warp1D)},
-                                      {"%in_out_t%", inOutType->glslType()},
+                                      {"%warpX%", warpIdSv},
+                                      {"%in_out_t%", inOutType->glslType},
                                   });
 }
 
@@ -974,29 +963,29 @@ SpirvBinary Conv2D::createSpirv(const std::shared_ptr<PipelineCache> &_pipelineC
                                 const std::shared_ptr<TensorDescriptor> &input,
                                 const std::shared_ptr<TensorDescriptor> &output,
                                 const std::shared_ptr<TensorDescriptor> &weights, const uint32_t accType) const {
-    auto inType = makeFormat(input->getFormat());
-    auto outType = makeFormat(output->getFormat());
-    auto weightType = makeFormat(weights->getFormat());
-    auto accTypeType = makeFormat(accTypeVkFormat(accType));
+    const auto *inType = getFormatInfo(input->getFormat());
+    const auto *outType = getFormatInfo(output->getFormat());
+    const auto *weightType = getFormatInfo(weights->getFormat());
+    const auto *accTypeType = getFormatInfo(accTypeVkFormat(accType));
 
     return _pipelineCache->lookup(shaderName,
                                   {
-                                      inType->glslType(),
-                                      weightType->glslType(),
-                                      outType->glslType(),
-                                      accTypeType->glslType(),
+                                      inType->glslType,
+                                      weightType->glslType,
+                                      outType->glslType,
+                                      accTypeType->glslType,
                                   },
                                   {
                                       {"%warpX%", std::to_string(warpX)},
                                       {"%warpY%", std::to_string(warpY)},
                                       {"%warpZ%", std::to_string(warpZ)},
-                                      {"%in_t%", inType->glslType()},
-                                      {"%in_t_type%", inType->toInt()},
-                                      {"%out_t%", outType->glslType()},
-                                      {"%out_t_type%", outType->toInt()},
-                                      {"%weight_t%", weightType->glslType()},
-                                      {"%acc_t_type%", accTypeType->toInt()},
-                                      {"%acc_t%", accTypeType->glslType()},
+                                      {"%in_t%", inType->glslType},
+                                      {"%in_t_type%", inType->typeId},
+                                      {"%out_t%", outType->glslType},
+                                      {"%out_t_type%", outType->typeId},
+                                      {"%weight_t%", weightType->glslType},
+                                      {"%acc_t_type%", accTypeType->typeId},
+                                      {"%acc_t%", accTypeType->glslType},
                                   });
 }
 
@@ -1072,27 +1061,27 @@ SpirvBinary Conv3D::createSpirv(const std::shared_ptr<PipelineCache> &_pipelineC
                                 const std::shared_ptr<TensorDescriptor> &input,
                                 const std::shared_ptr<TensorDescriptor> &output,
                                 const std::shared_ptr<TensorDescriptor> &weights, const uint32_t accType) const {
-    auto inType = makeFormat(input->getFormat());
-    auto outType = makeFormat(output->getFormat());
-    auto weightType = makeFormat(weights->getFormat());
-    auto accTypeType = makeFormat(accTypeVkFormat(accType));
+    const auto *inType = getFormatInfo(input->getFormat());
+    const auto *outType = getFormatInfo(output->getFormat());
+    const auto *weightType = getFormatInfo(weights->getFormat());
+    const auto *accTypeType = getFormatInfo(accTypeVkFormat(accType));
 
     return _pipelineCache->lookup(shaderName,
                                   {
-                                      inType->glslType(),
-                                      weightType->glslType(),
-                                      outType->glslType(),
-                                      accTypeType->glslType(),
+                                      inType->glslType,
+                                      weightType->glslType,
+                                      outType->glslType,
+                                      accTypeType->glslType,
                                   },
                                   {
-                                      {"%warpX%", std::to_string(warp1D)},
-                                      {"%in_t%", inType->glslType()},
-                                      {"%in_t_type%", inType->toInt()},
-                                      {"%out_t%", outType->glslType()},
-                                      {"%out_t_type%", outType->toInt()},
-                                      {"%weight_t%", weightType->glslType()},
-                                      {"%acc_t_type%", accTypeType->toInt()},
-                                      {"%acc_t%", accTypeType->glslType()},
+                                      {"%warpX%", warpIdSv},
+                                      {"%in_t%", inType->glslType},
+                                      {"%in_t_type%", inType->typeId},
+                                      {"%out_t%", outType->glslType},
+                                      {"%out_t_type%", outType->typeId},
+                                      {"%weight_t%", weightType->glslType},
+                                      {"%acc_t_type%", accTypeType->typeId},
+                                      {"%acc_t%", accTypeType->glslType},
                                   });
 }
 
@@ -1161,27 +1150,27 @@ SpirvBinary DepthwiseConv2D::createSpirv(const std::shared_ptr<PipelineCache> &_
                                          const std::shared_ptr<TensorDescriptor> &output,
                                          const std::shared_ptr<TensorDescriptor> &weights,
                                          const uint32_t accType) const {
-    auto inType = makeFormat(input->getFormat());
-    auto outType = makeFormat(output->getFormat());
-    auto weightType = makeFormat(weights->getFormat());
-    auto accTypeType = makeFormat(accTypeVkFormat(accType));
+    const auto *inType = getFormatInfo(input->getFormat());
+    const auto *outType = getFormatInfo(output->getFormat());
+    const auto *weightType = getFormatInfo(weights->getFormat());
+    const auto *accTypeType = getFormatInfo(accTypeVkFormat(accType));
 
     return _pipelineCache->lookup(shaderName,
                                   {
-                                      inType->glslType(),
-                                      weightType->glslType(),
-                                      outType->glslType(),
-                                      accTypeType->glslType(),
+                                      inType->glslType,
+                                      weightType->glslType,
+                                      outType->glslType,
+                                      accTypeType->glslType,
                                   },
                                   {
-                                      {"%warpX%", std::to_string(warp1D)},
-                                      {"%in_t%", inType->glslType()},
-                                      {"%in_t_type%", inType->toInt()},
-                                      {"%out_t%", outType->glslType()},
-                                      {"%out_t_type%", outType->toInt()},
-                                      {"%weight_t%", weightType->glslType()},
-                                      {"%acc_t_type%", accTypeType->toInt()},
-                                      {"%acc_t%", accTypeType->glslType()},
+                                      {"%warpX%", warpIdSv},
+                                      {"%in_t%", inType->glslType},
+                                      {"%in_t_type%", inType->typeId},
+                                      {"%out_t%", outType->glslType},
+                                      {"%out_t_type%", outType->typeId},
+                                      {"%weight_t%", weightType->glslType},
+                                      {"%acc_t_type%", accTypeType->typeId},
+                                      {"%acc_t%", accTypeType->glslType},
                                   });
 }
 
@@ -1193,7 +1182,7 @@ ElementwiseBinary::ElementwiseBinary(
     const std::shared_ptr<VULKAN_HPP_NAMESPACE::detail::DispatchLoaderDynamic> &_loader, VkDevice _device,
     const std::shared_ptr<PipelineCache> &_pipelineCache, const std::shared_ptr<TensorDescriptor> &_input1,
     const std::shared_ptr<TensorDescriptor> &_input2, const std::shared_ptr<TensorDescriptor> &_output,
-    const uint32_t _nanMode, const std::string &debugName, const std::string &_operation)
+    const uint32_t _nanMode, const std::string &debugName, const std::string_view &_operation)
     : ComputePipeline(_loader, _device, createDescriptorMap(_input1, _input2, _output),
                       {&pushConstant, sizeof(pushConstant)}, _pipelineCache,
                       createSpirv(_pipelineCache, _input1, _output, debugName, _operation), debugName,
@@ -1220,24 +1209,24 @@ DescriptorMap ElementwiseBinary::createDescriptorMap(const std::shared_ptr<Tenso
 SpirvBinary ElementwiseBinary::createSpirv(const std::shared_ptr<PipelineCache> &_pipelineCache,
                                            const std::shared_ptr<TensorDescriptor> &input,
                                            const std::shared_ptr<TensorDescriptor> &output, const std::string &name,
-                                           const std::string &operation) const {
-    auto inType = makeFormat(input->getFormat());
-    auto outType = makeFormat(output->getFormat());
+                                           const std::string_view &operation) const {
+    const auto *inType = getFormatInfo(input->getFormat());
+    const auto *outType = getFormatInfo(output->getFormat());
 
     return _pipelineCache->lookup(shaderName,
                                   {
                                       name,
-                                      inType->glslType(),
-                                      outType->glslType(),
+                                      inType->glslType,
+                                      outType->glslType,
                                   },
                                   {
-                                      {"%warpX%", std::to_string(warp1D)},
+                                      {"%warpX%", warpIdSv},
                                       {"%operation%", operation},
-                                      {"%in_t%", inType->glslType()},
-                                      {"%out_t%", outType->glslType()},
-                                      {"%in_t_type%", inType->toInt()},
-                                      {"%out_t_type%", outType->toInt()},
-                                      {"%in_t_comp%", compTypeString(inType)},
+                                      {"%in_t%", inType->glslType},
+                                      {"%out_t%", outType->glslType},
+                                      {"%in_t_type%", inType->typeId},
+                                      {"%out_t_type%", outType->typeId},
+                                      {"%in_t_comp%", inType->compType},
                                   });
 }
 
@@ -1249,7 +1238,7 @@ ElementwiseUnary::ElementwiseUnary(const std::shared_ptr<VULKAN_HPP_NAMESPACE::d
                                    VkDevice _device, const std::shared_ptr<PipelineCache> &_pipelineCache,
                                    const std::shared_ptr<TensorDescriptor> &_input1,
                                    const std::shared_ptr<TensorDescriptor> &_output, const std::string &debugName,
-                                   const std::string &_operation)
+                                   const std::string_view &_operation)
     : ComputePipeline(_loader, _device, createDescriptorMap(_input1, _output), {}, _pipelineCache,
                       createSpirv(_pipelineCache, _output, debugName, _operation), debugName, {_output->getRank()}) {}
 
@@ -1266,20 +1255,20 @@ DescriptorMap ElementwiseUnary::createDescriptorMap(const std::shared_ptr<Tensor
 
 SpirvBinary ElementwiseUnary::createSpirv(const std::shared_ptr<PipelineCache> &_pipelineCache,
                                           const std::shared_ptr<TensorDescriptor> &output, const std::string &name,
-                                          const std::string &operation) const {
-    auto inOutType = makeFormat(output->getFormat());
+                                          const std::string_view &operation) const {
+    const auto *inOutType = getFormatInfo(output->getFormat());
 
     return _pipelineCache->lookup(shaderName,
                                   {
                                       name,
-                                      inOutType->glslType(),
+                                      inOutType->glslType,
                                   },
                                   {
-                                      {"%warpX%", std::to_string(warp1D)},
+                                      {"%warpX%", warpIdSv},
                                       {"%operation%", operation},
-                                      {"%in_out_t%", inOutType->glslType()},
-                                      {"%in_out_t_type%", inOutType->toInt()},
-                                      {"%in_out_t_comp%", compTypeString(inOutType)},
+                                      {"%in_out_t%", inOutType->glslType},
+                                      {"%in_out_t_type%", inOutType->typeId},
+                                      {"%in_out_t_comp%", inOutType->compType},
                                   });
 }
 
@@ -1321,7 +1310,7 @@ DescriptorMap Fft2D::createDescriptorMap(const std::shared_ptr<TensorDescriptor>
 SpirvBinary Fft2D::createSpirv(const std::shared_ptr<PipelineCache> &_pipelineCache) const {
     return _pipelineCache->lookup(shaderName, {},
                                   {
-                                      {"%warpX%", std::to_string(warp1D)},
+                                      {"%warpX%", warpIdSv},
                                   });
 }
 
@@ -1352,18 +1341,18 @@ DescriptorMap Gather::createDescriptorMap(const std::shared_ptr<TensorDescriptor
 SpirvBinary Gather::createSpirv(const std::shared_ptr<PipelineCache> &_pipelineCache,
                                 const std::shared_ptr<TensorDescriptor> &indices,
                                 const std::shared_ptr<TensorDescriptor> &output) const {
-    auto inOutType = makeFormat(output->getFormat());
-    auto indicesType = makeFormat(indices->getFormat());
+    const auto *inOutType = getFormatInfo(output->getFormat());
+    const auto *indicesType = getFormatInfo(indices->getFormat());
 
     return _pipelineCache->lookup(shaderName,
                                   {
-                                      inOutType->glslType(),
-                                      indicesType->glslType(),
+                                      inOutType->glslType,
+                                      indicesType->glslType,
                                   },
                                   {
-                                      {"%warpX%", std::to_string(warp1D)},
-                                      {"%index_t%", indicesType->glslType()},
-                                      {"%in_out_t%", inOutType->glslType()},
+                                      {"%warpX%", warpIdSv},
+                                      {"%index_t%", indicesType->glslType},
+                                      {"%in_out_t%", inOutType->glslType},
                                   });
 }
 
@@ -1405,20 +1394,20 @@ DescriptorMap Matmul::createDescriptorMap(const std::shared_ptr<TensorDescriptor
 SpirvBinary Matmul::createSpirv(const std::shared_ptr<PipelineCache> &_pipelineCache,
                                 const std::shared_ptr<TensorDescriptor> &input1,
                                 const std::shared_ptr<TensorDescriptor> &output) const {
-    auto inType = makeFormat(input1->getFormat());
-    auto outType = makeFormat(output->getFormat());
+    const auto *inType = getFormatInfo(input1->getFormat());
+    const auto *outType = getFormatInfo(output->getFormat());
 
     return _pipelineCache->lookup(shaderName,
                                   {
-                                      inType->glslType(),
-                                      outType->glslType(),
+                                      inType->glslType,
+                                      outType->glslType,
                                   },
                                   {
-                                      {"%warpX%", std::to_string(warp1D)},
-                                      {"%in_t%", inType->glslType()},
-                                      {"%in_t_type%", inType->toInt()},
-                                      {"%out_t%", outType->glslType()},
-                                      {"%out_t_type%", outType->toInt()},
+                                      {"%warpX%", warpIdSv},
+                                      {"%in_t%", inType->glslType},
+                                      {"%in_t_type%", inType->typeId},
+                                      {"%out_t%", outType->glslType},
+                                      {"%out_t_type%", outType->typeId},
                                   });
 }
 
@@ -1472,19 +1461,19 @@ DescriptorMap MaxPool2D::createDescriptorMap(const std::shared_ptr<TensorDescrip
 
 SpirvBinary MaxPool2D::createSpirv(const std::shared_ptr<PipelineCache> &_pipelineCache,
                                    const std::shared_ptr<TensorDescriptor> &output, const uint32_t _nanMode) const {
-    auto inOutType = makeFormat(output->getFormat());
+    const auto *inOutType = getFormatInfo(output->getFormat());
 
-    const std::string init = (_nanMode == NanPropagationMode::Ignore ? "NAN" : inOutType->lowest());
+    const std::string_view init = (_nanMode == NanPropagationMode::Ignore ? "NAN" : inOutType->lowest);
     return _pipelineCache->lookup(shaderName,
                                   {
-                                      inOutType->glslType(),
+                                      inOutType->glslType,
                                   },
                                   {
-                                      {"%warpX%", std::to_string(warp1D)},
-                                      {"%in_out_t%", inOutType->glslType()},
+                                      {"%warpX%", warpIdSv},
+                                      {"%in_out_t%", inOutType->glslType},
                                       {"%in_out_t_lowest%", init},
-                                      {"%in_out_t_type%", inOutType->toInt()},
-                                      {"%in_out_t_comp%", compTypeString(inOutType)},
+                                      {"%in_out_t_type%", inOutType->typeId},
+                                      {"%in_out_t_comp%", inOutType->compType},
                                   });
 }
 
@@ -1526,20 +1515,20 @@ DescriptorMap Mul::createDescriptorMap(const std::shared_ptr<TensorDescriptor> &
 SpirvBinary Mul::createSpirv(const std::shared_ptr<PipelineCache> &_pipelineCache,
                              const std::shared_ptr<TensorDescriptor> &input1,
                              const std::shared_ptr<TensorDescriptor> &output) const {
-    auto inType = makeFormat(input1->getFormat());
-    auto outType = makeFormat(output->getFormat());
+    const auto *inType = getFormatInfo(input1->getFormat());
+    const auto *outType = getFormatInfo(output->getFormat());
 
     return _pipelineCache->lookup(shaderName,
                                   {
-                                      inType->glslType(),
-                                      outType->glslType(),
+                                      inType->glslType,
+                                      outType->glslType,
                                   },
                                   {
-                                      {"%warpX%", std::to_string(warp1D)},
-                                      {"%in_t_type%", inType->toInt()},
-                                      {"%out_t_type%", outType->toInt()},
-                                      {"%in_t%", inType->glslType()},
-                                      {"%out_t%", outType->glslType()},
+                                      {"%warpX%", warpIdSv},
+                                      {"%in_t_type%", inType->typeId},
+                                      {"%out_t_type%", outType->typeId},
+                                      {"%in_t%", inType->glslType},
+                                      {"%out_t%", outType->glslType},
                                   });
 }
 
@@ -1577,21 +1566,21 @@ DescriptorMap Negate::createDescriptorMap(const std::shared_ptr<TensorDescriptor
 
 SpirvBinary Negate::createSpirv(const std::shared_ptr<PipelineCache> &_pipelineCache,
                                 const std::shared_ptr<TensorDescriptor> &output) const {
-    auto inOutType = makeFormat(output->getFormat());
+    const auto *inOutType = getFormatInfo(output->getFormat());
 
-    std::string accType = inOutType->isInteger() ? "int32_t" : "float";
+    const std::string_view accType = inOutType->isInteger ? "int32_t" : "float";
 
     return _pipelineCache->lookup(shaderName,
                                   {
-                                      inOutType->glslType(),
+                                      inOutType->glslType,
                                   },
                                   {
-                                      {"%warpX%", std::to_string(warp1D)},
-                                      {"%in_out_t%", inOutType->glslType()},
-                                      {"%in_out_t_type%", inOutType->toInt()},
+                                      {"%warpX%", warpIdSv},
+                                      {"%in_out_t%", inOutType->glslType},
+                                      {"%in_out_t_type%", inOutType->typeId},
                                       {"%acc_t%", accType},
-                                      {"%in_out_t_lowest%", inOutType->lowest()},
-                                      {"%in_out_t_max%", inOutType->max()},
+                                      {"%in_out_t_lowest%", inOutType->lowest},
+                                      {"%in_out_t_max%", inOutType->max},
                                   });
 }
 
@@ -1632,16 +1621,16 @@ DescriptorMap Pad::createDescriptorMap(const std::shared_ptr<TensorDescriptor> &
 
 SpirvBinary Pad::createSpirv(const std::shared_ptr<PipelineCache> &_pipelineCache,
                              const std::shared_ptr<TensorDescriptor> &output) const {
-    auto inOutType = makeFormat(output->getFormat());
+    const auto *inOutType = getFormatInfo(output->getFormat());
 
     return _pipelineCache->lookup(shaderName,
                                   {
-                                      inOutType->glslType(),
+                                      inOutType->glslType,
                                   },
                                   {
-                                      {"%warpX%", std::to_string(warp1D)},
-                                      {"%in_out_t%", inOutType->glslType()},
-                                      {"%in_out_t_type%", inOutType->toInt()},
+                                      {"%warpX%", warpIdSv},
+                                      {"%in_out_t%", inOutType->glslType},
+                                      {"%in_out_t_type%", inOutType->typeId},
                                   });
 }
 
@@ -1652,11 +1641,11 @@ SpirvBinary Pad::createSpirv(const std::shared_ptr<PipelineCache> &_pipelineCach
 Reduce::Reduce(const std::shared_ptr<VULKAN_HPP_NAMESPACE::detail::DispatchLoaderDynamic> &_loader, VkDevice _device,
                const std::shared_ptr<PipelineCache> &_pipelineCache, const std::shared_ptr<TensorDescriptor> &_input,
                const std::shared_ptr<TensorDescriptor> &_output, const uint32_t _axis, const uint32_t _nanMode,
-               const std::string &debugName, const std::string &_init, const std::string &_operation)
+               const std::string &debugName, const std::string &_init, const std::string_view &_operation)
     : ComputePipeline(_loader, _device, createDescriptorMap(_input, _output), {&pushConstant, sizeof(pushConstant)},
                       _pipelineCache, createSpirv(_pipelineCache, _input, debugName, _init, _operation), debugName,
                       {_output->getRank()}),
-      pushConstant{createPushConstant(_axis, _nanMode, makeFormat(_input->getFormat())->isInteger())} {}
+      pushConstant{createPushConstant(_axis, _nanMode, getFormatInfo(_input->getFormat())->isInteger)} {}
 
 Reduce::PushConstant Reduce::createPushConstant(const uint32_t axis, const uint32_t nanMode,
                                                 const bool isInteger) const {
@@ -1681,21 +1670,21 @@ DescriptorMap Reduce::createDescriptorMap(const std::shared_ptr<TensorDescriptor
 
 SpirvBinary Reduce::createSpirv(const std::shared_ptr<PipelineCache> &_pipelineCache,
                                 const std::shared_ptr<TensorDescriptor> &output, const std::string &name,
-                                const std::string &init, const std::string &operation) const {
-    auto inOutType = makeFormat(output->getFormat());
+                                const std::string &init, const std::string_view &operation) const {
+    const auto *inOutType = getFormatInfo(output->getFormat());
 
     return _pipelineCache->lookup(shaderName,
                                   {
                                       name,
-                                      inOutType->glslType(),
+                                      inOutType->glslType,
                                   },
                                   {
-                                      {"%warpX%", std::to_string(warp1D)},
+                                      {"%warpX%", warpIdSv},
                                       {"%init%", init},
                                       {"%operation%", operation},
-                                      {"%in_out_t%", inOutType->glslType()},
-                                      {"%in_out_t_type%", inOutType->toInt()},
-                                      {"%in_out_t_comp%", compTypeString(inOutType)},
+                                      {"%in_out_t%", inOutType->glslType},
+                                      {"%in_out_t_type%", inOutType->typeId},
+                                      {"%in_out_t_comp%", inOutType->compType},
                                   });
 }
 
@@ -1745,23 +1734,23 @@ SpirvBinary Rescale::createSpirv(const std::shared_ptr<PipelineCache> &_pipeline
                                  const std::shared_ptr<TensorDescriptor> &output,
                                  const std::shared_ptr<TensorDescriptor> &multiplier, const bool inputUnsigned,
                                  const bool outputUnsigned) const {
-    auto inType = makeFormat(input->getFormat(), inputUnsigned);
-    auto outType = makeFormat(output->getFormat(), outputUnsigned);
-    auto mulType = makeFormat(multiplier->getFormat());
+    const auto *inType = getFormatInfo(input->getFormat(), inputUnsigned);
+    const auto *outType = getFormatInfo(output->getFormat(), outputUnsigned);
+    const auto *mulType = getFormatInfo(multiplier->getFormat());
 
     return _pipelineCache->lookup(shaderName,
                                   {
-                                      inType->glslType(),
-                                      outType->glslType(),
-                                      mulType->glslType(),
+                                      inType->glslType,
+                                      outType->glslType,
+                                      mulType->glslType,
                                   },
                                   {
-                                      {"%warpX%", std::to_string(warp1D)},
-                                      {"%in_t%", inType->glslType()},
-                                      {"%out_t%", outType->glslType()},
-                                      {"%mul_t%", mulType->glslType()},
-                                      {"%out_t_lowest%", outType->lowest()},
-                                      {"%out_t_max%", outType->max()},
+                                      {"%warpX%", warpIdSv},
+                                      {"%in_t%", inType->glslType},
+                                      {"%out_t%", outType->glslType},
+                                      {"%mul_t%", mulType->glslType},
+                                      {"%out_t_lowest%", outType->lowest},
+                                      {"%out_t_max%", outType->max},
                                   });
 }
 
@@ -1788,15 +1777,15 @@ DescriptorMap Reshape::createDescriptorMap(const std::shared_ptr<TensorDescripto
 
 SpirvBinary Reshape::createSpirv(const std::shared_ptr<PipelineCache> &_pipelineCache,
                                  const std::shared_ptr<TensorDescriptor> &output) const {
-    auto inOutType = makeFormat(output->getFormat());
+    const auto *inOutType = getFormatInfo(output->getFormat());
 
     return _pipelineCache->lookup(shaderName,
                                   {
-                                      inOutType->glslType(),
+                                      inOutType->glslType,
                                   },
                                   {
-                                      {"%warpX%", std::to_string(warp1D)},
-                                      {"%in_out_t%", inOutType->glslType()},
+                                      {"%warpX%", warpIdSv},
+                                      {"%in_out_t%", inOutType->glslType},
                                   });
 }
 
@@ -1850,21 +1839,21 @@ DescriptorMap Resize::createDescriptorMap(const std::shared_ptr<TensorDescriptor
 SpirvBinary Resize::createSpirv(const std::shared_ptr<PipelineCache> &_pipelineCache,
                                 const std::shared_ptr<TensorDescriptor> &input,
                                 const std::shared_ptr<TensorDescriptor> &output) const {
-    auto inType = makeFormat(input->getFormat());
-    auto outType = makeFormat(output->getFormat());
+    const auto *inType = getFormatInfo(input->getFormat());
+    const auto *outType = getFormatInfo(output->getFormat());
 
     return _pipelineCache->lookup(shaderName,
                                   {
-                                      inType->glslType(),
-                                      outType->glslType(),
+                                      inType->glslType,
+                                      outType->glslType,
                                   },
                                   {
-                                      {"%warpX%", std::to_string(warp1D)},
-                                      {"%in_t%", inType->glslType()},
-                                      {"%in_t_type%", inType->toInt()},
-                                      {"%out_t%", outType->glslType()},
-                                      {"%out_t_type%", outType->toInt()},
-                                      {"%out_t_comp%", compTypeString(outType)},
+                                      {"%warpX%", warpIdSv},
+                                      {"%in_t%", inType->glslType},
+                                      {"%in_t_type%", inType->typeId},
+                                      {"%out_t%", outType->glslType},
+                                      {"%out_t_type%", outType->typeId},
+                                      {"%out_t_comp%", outType->compType},
                                   });
 }
 
@@ -1899,15 +1888,15 @@ DescriptorMap Reverse::createDescriptorMap(const std::shared_ptr<TensorDescripto
 
 SpirvBinary Reverse::createSpirv(const std::shared_ptr<PipelineCache> &_pipelineCache,
                                  const std::shared_ptr<TensorDescriptor> &output) const {
-    auto inOutType = makeFormat(output->getFormat());
+    const auto *inOutType = getFormatInfo(output->getFormat());
 
     return _pipelineCache->lookup(shaderName,
                                   {
-                                      inOutType->glslType(),
+                                      inOutType->glslType,
                                   },
                                   {
-                                      {"%warpX%", std::to_string(warp1D)},
-                                      {"%in_out_t%", inOutType->glslType()},
+                                      {"%warpX%", warpIdSv},
+                                      {"%in_out_t%", inOutType->glslType},
                                   });
 }
 
@@ -1938,7 +1927,7 @@ DescriptorMap Rfft2D::createDescriptorMap(const std::shared_ptr<TensorDescriptor
 SpirvBinary Rfft2D::createSpirv(const std::shared_ptr<PipelineCache> &_pipelineCache) const {
     return _pipelineCache->lookup(shaderName, {},
                                   {
-                                      {"%warpX%", std::to_string(warp1D)},
+                                      {"%warpX%", warpIdSv},
                                   });
 }
 
@@ -1971,18 +1960,18 @@ DescriptorMap Scatter::createDescriptorMap(const std::shared_ptr<TensorDescripto
 SpirvBinary Scatter::createSpirv(const std::shared_ptr<PipelineCache> &_pipelineCache,
                                  const std::shared_ptr<TensorDescriptor> &indices,
                                  const std::shared_ptr<TensorDescriptor> &output) const {
-    auto inOutType = makeFormat(output->getFormat());
-    auto indicesType = makeFormat(indices->getFormat());
+    const auto *inOutType = getFormatInfo(output->getFormat());
+    const auto *indicesType = getFormatInfo(indices->getFormat());
 
     return _pipelineCache->lookup(shaderName,
                                   {
-                                      inOutType->glslType(),
-                                      indicesType->glslType(),
+                                      inOutType->glslType,
+                                      indicesType->glslType,
                                   },
                                   {
-                                      {"%warpX%", std::to_string(warp1D)},
-                                      {"%index_t%", indicesType->glslType()},
-                                      {"%in_out_t%", inOutType->glslType()},
+                                      {"%warpX%", warpIdSv},
+                                      {"%index_t%", indicesType->glslType},
+                                      {"%in_out_t%", inOutType->glslType},
                                   });
 }
 
@@ -2014,15 +2003,15 @@ DescriptorMap Select::createDescriptorMap(const std::shared_ptr<TensorDescriptor
 
 SpirvBinary Select::createSpirv(const std::shared_ptr<PipelineCache> &_pipelineCache,
                                 const std::shared_ptr<TensorDescriptor> &output) const {
-    auto inOutType = makeFormat(output->getFormat());
+    const auto *inOutType = getFormatInfo(output->getFormat());
 
     return _pipelineCache->lookup(shaderName,
                                   {
-                                      inOutType->glslType(),
+                                      inOutType->glslType,
                                   },
                                   {
-                                      {"%warpX%", std::to_string(warp1D)},
-                                      {"%in_out_t%", inOutType->glslType()},
+                                      {"%warpX%", warpIdSv},
+                                      {"%in_out_t%", inOutType->glslType},
                                   });
 }
 
@@ -2058,15 +2047,15 @@ DescriptorMap Slice::createDescriptorMap(const std::shared_ptr<TensorDescriptor>
 
 SpirvBinary Slice::createSpirv(const std::shared_ptr<PipelineCache> &_pipelineCache,
                                const std::shared_ptr<TensorDescriptor> &input) const {
-    auto inOutType = makeFormat(input->getFormat());
+    const auto *inOutType = getFormatInfo(input->getFormat());
 
     return _pipelineCache->lookup(shaderName,
                                   {
-                                      inOutType->glslType(),
+                                      inOutType->glslType,
                                   },
                                   {
-                                      {"%warpX%", std::to_string(warp1D)},
-                                      {"%in_out_t%", inOutType->glslType()},
+                                      {"%warpX%", warpIdSv},
+                                      {"%in_out_t%", inOutType->glslType},
                                   });
 }
 
@@ -2097,18 +2086,18 @@ DescriptorMap Table::createDescriptorMap(const std::shared_ptr<TensorDescriptor>
 SpirvBinary Table::createSpirv(const std::shared_ptr<PipelineCache> &_pipelineCache,
                                const std::shared_ptr<TensorDescriptor> &input,
                                const std::shared_ptr<TensorDescriptor> &output) const {
-    auto inType = makeFormat(input->getFormat());
-    auto outType = makeFormat(output->getFormat());
+    const auto *inType = getFormatInfo(input->getFormat());
+    const auto *outType = getFormatInfo(output->getFormat());
 
     return _pipelineCache->lookup(shaderName,
                                   {
-                                      inType->glslType(),
-                                      outType->glslType(),
+                                      inType->glslType,
+                                      outType->glslType,
                                   },
                                   {
-                                      {"%warpX%", std::to_string(warp1D)},
-                                      {"%in_t%", inType->glslType()},
-                                      {"%out_t%", outType->glslType()},
+                                      {"%warpX%", warpIdSv},
+                                      {"%in_t%", inType->glslType},
+                                      {"%out_t%", outType->glslType},
                                   });
 }
 
@@ -2135,15 +2124,15 @@ DescriptorMap Tile::createDescriptorMap(const std::shared_ptr<TensorDescriptor> 
 
 SpirvBinary Tile::createSpirv(const std::shared_ptr<PipelineCache> &_pipelineCache,
                               const std::shared_ptr<TensorDescriptor> &output) const {
-    auto inOutType = makeFormat(output->getFormat());
+    const auto *inOutType = getFormatInfo(output->getFormat());
 
     return _pipelineCache->lookup(shaderName,
                                   {
-                                      inOutType->glslType(),
+                                      inOutType->glslType,
                                   },
                                   {
-                                      {"%warpX%", std::to_string(warp1D)},
-                                      {"%in_out_t%", inOutType->glslType()},
+                                      {"%warpX%", warpIdSv},
+                                      {"%in_out_t%", inOutType->glslType},
                                   });
 }
 
@@ -2179,15 +2168,15 @@ DescriptorMap Transpose::createDescriptorMap(const std::shared_ptr<TensorDescrip
 
 SpirvBinary Transpose::createSpirv(const std::shared_ptr<PipelineCache> &_pipelineCache,
                                    const std::shared_ptr<TensorDescriptor> &output) const {
-    auto inOutType = makeFormat(output->getFormat());
+    const auto *inOutType = getFormatInfo(output->getFormat());
 
     return _pipelineCache->lookup(shaderName,
                                   {
-                                      inOutType->glslType(),
+                                      inOutType->glslType,
                                   },
                                   {
-                                      {"%warpX%", std::to_string(warp1D)},
-                                      {"%in_out_t%", inOutType->glslType()},
+                                      {"%warpX%", warpIdSv},
+                                      {"%in_out_t%", inOutType->glslType},
                                   });
 }
 
@@ -2250,26 +2239,26 @@ SpirvBinary TransposeConv2D::createSpirv(const std::shared_ptr<PipelineCache> &_
                                          const std::shared_ptr<TensorDescriptor> &output,
                                          const std::shared_ptr<TensorDescriptor> &weights,
                                          const uint32_t accType) const {
-    auto inType = makeFormat(input->getFormat());
-    auto outType = makeFormat(output->getFormat());
-    auto weightType = makeFormat(weights->getFormat());
-    auto accTypeType = makeFormat(accTypeVkFormat(accType));
+    const auto *inType = getFormatInfo(input->getFormat());
+    const auto *outType = getFormatInfo(output->getFormat());
+    const auto *weightType = getFormatInfo(weights->getFormat());
+    const auto *accTypeType = getFormatInfo(accTypeVkFormat(accType));
 
     return _pipelineCache->lookup(shaderName,
                                   {
-                                      inType->glslType(),
-                                      weightType->glslType(),
-                                      outType->glslType(),
-                                      accTypeType->glslType(),
+                                      inType->glslType,
+                                      weightType->glslType,
+                                      outType->glslType,
+                                      accTypeType->glslType,
                                   },
                                   {
-                                      {"%warpX%", std::to_string(warp1D)},
-                                      {"%in_t%", inType->glslType()},
-                                      {"%in_t_type%", inType->toInt()},
-                                      {"%out_t%", outType->glslType()},
-                                      {"%out_t_type%", outType->toInt()},
-                                      {"%weight_t%", weightType->glslType()},
-                                      {"%acc_t%", accTypeType->glslType()},
+                                      {"%warpX%", warpIdSv},
+                                      {"%in_t%", inType->glslType},
+                                      {"%in_t_type%", inType->typeId},
+                                      {"%out_t%", outType->glslType},
+                                      {"%out_t_type%", outType->typeId},
+                                      {"%weight_t%", weightType->glslType},
+                                      {"%acc_t%", accTypeType->glslType},
                                   });
 }
 
@@ -2803,18 +2792,18 @@ void GraphPipeline::makeReduceAny(const std::shared_ptr<TensorDescriptor> &input
 void GraphPipeline::makeReduceMax(const std::shared_ptr<TensorDescriptor> &input,
                                   const std::shared_ptr<TensorDescriptor> &output, const uint32_t axis,
                                   const uint32_t nanMode, const std::string &debugName) {
-    auto inOutType = makeFormat(output->getFormat());
+    const auto *inOutType = getFormatInfo(output->getFormat());
     const std::string init =
-        "(pushConstants.nanMode == NAN_MODE_IGNORE) ? IN_OUT_T(NAN) : IN_OUT_T(" + inOutType->lowest() + ')';
+        "(pushConstants.nanMode == NAN_MODE_IGNORE) ? IN_OUT_T(NAN) : IN_OUT_T(" + std::string(inOutType->lowest) + ')';
     makePipeline<Reduce>(input, output, axis, nanMode, debugName, init, "max(result, value)");
 }
 
 void GraphPipeline::makeReduceMin(const std::shared_ptr<TensorDescriptor> &input,
                                   const std::shared_ptr<TensorDescriptor> &output, const uint32_t axis,
                                   const uint32_t nanMode, const std::string &debugName) {
-    auto inOutType = makeFormat(output->getFormat());
+    const auto *inOutType = getFormatInfo(output->getFormat());
     const std::string init =
-        "(pushConstants.nanMode == NAN_MODE_IGNORE) ? IN_OUT_T(NAN) : IN_OUT_T(" + inOutType->max() + ')';
+        "(pushConstants.nanMode == NAN_MODE_IGNORE) ? IN_OUT_T(NAN) : IN_OUT_T(" + std::string(inOutType->max) + ')';
     makePipeline<Reduce>(input, output, axis, nanMode, debugName, init, "min(result, value)");
 }
 

--- a/graph/compute_graph_op.hpp
+++ b/graph/compute_graph_op.hpp
@@ -206,6 +206,7 @@ class ComputePipeline : public ComputePipelineBase {
     VkPipeline pipeline;
 
     static const uint32_t warp1D = 64;
+    static constexpr std::string_view warpIdSv = "64";
     static const uint32_t MAX_CONST_LEN = 32;
 };
 
@@ -531,7 +532,7 @@ class ElementwiseBinary : public ComputePipeline {
                       const std::shared_ptr<TensorDescriptor> &_input1,
                       const std::shared_ptr<TensorDescriptor> &_input2,
                       const std::shared_ptr<TensorDescriptor> &_output, uint32_t _nanMode, const std::string &debugName,
-                      const std::string &_operation);
+                      const std::string_view &_operation);
 
   private:
     struct PushConstant {
@@ -547,7 +548,7 @@ class ElementwiseBinary : public ComputePipeline {
     SpirvBinary createSpirv(const std::shared_ptr<PipelineCache> &pipelineCache,
                             const std::shared_ptr<TensorDescriptor> &input,
                             const std::shared_ptr<TensorDescriptor> &output, const std::string &debugName,
-                            const std::string &operation) const;
+                            const std::string_view &operation) const;
 
     PushConstant pushConstant;
     static constexpr std::string_view shaderName = "elementwise_binary";
@@ -562,7 +563,7 @@ class ElementwiseUnary : public ComputePipeline {
     ElementwiseUnary(const std::shared_ptr<VULKAN_HPP_NAMESPACE::detail::DispatchLoaderDynamic> &_loader,
                      VkDevice _device, const std::shared_ptr<PipelineCache> &_pipelineCache,
                      const std::shared_ptr<TensorDescriptor> &_input1, const std::shared_ptr<TensorDescriptor> &_output,
-                     const std::string &debugName, const std::string &_operation);
+                     const std::string &debugName, const std::string_view &_operation);
 
   private:
     DescriptorMap createDescriptorMap(const std::shared_ptr<TensorDescriptor> &input1,
@@ -570,7 +571,7 @@ class ElementwiseUnary : public ComputePipeline {
 
     SpirvBinary createSpirv(const std::shared_ptr<PipelineCache> &pipelineCache,
                             const std::shared_ptr<TensorDescriptor> &output, const std::string &debugName,
-                            const std::string &operation) const;
+                            const std::string_view &operation) const;
 
     static constexpr std::string_view shaderName = "elementwise_unary";
 };
@@ -794,7 +795,7 @@ class Reduce : public ComputePipeline {
     Reduce(const std::shared_ptr<VULKAN_HPP_NAMESPACE::detail::DispatchLoaderDynamic> &_loader, VkDevice _device,
            const std::shared_ptr<PipelineCache> &_pipelineCache, const std::shared_ptr<TensorDescriptor> &_input,
            const std::shared_ptr<TensorDescriptor> &_output, uint32_t _axis, uint32_t _nanMode,
-           const std::string &debugName, const std::string &_init, const std::string &_operation);
+           const std::string &debugName, const std::string &_init, const std::string_view &_operation);
 
   private:
     struct PushConstant {
@@ -809,7 +810,7 @@ class Reduce : public ComputePipeline {
 
     SpirvBinary createSpirv(const std::shared_ptr<PipelineCache> &pipelineCache,
                             const std::shared_ptr<TensorDescriptor> &output, const std::string &name,
-                            const std::string &init, const std::string &operation) const;
+                            const std::string &init, const std::string_view &operation) const;
 
     PushConstant pushConstant;
 

--- a/tensor/tensor_arm.cpp
+++ b/tensor/tensor_arm.cpp
@@ -229,7 +229,7 @@ TensorCopyPipeline::PushConstant TensorCopyPipeline::createPushConstant(const Te
 }
 
 VkShaderModule TensorCopyPipeline::createShaderModule(const TensorARM &srcTensor) const {
-    const auto srcType = makeFormat((srcTensor.getTensorInfo().format))->glslType();
+    const auto srcType = std::string(getFormatInfo(srcTensor.getTensorInfo().format)->glslType);
     const std::lock_guard lock(cacheMutex);
     auto &spirv = spirvCache[srcType];
     if (spirv.empty()) {

--- a/tests/common_tests.cpp
+++ b/tests/common_tests.cpp
@@ -204,4 +204,93 @@ TEST(MLEmulationLayerFloat, Formats) {
     ASSERT_FALSE(std::isnormal(float(f16)));
 }
 
+struct ExpectedFormatInfo {
+    VkFormat format;
+    bool isInteger;
+    bool isSigned;
+    std::string lowest;
+    std::string max;
+    std::string_view glslType;
+    uint64_t typeId;
+    std::string_view compType;
+};
+
+template <typename T> constexpr int legacyCharType() {
+    if constexpr (std::numeric_limits<T>::is_integer) {
+        if constexpr (std::numeric_limits<T>::digits == 1) {
+            return 'b';
+        } else if constexpr (std::numeric_limits<T>::is_signed) {
+            return 'i';
+        } else {
+            return 'u';
+        }
+    } else {
+        return 'f';
+    }
+}
+
+template <typename T>
+ExpectedFormatInfo legacyFormat(VkFormat format, std::string_view glslType, std::string_view literalSuffix = "",
+                                std::string_view compType = "") {
+    constexpr auto typeId = uint64_t(legacyCharType<T>()) << 8 | ('0' + sizeof(T));
+    return {
+        format,
+        std::numeric_limits<T>::is_integer,
+        std::numeric_limits<T>::is_signed,
+        std::to_string(std::numeric_limits<T>::lowest()) + std::string(literalSuffix),
+        std::to_string(std::numeric_limits<T>::max()) + std::string(literalSuffix),
+        glslType,
+        typeId,
+        compType.empty() ? glslType : compType,
+    };
+}
+
+uint64_t parseTypeId(std::string_view typeId) { return std::stoull(std::string(typeId), nullptr, 0); }
+
+void expectFormatInfo(const ExpectedFormatInfo &expected) {
+    const auto *actual = getFormatInfo(expected.format);
+
+    ASSERT_NE(actual, nullptr);
+    EXPECT_EQ(actual->isInteger, expected.isInteger);
+    EXPECT_EQ(actual->isSigned, expected.isSigned);
+    EXPECT_EQ(actual->lowest, expected.lowest);
+    EXPECT_EQ(actual->max, expected.max);
+    EXPECT_EQ(actual->glslType, expected.glslType);
+    EXPECT_EQ(parseTypeId(actual->typeId), expected.typeId);
+    EXPECT_EQ(actual->compType, expected.compType);
+}
+
+TEST(MLEmulationLayerUtils, MakeFormatSupportedFormatsMatchLegacyFormatImplementation) {
+    const std::vector<ExpectedFormatInfo> expectedFormats = {
+        legacyFormat<int8_t>(VK_FORMAT_R8_SINT, "int8_t"),
+        legacyFormat<uint8_t>(VK_FORMAT_R8_UINT, "uint8_t", "u"),
+        legacyFormat<uint8_t>(VK_FORMAT_S8_UINT, "uint8_t", "u"),
+        legacyFormat<bool>(VK_FORMAT_R8_BOOL_ARM, "bool"),
+        legacyFormat<int16_t>(VK_FORMAT_R16_SINT, "int16_t"),
+        legacyFormat<uint16_t>(VK_FORMAT_R16_UINT, "uint16_t", "u"),
+        legacyFormat<float16>(VK_FORMAT_R16_SFLOAT, "float16_t"),
+        {VK_FORMAT_R16_SFLOAT_FPENCODING_BFLOAT16_ARM, false, true, "-3.3895313892515355e+38", "3.3895313892515355e+38",
+         "bfloat16_t", 0x6642, "float"},
+        {VK_FORMAT_R8_SFLOAT_FPENCODING_FLOAT8E5M2_ARM, false, true, "-57344", "57344", "float8_e5m2_t", 0x664D,
+         "float16_t"},
+        {VK_FORMAT_R8_SFLOAT_FPENCODING_FLOAT8E4M3_ARM, false, true, "-448", "448", "float8_e4m3_t", 0x664E,
+         "float16_t"},
+        legacyFormat<int32_t>(VK_FORMAT_R32_SINT, "int"),
+        legacyFormat<uint32_t>(VK_FORMAT_R32_UINT, "uint32_t", "u"),
+        legacyFormat<float>(VK_FORMAT_R32_SFLOAT, "float"),
+        legacyFormat<int64_t>(VK_FORMAT_R64_SINT, "int64_t", "ll"),
+        legacyFormat<uint64_t>(VK_FORMAT_R64_UINT, "uint64_t", "ull"),
+        legacyFormat<double>(VK_FORMAT_R64_SFLOAT, "double", "ll"),
+    };
+
+    for (const auto &expected : expectedFormats) {
+        SCOPED_TRACE(std::to_string(expected.format));
+        expectFormatInfo(expected);
+    }
+}
+
+TEST(MLEmulationLayerUtils, MakeFormatThrowsForUnsupportedFormat) {
+    EXPECT_THROW(static_cast<void>(getFormatInfo(VK_FORMAT_UNDEFINED)), std::runtime_error);
+}
+
 } // namespace


### PR DESCRIPTION
Refactor Format class to avoid temporary objects and to be more efficient. Prefer returning pointer to an info struct.
Use string_view to avoid temporary strings.
Add unit tests to cover all formats.

Change-Id: I6918311f3fa76457e3d2e54fac81e4fb726f605f