### PR TITLE
Change shader dir for Android

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,7 +3,7 @@
 #
 
 if(ANDROID)
-    set(SHADER_SOURCE_DIR "/data/local/tmp/tests/shader")
+    set(SHADER_SOURCE_DIR "tests/shader")
 else()
     set(SHADER_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/shader")
 endif()


### PR DESCRIPTION
The path for the source shader dirs is not correct anymore since each adb_helper instance has a separate test_runner dir under /data/local/tmp/

Change-Id: If233d081a0e239d1eacf3ea7ae4a1c4b81c14ba1