### PR TITLE
Handle FloatingPoint constants in SPIR-V pass

### DIFF
--- a/common/include/mlel/float.hpp
+++ b/common/include/mlel/float.hpp
@@ -36,6 +36,13 @@ using float16 = FloatingPoint<5, 10>;
 using float32 = FloatingPoint<8, 23>;
 using float64 = FloatingPoint<11, 52>;
 
+template <typename T> struct IsElFloatingPoint : std::false_type {};
+
+template <std::size_t EXPONENT, std::size_t MANTISSA>
+struct IsElFloatingPoint<FloatingPoint<EXPONENT, MANTISSA>> : std::true_type {};
+
+template <typename T> inline constexpr bool is_el_floating_point_v = IsElFloatingPoint<std::remove_cv_t<T>>::value;
+
 /**
  * Floating point conversion between double and the most common floating point types.
  *

--- a/graph/spirv_pass.hpp
+++ b/graph/spirv_pass.hpp
@@ -142,7 +142,7 @@ class GraphPassBase : public Pass {
                                              std::to_string(type->width()));
                 }
             }
-        } else if constexpr (std::is_floating_point_v<T>) {
+        } else if constexpr (std::is_floating_point_v<T> || is_el_floating_point_v<T>) {
             const auto *floatConstant = constant->AsFloatConstant();
             if (floatConstant) {
                 const auto *type = floatConstant->type()->AsFloat();
@@ -182,7 +182,8 @@ class GraphPassBase : public Pass {
                 return boolConstant->value();
             }
         }
-        throw std::runtime_error(std::string("Unsupported constant type: ") + std::to_string(constant->type()->kind()));
+        throw std::runtime_error(std::string("Unsupported constant type: ") + std::to_string(constant->type()->kind()) +
+                                 " for requested return type: " + typeid(T).name());
     }
 
     static bool isBFloat16(const spvtools::opt::analysis::Float *f);


### PR DESCRIPTION
- Add type trait to identify FloatingPoint types.
- Log failing const template type.

Change-Id: I2e7e7241ee1800817fb37fd2d55b5c476d07416b