### PR TITLE
Move semantics and template type improvements

### DIFF
--- a/graph/compute_graph_op.cpp
+++ b/graph/compute_graph_op.cpp
@@ -2378,10 +2378,10 @@ std::shared_ptr<TensorDescriptor> GraphPipeline::getConstTensor(const uint32_t i
     return constTensorMap.at(id)->getTensorDescriptor();
 }
 
-std::shared_ptr<TensorDescriptor> GraphPipeline::makeConstCompositeTensor(const VkFormat format,
-                                                                          const std::vector<int64_t> &dimensions,
-                                                                          const void *data) {
-    auto tensorDescriptor = std::make_shared<TensorDescriptor>(loader, physicalDevice, device, format, dimensions);
+std::shared_ptr<TensorDescriptor>
+GraphPipeline::makeConstCompositeTensor(const VkFormat format, std::vector<int64_t> dimensions, const void *data) {
+    auto tensorDescriptor =
+        std::make_shared<TensorDescriptor>(loader, physicalDevice, device, format, std::move(dimensions));
     auto tensor = TensorDescriptor::makeTensor(tensorDescriptor);
     auto *const deviceMemory = tensorDescriptor->createInitializeDeviceMemory(data);
 
@@ -2422,10 +2422,10 @@ std::shared_ptr<TensorDescriptor> GraphPipeline::getTensor(const uint32_t set, c
     return tensorMap.at(set).at(binding).at(arrayIndex);
 }
 
-std::shared_ptr<TensorDescriptor> GraphPipeline::makeTensor(const VkFormat format,
-                                                            const std::vector<int64_t> &dimensions,
-                                                            const std::vector<int64_t> &strides) {
-    auto tensor = std::make_shared<TensorDescriptor>(loader, physicalDevice, device, format, dimensions, strides);
+std::shared_ptr<TensorDescriptor> GraphPipeline::makeTensor(const VkFormat format, std::vector<int64_t> dimensions,
+                                                            std::vector<int64_t> strides) {
+    auto tensor = std::make_shared<TensorDescriptor>(loader, physicalDevice, device, format, std::move(dimensions),
+                                                     std::move(strides));
 
     auto [iterator, inserted] = tensorSet.insert(tensor);
 

--- a/graph/compute_graph_op.hpp
+++ b/graph/compute_graph_op.hpp
@@ -1203,7 +1203,7 @@ class GraphPipeline {
     // Constant tensors owned by the pipeline
     void makeConstTensor(uint32_t id, const VkTensorDescriptionARM &tensorDescription, const void *data);
     std::shared_ptr<TensorDescriptor> getConstTensor(uint32_t id) const;
-    std::shared_ptr<TensorDescriptor> makeConstCompositeTensor(VkFormat format, const std::vector<int64_t> &dimensions,
+    std::shared_ptr<TensorDescriptor> makeConstCompositeTensor(VkFormat format, std::vector<int64_t> dimensions,
                                                                const void *data);
 
     // External tensors owned by the application
@@ -1212,8 +1212,8 @@ class GraphPipeline {
     std::shared_ptr<TensorDescriptor> getTensor(uint32_t set, uint32_t binding, uint32_t arrayIndex = 0) const;
 
     // Tensors allocated in session ram
-    std::shared_ptr<TensorDescriptor> makeTensor(VkFormat format, const std::vector<int64_t> &dimensions = {},
-                                                 const std::vector<int64_t> &strides = {});
+    std::shared_ptr<TensorDescriptor> makeTensor(VkFormat format, std::vector<int64_t> dimensions = {},
+                                                 std::vector<int64_t> strides = {});
 
     const std::vector<std::shared_ptr<TensorDescriptor>> &getTensors() const;
 

--- a/graph/spirv_pass.cpp
+++ b/graph/spirv_pass.cpp
@@ -22,21 +22,23 @@ template <typename T, spv::FPEncoding encoding> bool isFloatEncoding(const spvto
     return f && f->width() == (8 * sizeof(T)) && f->encoding() == encoding;
 }
 
-bool isBFloat16(const spvtools::opt::analysis::Float *f) {
+bool isBFloat16Impl(const spvtools::opt::analysis::Float *f) {
     return isFloatEncoding<uint16_t, spv::FPEncoding::BFloat16KHR>(f);
 }
 
-bool isFloat8E5M2(const spvtools::opt::analysis::Float *f) {
+bool isFloat8E5M2Impl(const spvtools::opt::analysis::Float *f) {
     return isFloatEncoding<uint8_t, spv::FPEncoding::Float8E5M2EXT>(f);
 }
 
-bool isFloat8E4M3(const spvtools::opt::analysis::Float *f) {
+bool isFloat8E4M3Impl(const spvtools::opt::analysis::Float *f) {
     return isFloatEncoding<uint8_t, spv::FPEncoding::Float8E4M3EXT>(f);
 }
 
 template <typename T, spv::FPEncoding encoding>
 void flattenFloatComposite(const spvtools::opt::analysis::CompositeConstant *composite, std::vector<T> &values) {
-    for (const auto &component : composite->GetComponents()) {
+    const auto &components = composite->GetComponents();
+    values.reserve(values.size() + components.size());
+    for (const auto &component : components) {
         if (const auto *innerComposite = component->AsCompositeConstant()) {
             flattenFloatComposite<T, encoding>(innerComposite, values);
             continue;
@@ -47,6 +49,7 @@ void flattenFloatComposite(const spvtools::opt::analysis::CompositeConstant *com
             throw std::runtime_error("Unsupported float constant encoding in composite constant");
         }
 
+        // Raw payload extraction
         values.push_back(T(floatConstant->words()[0]));
     }
 }
@@ -122,16 +125,16 @@ void GraphPassBase::handleInputsAndOutputs(const Instruction &opGraphEntryPoint)
         const auto resultId = opGraphInputARM->result_id();
 
         // External id from the graph entry point
-        const auto &inputIndex = getConstScalar(opGraphInputARM->GetOperand(2));
+        const auto inputIndex = getConstScalar(opGraphInputARM->GetOperand(2));
         const uint32_t arrayIndex =
             opGraphInputARM->NumOperands() > 3 ? getConstScalar<uint32_t>(opGraphInputARM->GetOperand(3)) : 0;
-        const auto &inputTensor = getTensor(inputs[inputIndex], arrayIndex);
+        auto inputTensor = getTensor(inputs[inputIndex], arrayIndex);
 
-        // Map result id to external tensor
-        tensorMap[resultId][0] = inputTensor;
-        graphLog(Severity::Info) << "%" << resultId << ": tensor=" << inputTensor << std::endl;
-
+        // Seed OpGraphInputARM in the local cache before visiting graph ops.
+        // Unlike OpVariable and OpGraphConstantARM, graph inputs do not have a GraphPipeline lookup path.
+        graphLog(Severity::Info) << '%' << resultId << ": tensor=" << inputTensor << std::endl;
         graphPipeline.makeInput(inputTensor);
+        tensorMap[resultId][0] = std::move(inputTensor);
     }
 
     // Create and connect output tensors
@@ -141,13 +144,13 @@ void GraphPassBase::handleInputsAndOutputs(const Instruction &opGraphEntryPoint)
         assert(opGraphSetOutputARM->opcode() == spv::Op::OpGraphSetOutputARM);
 
         // Tensor that shall be bound to the output
-        const auto &instruction = get_def_use_mgr()->GetDef(opGraphSetOutputARM->GetOperand(0).AsId());
+        const auto *instruction = get_def_use_mgr()->GetDef(opGraphSetOutputARM->GetOperand(0).AsId());
 
         // The external tensor id from the graph entry point
-        const auto &outputIndex = getConstScalar(opGraphSetOutputARM->GetOperand(1));
+        const auto outputIndex = getConstScalar(opGraphSetOutputARM->GetOperand(1));
         const uint32_t arrayIndex =
             opGraphSetOutputARM->NumOperands() > 2 ? getConstScalar<uint32_t>(opGraphSetOutputARM->GetOperand(2)) : 0;
-        const auto &outputTensor = getTensor(outputs[outputIndex], arrayIndex);
+        auto outputTensor = getTensor(outputs[outputIndex], arrayIndex);
 
         graphPipeline.makeOutput(outputTensor);
 
@@ -156,22 +159,22 @@ void GraphPassBase::handleInputsAndOutputs(const Instruction &opGraphEntryPoint)
         case spv::Op::OpConstantCompositeReplicateEXT:
         case spv::Op::OpGraphInputARM:
         case spv::Op::OpGraphConstantARM: {
-            const auto &inputTensor = getTensor(*instruction);
+            const auto inputTensor = getTensor(*instruction);
             graphPipeline.makeCast(inputTensor, outputTensor, extractDebugInfoFromSPV(instruction, "CAST"));
             break;
         }
         case spv::Op::OpCompositeExtract: {
             const auto &compositeId = instruction->GetOperand(2);
-            const auto &compositeIndex = instruction->GetOperand(3).AsLiteralUint64();
+            const auto compositeIndex = instruction->GetOperand(3).AsLiteralUint64();
 
-            tensorMap[compositeId.AsId()][compositeIndex] = outputTensor;
-            graphLog(Severity::Info) << "%" << compositeId.AsId() << "[" << compositeIndex
+            graphLog(Severity::Info) << '%' << compositeId.AsId() << '[' << compositeIndex
                                      << "]: tensor=" << outputTensor << std::endl;
+            tensorMap[compositeId.AsId()][compositeIndex] = std::move(outputTensor);
             break;
         }
         default: {
-            tensorMap[instruction->result_id()][0] = outputTensor;
-            graphLog(Severity::Info) << "%" << instruction->result_id() << ": tensor=" << outputTensor << std::endl;
+            graphLog(Severity::Info) << '%' << instruction->result_id() << ": tensor=" << outputTensor << std::endl;
+            tensorMap[instruction->result_id()][0] = std::move(outputTensor);
         }
         }
     }
@@ -179,12 +182,12 @@ void GraphPassBase::handleInputsAndOutputs(const Instruction &opGraphEntryPoint)
 
 const Graph *GraphPassBase::getGraphById(const Operand &operand) {
     // OpGraphARM <OpTypeGraphARM id>
-    const auto &opGraphARM = get_def_use_mgr()->GetDef(operand.AsId());
+    const auto *opGraphARM = get_def_use_mgr()->GetDef(operand.AsId());
     const auto &graphs = get_module()->graphs();
     const auto found =
         std::find_if(graphs.begin(), graphs.end(), [&](auto &graph) { return graph->DefInst() == *opGraphARM; });
     if (found != graphs.end()) {
-        return (*found).get();
+        return found->get();
     }
     return nullptr;
 }
@@ -194,7 +197,7 @@ const analysis::TensorARM *GraphPassBase::getTensorType(const Operand &operand) 
 }
 
 const analysis::TensorARM *GraphPassBase::getTensorType(uint32_t id) const {
-    const auto &instruction = get_def_use_mgr()->GetDef(id);
+    const auto *instruction = get_def_use_mgr()->GetDef(id);
 
     switch (instruction->opcode()) {
     case spv::Op::OpTypeTensorARM:
@@ -227,7 +230,7 @@ std::tuple<uint64_t, uint64_t> GraphPassBase::getDescriptorSetAndBinding(const O
     uint64_t descriptorSet = std::numeric_limits<uint64_t>::max();
     uint64_t binding = 0;
 
-    for (const auto &decoration : get_decoration_mgr()->GetDecorationsFor(operand.AsId(), false)) {
+    for (const auto *decoration : get_decoration_mgr()->GetDecorationsFor(operand.AsId(), false)) {
         switch (static_cast<spv::Decoration>(decoration->GetSingleWordInOperand(1))) {
         case spv::Decoration::DescriptorSet:
             descriptorSet = decoration->GetOperand(2).AsLiteralUint64();
@@ -267,6 +270,8 @@ std::shared_ptr<TensorDescriptor> GraphPassBase::getTensor(const Instruction &in
         const auto index = static_cast<uint32_t>(instruction.GetOperand(3).AsLiteralUint64());
         return getTensor(compositeId, index);
     }
+    case spv::Op::OpGraphInputARM:
+        throw std::runtime_error("OpGraphInputARM tensor requested before graph inputs were connected");
     case spv::Op::OpConstantComposite:
     case spv::Op::OpConstantCompositeReplicateEXT:
     case spv::Op::OpConstantNull: {
@@ -278,18 +283,25 @@ std::shared_ptr<TensorDescriptor> GraphPassBase::getTensor(const Instruction &in
         auto tensor = makeTensor(getTensorType(instruction.GetOperand(1)));
         tensorMap[instruction.result_id()][arrayIndex] = tensor;
 
-        graphLog(Severity::Info) << "%" << instruction.result_id() << "[" << arrayIndex << "]: tensor=" << tensor
+        graphLog(Severity::Info) << '%' << instruction.result_id() << '[' << arrayIndex << "]: tensor=" << tensor
                                  << ", " << *tensor << std::endl;
 
         return tensor;
     }
     case spv::Op::OpGraphConstantARM: {
         const auto constantId = static_cast<uint32_t>(instruction.GetOperand(2).AsLiteralUint64());
-        return graphPipeline.getConstTensor(constantId);
+        // Graph constants are canonicalized in GraphPipeline, so resolve them there and mirror the
+        // descriptor in the local cache for later result-id lookups.
+        auto tensor = graphPipeline.getConstTensor(constantId);
+        tensorMap[instruction.result_id()][arrayIndex] = tensor;
+        return tensor;
     }
     case spv::Op::OpVariable: {
         const auto &[set, binding, tensor] = getTensorByDecoration(instruction.GetOperand(1), arrayIndex);
-        graphLog(Severity::Info) << "%" << instruction.result_id() << "[" << arrayIndex << "]: set=" << set
+        // Descriptor-backed variables are owned by GraphPipeline's set/binding cache.
+        // Store the descriptor locally as well so subsequent uses resolve through one code path.
+        tensorMap[instruction.result_id()][arrayIndex] = tensor;
+        graphLog(Severity::Info) << '%' << instruction.result_id() << '[' << arrayIndex << "]: set=" << set
                                  << ", binding=" << binding << ", tensor=" << tensor << ", " << *tensor << std::endl;
         return tensor;
     }
@@ -300,75 +312,74 @@ std::shared_ptr<TensorDescriptor> GraphPassBase::getTensor(const Instruction &in
 }
 
 std::shared_ptr<TensorDescriptor> GraphPassBase::getTensor(const Operand &operand, const uint32_t arrayIndex) {
-    const auto &instruction = get_def_use_mgr()->GetDef(operand.AsId());
+    const auto *instruction = get_def_use_mgr()->GetDef(operand.AsId());
     return getTensor(*instruction, arrayIndex);
 }
 
 std::shared_ptr<TensorDescriptor> GraphPassBase::makeTensor(const analysis::TensorARM *tensor) const {
     const VkFormat format = getVkFormat(tensor->element_type());
-    const std::vector<int64_t> dimensions =
-        tensor->is_shaped() ? getConstVector<int64_t>(tensor->shape_id()) : std::vector<int64_t>{};
+    auto dimensions = tensor->is_shaped() ? getConstVector<int64_t>(tensor->shape_id()) : std::vector<int64_t>{};
 
-    return graphPipeline.makeTensor(format, dimensions);
+    return graphPipeline.makeTensor(format, std::move(dimensions));
 }
 
 std::shared_ptr<TensorDescriptor> GraphPassBase::getOrMakeCompositeTensor(const uint32_t id) {
-    if (tensorMap[id][0] != nullptr) {
-        return tensorMap[id][0];
+    auto tensor = tensorMap[id][0];
+    if (tensor != nullptr) {
+        return tensor;
     }
 
-    const auto &instruction = get_def_use_mgr()->GetDef(id);
+    const auto *instruction = get_def_use_mgr()->GetDef(id);
     if (instruction->opcode() == spv::Op::OpGraphConstantARM) {
         const auto constantId = static_cast<uint32_t>(instruction->GetOperand(2).AsLiteralUint64());
-        tensorMap[id][0] = graphPipeline.getConstTensor(constantId);
-        return tensorMap[id][0];
+        tensor = graphPipeline.getConstTensor(constantId);
+    } else {
+        tensor = makeCompositeTensor(instruction->result_id());
     }
-
-    auto tensor = makeCompositeTensor(instruction->result_id());
     tensorMap[id][0] = tensor;
     return tensor;
 }
 
 std::shared_ptr<TensorDescriptor> GraphPassBase::makeCompositeTensor(const uint32_t id) const {
-    const auto &instruction = get_def_use_mgr()->GetDef(id);
-    const auto &tensorType = getTensorType(instruction->type_id());
-    const auto &format = getVkFormat(tensorType->element_type());
-    const auto &dimensions = getConstVector<int64_t>(tensorType->shape_id());
+    const auto *instruction = get_def_use_mgr()->GetDef(id);
+    const auto *tensorType = getTensorType(instruction->type_id());
+    const auto format = getVkFormat(tensorType->element_type());
+    auto dimensions = getConstVector<int64_t>(tensorType->shape_id());
 
     switch (format) {
     case VK_FORMAT_R8_BOOL_ARM:
     case VK_FORMAT_R8_SINT:
-        return graphPipeline.makeConstCompositeTensor(format, dimensions,
+        return graphPipeline.makeConstCompositeTensor(format, std::move(dimensions),
                                                       getConstVector<int8_t>(instruction->result_id()).data());
     case VK_FORMAT_R16_SINT:
-        return graphPipeline.makeConstCompositeTensor(format, dimensions,
+        return graphPipeline.makeConstCompositeTensor(format, std::move(dimensions),
                                                       getConstVector<int16_t>(instruction->result_id()).data());
     case VK_FORMAT_R32_SINT:
-        return graphPipeline.makeConstCompositeTensor(format, dimensions,
+        return graphPipeline.makeConstCompositeTensor(format, std::move(dimensions),
                                                       getConstVector<int32_t>(instruction->result_id()).data());
     case VK_FORMAT_R64_SINT:
-        return graphPipeline.makeConstCompositeTensor(format, dimensions,
+        return graphPipeline.makeConstCompositeTensor(format, std::move(dimensions),
                                                       getConstVector<int64_t>(instruction->result_id()).data());
     case VK_FORMAT_R16_SFLOAT:
-        return graphPipeline.makeConstCompositeTensor(format, dimensions,
+        return graphPipeline.makeConstCompositeTensor(format, std::move(dimensions),
                                                       getConstVector<float16>(instruction->result_id()).data());
     case VK_FORMAT_R16_SFLOAT_FPENCODING_BFLOAT16_ARM: {
         const auto bf16Values = getConstVector<uint16_t, spv::FPEncoding::BFloat16KHR>(instruction, dimensions);
-        return graphPipeline.makeConstCompositeTensor(format, dimensions, bf16Values.data());
+        return graphPipeline.makeConstCompositeTensor(format, std::move(dimensions), bf16Values.data());
     }
     case VK_FORMAT_R8_SFLOAT_FPENCODING_FLOAT8E5M2_ARM: {
         const auto f8Values = getConstVector<uint8_t, spv::FPEncoding::Float8E5M2EXT>(instruction, dimensions);
-        return graphPipeline.makeConstCompositeTensor(format, dimensions, f8Values.data());
+        return graphPipeline.makeConstCompositeTensor(format, std::move(dimensions), f8Values.data());
     }
     case VK_FORMAT_R8_SFLOAT_FPENCODING_FLOAT8E4M3_ARM: {
         const auto f8Values = getConstVector<uint8_t, spv::FPEncoding::Float8E4M3EXT>(instruction, dimensions);
-        return graphPipeline.makeConstCompositeTensor(format, dimensions, f8Values.data());
+        return graphPipeline.makeConstCompositeTensor(format, std::move(dimensions), f8Values.data());
     }
     case VK_FORMAT_R32_SFLOAT:
-        return graphPipeline.makeConstCompositeTensor(format, dimensions,
+        return graphPipeline.makeConstCompositeTensor(format, std::move(dimensions),
                                                       getConstVector<float>(instruction->result_id()).data());
     case VK_FORMAT_R64_SFLOAT:
-        return graphPipeline.makeConstCompositeTensor(format, dimensions,
+        return graphPipeline.makeConstCompositeTensor(format, std::move(dimensions),
                                                       getConstVector<double>(instruction->result_id()).data());
     default:
         throw std::runtime_error(std::string("Unsupported composite tensor format: " + std::to_string(format)));
@@ -376,7 +387,7 @@ std::shared_ptr<TensorDescriptor> GraphPassBase::makeCompositeTensor(const uint3
 }
 
 VkFormat GraphPassBase::getVkFormat(const analysis::Type *type) const {
-    const auto &integerType = type->AsInteger();
+    const auto *integerType = type->AsInteger();
     if (integerType) {
         switch (integerType->width()) {
         case 8:
@@ -392,22 +403,22 @@ VkFormat GraphPassBase::getVkFormat(const analysis::Type *type) const {
         }
     }
 
-    const auto &boolType = type->AsBool();
+    const auto *boolType = type->AsBool();
     if (boolType) {
         return VK_FORMAT_R8_BOOL_ARM;
     }
 
-    const auto &floatType = type->AsFloat();
+    const auto *floatType = type->AsFloat();
     if (floatType) {
-        if (isFloat8E5M2(floatType)) {
+        if (isFloat8E5M2Impl(floatType)) {
             return VK_FORMAT_R8_SFLOAT_FPENCODING_FLOAT8E5M2_ARM;
         }
-        if (isFloat8E4M3(floatType)) {
+        if (isFloat8E4M3Impl(floatType)) {
             return VK_FORMAT_R8_SFLOAT_FPENCODING_FLOAT8E4M3_ARM;
         }
         switch (floatType->width()) {
         case 16:
-            if (isBFloat16(floatType)) {
+            if (isBFloat16Impl(floatType)) {
                 return VK_FORMAT_R16_SFLOAT_FPENCODING_BFLOAT16_ARM;
             } else {
                 return VK_FORMAT_R16_SFLOAT;
@@ -425,34 +436,39 @@ VkFormat GraphPassBase::getVkFormat(const analysis::Type *type) const {
 }
 
 bool GraphPassBase::getBoolConstant(const Operand &operand) {
-    const auto &constant = context()->get_constant_mgr()->FindDeclaredConstant(operand.AsId());
+    const auto *constant = context()->get_constant_mgr()->FindDeclaredConstant(operand.AsId());
     return constant->AsBoolConstant()->value();
 }
 
-std::string GraphPassBase::extractDebugInfoFromSPV(const Instruction *opExtInst, const std::string &defaultName) {
-    if (!opExtInst) {
-        return defaultName;
-    }
+// Disabled until needed
+// std::string GraphPassBase::extractDebugInfoFromSPV(const Instruction *opExtInst, const std::string &defaultName) {
+//     if (!opExtInst) {
+//         return defaultName;
+//     }
 
-    graphLog(Severity::Debug) << "[TRACE] extractDebugInfoFromSPV called with result_id: " << opExtInst->result_id()
-                              << std::endl;
+//     graphLog(Severity::Debug) << "[TRACE] extractDebugInfoFromSPV called with result_id: " << opExtInst->result_id()
+//                               << std::endl;
 
-    bool hasDebugInfoExtension = false;
-    for (const auto &inst : get_module()->extensions()) {
-        if (inst.opcode() == spv::Op::OpExtension && inst.GetOperand(0).AsString() == "SPV_KHR_non_semantic_info") {
-            hasDebugInfoExtension = true;
-            break;
-        }
-    }
+//     bool hasDebugInfoExtension = false;
+//     for (const auto &inst : get_module()->extensions()) {
+//         if (inst.opcode() == spv::Op::OpExtension && inst.GetOperand(0).AsString() == "SPV_KHR_non_semantic_info") {
+//             hasDebugInfoExtension = true;
+//             break;
+//         }
+//     }
 
-    if (!hasDebugInfoExtension) {
-        return defaultName;
-    }
+//     if (!hasDebugInfoExtension) {
+//         return defaultName;
+//     }
 
-    // TODO: extend with other non-semantic info decoration options
+//     // TODO: extend with other non-semantic info decoration options
 
-    return defaultName;
-}
+//     return defaultName;
+// }
+
+bool GraphPassBase::isBFloat16(const spvtools::opt::analysis::Float *f) { return isBFloat16Impl(f); }
+bool GraphPassBase::isFloat8E5M2(const spvtools::opt::analysis::Float *f) { return isFloat8E5M2Impl(f); }
+bool GraphPassBase::isFloat8E4M3(const spvtools::opt::analysis::Float *f) { return isFloat8E4M3Impl(f); }
 
 size_t GraphPassBase::getElementCount(const uint32_t id) const {
     const auto dimensions = getConstVector<int64_t>(id);

--- a/graph/spirv_pass.hpp
+++ b/graph/spirv_pass.hpp
@@ -62,7 +62,10 @@ class GraphPassBase : public Pass {
     std::shared_ptr<mlsdk::el::compute::TensorDescriptor> makeCompositeTensor(uint32_t id) const;
     VkFormat getVkFormat(const analysis::Type *type) const;
     bool getBoolConstant(const Operand &operand);
-    std::string extractDebugInfoFromSPV(const Instruction *opExtInst, const std::string &defaultname);
+
+    // Temp implementation until debug info is truly available
+    std::string extractDebugInfoFromSPV(const Instruction *, const std::string &defaultname) { return defaultname; }
+
     template <typename T = uint32_t> std::vector<T> getConstVector(const Operand &operand) const {
         return getConstVector<T>(operand.AsId());
     }
@@ -70,7 +73,9 @@ class GraphPassBase : public Pass {
     template <typename T = uint32_t>
     void getFlattenedCompositeConstant(const spvtools::opt::analysis::CompositeConstant *composite,
                                        std::vector<T> &kernel) const {
-        for (const auto *component : composite->GetComponents()) {
+        const auto &components = composite->GetComponents();
+        kernel.reserve(kernel.size() + components.size());
+        for (const auto *component : components) {
             if (const auto *innerComposite = component->AsCompositeConstant()) {
                 getFlattenedCompositeConstant(innerComposite, kernel);
             } else {
@@ -80,7 +85,7 @@ class GraphPassBase : public Pass {
     }
 
     template <typename T = uint32_t> std::vector<T> getConstVector(const uint32_t id) const {
-        const auto &constant = context()->get_constant_mgr()->FindDeclaredConstant(id);
+        const auto *constant = context()->get_constant_mgr()->FindDeclaredConstant(id);
         std::vector<T> kernel;
 
         if (const auto *composite = constant->AsCompositeConstant()) {
@@ -98,7 +103,7 @@ class GraphPassBase : public Pass {
             if (const auto *tensor = constant->type()->AsTensorARM()) {
                 // TensorARM: zero-initialize a composite tensor with the total element count
                 const auto elemCount = getElementCount(tensor->shape_id());
-                kernel.resize(elemCount);
+                kernel.resize(elemCount, 0);
             } else {
                 assert(false);
             }
@@ -114,74 +119,81 @@ class GraphPassBase : public Pass {
     }
 
     template <typename T = int64_t> T getConstScalar(const analysis::Constant *constant) const {
-        const auto *intConstant = constant->AsIntConstant();
-        if (intConstant) {
-            const auto *type = intConstant->type()->AsInteger();
+        if constexpr (std::is_integral_v<T>) {
+            const auto *intConstant = constant->AsIntConstant();
+            if (intConstant) {
+                const auto *type = intConstant->type()->AsInteger();
 
-            if (type->IsSigned()) {
-                return static_cast<T>(constant->GetSignExtendedValue());
+                if (type->IsSigned()) {
+                    return static_cast<T>(constant->GetSignExtendedValue());
+                }
+
+                switch (type->width()) {
+                case 8:
+                    return T(int8_t(constant->GetZeroExtendedValue()));
+                case 16:
+                    return T(int16_t(constant->GetZeroExtendedValue()));
+                case 32:
+                    return T(int32_t(constant->GetZeroExtendedValue()));
+                case 64:
+                    return T(int64_t(constant->GetZeroExtendedValue()));
+                default:
+                    throw std::runtime_error(std::string("Unsupported integer constant width: ") +
+                                             std::to_string(type->width()));
+                }
             }
+        } else if constexpr (std::is_floating_point_v<T>) {
+            const auto *floatConstant = constant->AsFloatConstant();
+            if (floatConstant) {
+                const auto *type = floatConstant->type()->AsFloat();
 
-            switch (type->width()) {
-            case 8:
-                return T(int8_t(constant->GetZeroExtendedValue()));
-            case 16:
-                return T(int16_t(constant->GetZeroExtendedValue()));
-            case 32:
-                return T(int32_t(constant->GetZeroExtendedValue()));
-            case 64:
-                return T(int64_t(constant->GetZeroExtendedValue()));
-            default:
-                throw std::runtime_error(std::string("Unsupported integer constant width: ") +
-                                         std::to_string(type->width()));
-            }
-        }
-
-        const auto *floatConstant = constant->AsFloatConstant();
-        if (floatConstant) {
-            const auto *type = floatConstant->type()->AsFloat();
-
-            switch (type->width()) {
-            case 8: {
-                if (type->encoding() == spv::FPEncoding::Float8E5M2EXT) {
-                    const auto value = uint8_t(floatConstant->words()[0]);
-                    const auto &fp = reinterpret_cast<const float8_e5m2 &>(value);
+                switch (type->width()) {
+                case 8: {
+                    if (type->encoding() == spv::FPEncoding::Float8E5M2EXT) {
+                        const auto value = uint8_t(floatConstant->words()[0]);
+                        const auto &fp = reinterpret_cast<const float8_e5m2 &>(value);
+                        return T(fp);
+                    }
+                    if (type->encoding() == spv::FPEncoding::Float8E4M3EXT) {
+                        const auto value = uint8_t(floatConstant->words()[0]);
+                        const auto &fp = reinterpret_cast<const float8_e4m3 &>(value);
+                        return T(fp);
+                    }
+                    throw std::runtime_error(std::string("Unsupported 8-bit float encoding: ") +
+                                             std::to_string(static_cast<uint32_t>(type->encoding())));
+                }
+                case 16: {
+                    const auto value = uint16_t(floatConstant->words()[0]);
+                    const auto &fp = reinterpret_cast<const float16 &>(value);
                     return T(fp);
                 }
-                if (type->encoding() == spv::FPEncoding::Float8E4M3EXT) {
-                    const auto value = uint8_t(floatConstant->words()[0]);
-                    const auto &fp = reinterpret_cast<const float8_e4m3 &>(value);
-                    return T(fp);
+                case 32:
+                    return T(floatConstant->GetFloatValue());
+                case 64:
+                    return T(floatConstant->GetDoubleValue());
+                default:
+                    throw std::runtime_error(std::string("Unsupported constant float width: ") +
+                                             std::to_string(type->width()));
                 }
-                throw std::runtime_error(std::string("Unsupported 8-bit float encoding: ") +
-                                         std::to_string(static_cast<uint32_t>(type->encoding())));
             }
-            case 16: {
-                const auto value = uint16_t(floatConstant->words()[0]);
-                const auto &fp = reinterpret_cast<const float16 &>(value);
-                return T(fp);
-            }
-            case 32:
-                return T(floatConstant->GetFloatValue());
-            case 64:
-                return T(floatConstant->GetDoubleValue());
-            default:
-                throw std::runtime_error(std::string("Unsupported constant float width: ") +
-                                         std::to_string(type->width()));
+        } else if constexpr (std::is_same_v<T, bool>) {
+            const auto *boolConstant = constant->AsBoolConstant();
+            if (boolConstant) {
+                return boolConstant->value();
             }
         }
-
-        const auto *boolConstant = constant->AsBoolConstant();
-        if (boolConstant) {
-            return T(boolConstant->value() ? 1 : 0);
-        }
-
         throw std::runtime_error(std::string("Unsupported constant type: ") + std::to_string(constant->type()->kind()));
     }
+
+    static bool isBFloat16(const spvtools::opt::analysis::Float *f);
+    static bool isFloat8E5M2(const spvtools::opt::analysis::Float *f);
+    static bool isFloat8E4M3(const spvtools::opt::analysis::Float *f);
 
     GraphPipeline &graphPipeline;
 
   private:
+    // Local cache from SPIR-V result id to the tensor descriptors used while lowering a graph.
+    // Slot 1 is for multi-result logical values (for example FFT-style ops), not descriptor array elements.
     std::map<uint32_t, std::array<std::shared_ptr<mlsdk::el::compute::TensorDescriptor>, 2>> tensorMap;
 
     size_t getElementCount(uint32_t id) const;

--- a/graph/spirv_pass_tosaspv_v100.cpp
+++ b/graph/spirv_pass_tosaspv_v100.cpp
@@ -39,13 +39,13 @@ void GraphPassTosaSpv100::handleGraph(const Graph *graph) {
         }
 
         const auto &resultId = opExtInst->GetInOperand(0);
-        const auto &importInstr = get_def_use_mgr()->GetDef(resultId.AsId());
+        const auto *importInstr = get_def_use_mgr()->GetDef(resultId.AsId());
         const auto &importName = importInstr->GetInOperand(0).AsString();
 
         if (importName == tosaSpv100) {
-            handleTosaInst(&*opExtInst);
+            handleTosaInst(opExtInst.get());
         } else if (importName == motionEngine100) {
-            handleMotionEngineInst(&*opExtInst);
+            handleMotionEngineInst(opExtInst.get());
         } else {
             throw std::runtime_error(std::string("Unsupported extension ") + importName);
         }
@@ -428,26 +428,26 @@ void GraphPassTosaSpv100::handleClamp(const Instruction *opExtInst, const std::s
     // OpExtInst <result id> <OpExtInstImport id> CLAMP minVal maxVal nanMode input
     assert(opExtInst->NumInOperands() == 6);
 
-    auto getClampBound = [&](const Operand &operand) -> double {
+    auto getClampBound = [&](const Operand &operand) {
         const auto *constant = context()->get_constant_mgr()->FindDeclaredConstant(operand.AsId());
         const auto *floatConstant = constant->AsFloatConstant();
         if (floatConstant != nullptr) {
             const auto *type = floatConstant->type()->AsFloat();
-            if (type != nullptr && type->width() == 16 && type->encoding() == spv::FPEncoding::BFloat16KHR) {
+            if (GraphPassBase::isBFloat16(type)) {
                 const uint32_t bits = uint32_t(uint16_t(floatConstant->words()[0])) << 16;
                 float value = 0.0F;
                 std::memcpy(&value, &bits, sizeof(value));
-                return double(value);
+                return real_t(value);
             }
         }
 
-        return getConstScalar<double>(constant);
+        return getConstScalar<real_t>(constant);
     };
 
     const auto &resultId = opExtInst->result_id();
     const auto minVal = getClampBound(opExtInst->GetInOperand(2));
     const auto maxVal = getClampBound(opExtInst->GetInOperand(3));
-    const auto &nanMode = getConstScalar<uint32_t>(opExtInst->GetInOperand(4));
+    const auto nanMode = getConstScalar<uint32_t>(opExtInst->GetInOperand(4));
     const auto &inputId = opExtInst->GetInOperand(5);
 
     graphLog(Severity::Info) << "OpExtInst result=%" << resultId << "," << debugName << ", minVal=" << minVal
@@ -748,8 +748,7 @@ void GraphPassTosaSpv100::handlePad(const Instruction *opExtInst, const std::str
         const auto *floatConstant = scalar->AsFloatConstant();
         const auto *floatType = floatConstant == nullptr ? nullptr : floatConstant->type()->AsFloat();
         if (output->getFormat() == VK_FORMAT_R16_SFLOAT_FPENCODING_BFLOAT16_ARM) {
-            if (floatType == nullptr || floatType->width() != 16 ||
-                floatType->encoding() != spv::FPEncoding::BFloat16KHR) {
+            if (!GraphPassBase::isBFloat16(floatType)) {
                 throw std::runtime_error("Unsupported BF16 PAD constant encoding");
             }
 
@@ -759,8 +758,7 @@ void GraphPassTosaSpv100::handlePad(const Instruction *opExtInst, const std::str
             std::memcpy(&fp32Value, &fp32Bits, sizeof(fp32Bits));
             padConst = real_t(fp32Value);
         } else if (output->getFormat() == VK_FORMAT_R8_SFLOAT_FPENCODING_FLOAT8E5M2_ARM) {
-            if (floatType == nullptr || floatType->width() != 8 ||
-                floatType->encoding() != spv::FPEncoding::Float8E5M2EXT) {
+            if (!GraphPassBase::isFloat8E5M2(floatType)) {
                 throw std::runtime_error("Unsupported FLOAT8E5M2 PAD constant encoding");
             }
 
@@ -768,16 +766,13 @@ void GraphPassTosaSpv100::handlePad(const Instruction *opExtInst, const std::str
             const auto &fp = reinterpret_cast<const float8_e5m2 &>(f8);
             padConst = real_t(fp);
         } else if (output->getFormat() == VK_FORMAT_R8_SFLOAT_FPENCODING_FLOAT8E4M3_ARM) {
-            if (floatType == nullptr || floatType->width() != 8 ||
-                floatType->encoding() != spv::FPEncoding::Float8E4M3EXT) {
+            if (!GraphPassBase::isFloat8E4M3(floatType)) {
                 throw std::runtime_error("Unsupported FLOAT8E4M3 PAD constant encoding");
             }
 
             const auto f8 = uint8_t(floatConstant->words()[0]);
             const auto &fp = reinterpret_cast<const float8_e4m3 &>(f8);
             padConst = real_t(fp);
-        } else {
-            throw std::runtime_error("Unsupported ouput format for PAD operation");
         }
     } else if (output->getFormat() == VK_FORMAT_R32_SINT) {
         const auto &padConstVector = getConstVector<int32_t>(opExtInst->GetInOperand(4));

--- a/graph/tensor.cpp
+++ b/graph/tensor.cpp
@@ -69,9 +69,9 @@ VkDeviceSize Tensor::bindTensorMemory(VkDeviceMemory deviceMemory, VkDeviceSize 
 
 TensorDescriptor::TensorDescriptor(const std::shared_ptr<VULKAN_HPP_NAMESPACE::detail::DispatchLoaderDynamic> &_loader,
                                    VkPhysicalDevice _physicalDevice, VkDevice _device, const VkFormat _format,
-                                   const std::vector<int64_t> &_dimensions, const std::vector<int64_t> &_strides)
+                                   std::vector<int64_t> _dimensions, std::vector<int64_t> _strides)
     : loader{_loader}, physicalDevice{_physicalDevice}, device{_device}, format{_format},
-      dimensions{_dimensions}, strides{_strides} {}
+      dimensions{std::move(_dimensions)}, strides{std::move(_strides)} {}
 
 TensorDescriptor::TensorDescriptor(const std::shared_ptr<VULKAN_HPP_NAMESPACE::detail::DispatchLoaderDynamic> &_loader,
                                    VkPhysicalDevice _physicalDevice, VkDevice _device,

--- a/graph/tensor.hpp
+++ b/graph/tensor.hpp
@@ -62,7 +62,7 @@ class TensorDescriptor {
   public:
     TensorDescriptor(const std::shared_ptr<VULKAN_HPP_NAMESPACE::detail::DispatchLoaderDynamic> &_loader,
                      VkPhysicalDevice _physicalDevice, VkDevice _device, VkFormat _format,
-                     const std::vector<int64_t> &_dimensions = {}, const std::vector<int64_t> &_strides = {});
+                     std::vector<int64_t> _dimensions = {}, std::vector<int64_t> _strides = {});
 
     TensorDescriptor(const std::shared_ptr<VULKAN_HPP_NAMESPACE::detail::DispatchLoaderDynamic> &_loader,
                      VkPhysicalDevice _physicalDevice, VkDevice _device,


### PR DESCRIPTION
- Use move semantics to avoid unnecessary copying of vectors when constructing objects.
- Use auto* to signal it's a pointer and not a reference.
- Add comments to explain the tensor cache and its role in the graph.
- Enable code based on template type.
- Stub out extractDebugInfoFromSPV until an useful implementation exist.

Change-Id: I2a7d8018c3b60b7350357e8ee1f2a65f22bede34