### PR TITLE
Add version information to logs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,12 +57,20 @@ include(spirv-headers)
 include(spirv-cross)
 include(spirv-tools)
 include(glslang)
+include(version)
 
 if(NOT EXISTS ${SPIRV_TOOLS_PATH}/CMakeLists.txt)
     message(FATAL_ERROR "ML Emulation Layer for Vulkan only supports building SPIR-V Tools from source")
 endif()
 
 include(setLayerEntrypoints)
+
+set(VMEL_VERSION_DEPS
+    glslang
+    SPIRV-Cross
+    SPIRV-Headers
+    SPIRV-Tools
+    VulkanHeaders)
 
 ###############################################################################
 # Precision configuration

--- a/cmake/spirv-cross.cmake
+++ b/cmake/spirv-cross.cmake
@@ -1,15 +1,18 @@
 #
-# SPDX-FileCopyrightText: Copyright 2024-2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-FileCopyrightText: Copyright 2024-2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
 # SPDX-License-Identifier: Apache-2.0
 #
 
 set(SPIRV_CROSS_PATH "SPIRV_CROSS-NOTFOUND" CACHE PATH "Path to SPIRV-Cross")
+set(SPIRV-Cross_VERSION "unknown")
 
 if(EXISTS ${SPIRV_CROSS_PATH}/CMakeLists.txt)
     if(NOT TARGET spirv-cross-glsl)
         option(SPIRV_CROSS_ENABLE_TESTS "" OFF)
         add_subdirectory(${SPIRV_CROSS_PATH} spirv-cross SYSTEM EXCLUDE_FROM_ALL)
     endif()
+
+    mlsdk_get_git_revision(${SPIRV_CROSS_PATH} SPIRV-Cross_VERSION)
 else()
     find_package(spirv_cross_core REQUIRED CONFIG)
     find_package(spirv_cross_glsl REQUIRED CONFIG)

--- a/common/include/mlel/log.hpp
+++ b/common/include/mlel/log.hpp
@@ -10,13 +10,11 @@
  * Includes
  *******************************************************************************/
 
-#include <algorithm>
-#include <array>
 #include <cstdint>
 #include <iomanip>
 #include <iostream>
-#include <map>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace mlsdk::el::log {
@@ -64,17 +62,7 @@ class Log {
     bool enabled(Severity _severity) const;
 
   private:
-    static Severity getLogLevel(const std::string &environmentVariable, Severity defaultLogLevel);
-    std::string severityToString() const;
-
-    static inline const std::map<std::string, Severity> stringToSeverityMap = {
-        {std::string("error"), Severity::Error},
-        {std::string("warning"), Severity::Warning},
-        {std::string("info"), Severity::Info},
-        {std::string("debug"), Severity::Debug}};
-
-    static inline const std::array<std::string, 4> severityStringsArr = {std::string("Error"), std::string("Warning"),
-                                                                         std::string("Info"), std::string("Debug")};
+    std::string_view severityToString() const;
 
     Severity logLevel;
     std::string loggerName;
@@ -92,7 +80,7 @@ template <typename T> auto getValue(T value) {
 };
 
 template <typename T> Log &operator<<(Log &os, const std::vector<T> &v) {
-    os << std::dec << "[";
+    os << std::dec << '[';
     auto it = v.begin();
     if (it != v.end()) {
         os << getValue(*it);
@@ -102,7 +90,7 @@ template <typename T> Log &operator<<(Log &os, const std::vector<T> &v) {
         os << ", " << getValue(*it);
         ++it;
     }
-    os << "]";
+    os << ']';
     return os;
 }
 

--- a/common/log.cpp
+++ b/common/log.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2023-2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2023-2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
  * SPDX-License-Identifier: Apache-2.0
  *
  */
@@ -10,11 +10,39 @@
 
 #include "mlel/log.hpp"
 
+#include <algorithm>
+#include <array>
+
 /*******************************************************************************
  * Log
  *******************************************************************************/
 
 namespace mlsdk::el::log {
+namespace {
+constexpr std::array<std::pair<std::string_view, Severity>, 4> stringToSeverity = {
+    {{"Error", Severity::Error}, {"Warning", Severity::Warning}, {"Info", Severity::Info}, {"Debug", Severity::Debug}}};
+
+bool equalsIgnoreCase(std::string_view a, std::string_view b) {
+    return a.size() == b.size() && std::equal(a.begin(), a.end(), b.begin(), [](unsigned char c1, unsigned char c2) {
+               return std::tolower(c1) == std::tolower(c2);
+           });
+}
+
+Severity getLogLevel(const std::string &environmentVariable, const Severity defaultLogLevel) {
+    const char *logLevelCharArr = std::getenv(environmentVariable.c_str());
+    if (logLevelCharArr == nullptr) {
+        return defaultLogLevel;
+    }
+
+    const std::string logLevelStr(logLevelCharArr);
+    for (const auto &[name, severity] : stringToSeverity) {
+        if (equalsIgnoreCase(name, logLevelStr)) {
+            return severity;
+        }
+    }
+    return defaultLogLevel;
+}
+} // namespace
 
 Log::Log(const std::string &_environmentVariable, const std::string &_loggerName, const Severity _defaultLogLevel)
     : logLevel{getLogLevel(_environmentVariable, _defaultLogLevel)}, loggerName(_loggerName), os(&std::cout) {}
@@ -29,36 +57,22 @@ Log &Log::operator<<(std::ostream &(*f)(std::ostream &)) {
 Log &Log::operator()(const Severity _severity) {
     severity = _severity;
     if (enabled(severity)) {
-        *os << "[" << loggerName << "][" << severityToString() << "] ";
+        *os << '[' << loggerName << "][" << severityToString() << "] ";
     }
     return *this;
 }
 
 bool Log::enabled(const Severity _severity) const { return logLevel >= _severity; }
 
-Severity Log::getLogLevel(const std::string &environmentVariable, const Severity defaultLogLevel) {
-    char const *logLevelCharArr = std::getenv(environmentVariable.c_str());
-    if (logLevelCharArr == nullptr) {
-        return defaultLogLevel;
-    }
-
-    std::string logLevelStr(logLevelCharArr);
-    std::transform(logLevelStr.begin(), logLevelStr.end(), logLevelStr.begin(), ::tolower);
-    auto it = stringToSeverityMap.find(logLevelStr);
-    if (it == stringToSeverityMap.end()) {
-        return defaultLogLevel;
-    }
-    return it->second;
-}
-
-std::string Log::severityToString() const {
-    return size_t(severity) >= severityStringsArr.size() ? "Unknown" : severityStringsArr[uint32_t(severity)];
+std::string_view Log::severityToString() const {
+    const auto index = size_t(severity);
+    return index >= stringToSeverity.size() ? "Unknown" : stringToSeverity[index].first;
 }
 
 Log &operator<<(Log &os, const StringLineNumber &s) {
     std::string::size_type pastPos{};
     unsigned line{1};
-    os << std::resetiosflags(std::ios_base::dec) << "\n";
+    os << std::resetiosflags(std::ios_base::dec) << '\n';
     for (auto curPos = s.str.find('\n', pastPos); curPos != std::string::npos; curPos = s.str.find('\n', pastPos)) {
         os << std::setw(3) << line++ << ": " << s.str.substr(pastPos, curPos - pastPos + 1);
         pastPos = curPos + 1;
@@ -78,7 +92,7 @@ Log &operator<<(Log &os, const HexDump &dump) {
         if ((i % dump.width) == 0) {
             os << std::endl << std::setw(8) << i << ": ";
         }
-        os << std::setw(2) << static_cast<unsigned>(dump.pointer[i]) << " ";
+        os << std::setw(2) << static_cast<unsigned>(dump.pointer[i]) << ' ';
     }
 
     os.getStreamMutable()->copyfmt(osStateOrig);

--- a/common/version.hpp.in
+++ b/common/version.hpp.in
@@ -1,0 +1,19 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <string_view>
+
+namespace mlsdk::el::details {
+
+constexpr std::string_view version{R""""({
+  "version": "@GIT_REVISION@",
+  "dependencies": [
+    @DEP_GIT_REVISIONS@
+  ]
+})""""};
+
+} // namespace mlsdk::el::details

--- a/graph/CMakeLists.txt
+++ b/graph/CMakeLists.txt
@@ -44,6 +44,15 @@ target_link_libraries(VkLayer_Graph PRIVATE
 target_include_directories(VkLayer_Graph PRIVATE
     ${CMAKE_CURRENT_BINARY_DIR})
 
+set(GRAPH_VERSION_HEADER "${CMAKE_CURRENT_BINARY_DIR}/generated/version.hpp")
+mlsdk_generate_version_header(
+    TARGET VkLayer_Graph
+    SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/../common/version.hpp.in"
+    DESTINATION "${GRAPH_VERSION_HEADER}"
+    DEPENDENCIES
+        ${VMEL_VERSION_DEPS}
+)
+
 install(TARGETS VkLayer_Graph EXPORT ${ML_SDK_EL_PACKAGE_NAME}Config)
 
 # Generate VkLayer_Graph.json

--- a/graph/graph_layer.cpp
+++ b/graph/graph_layer.cpp
@@ -15,6 +15,8 @@
 #include "memory_planner.hpp"
 #include "optical_flow.hpp"
 #include "pipeline_cache.hpp"
+#include "version.hpp"
+
 #include "source/opt/build_module.h"
 #include "source/opt/ir_context.h"
 #include "source/opt/module.h"
@@ -1893,6 +1895,8 @@ vkNegotiateLoaderLayerInterfaceVersion(VkNegotiateLayerInterface *pNegotiateLaye
     if (pNegotiateLayerInterface->loaderLayerInterfaceVersion < 2) {
         return VK_ERROR_INITIALIZATION_FAILED;
     }
+
+    graphLog(Severity::Info) << mlsdk::el::details::version << std::endl;
 
     pNegotiateLayerInterface->loaderLayerInterfaceVersion = 2;
     pNegotiateLayerInterface->pfnGetInstanceProcAddr = GraphLayer::vkGetInstanceProcAddr;

--- a/graph/spirv_pass.cpp
+++ b/graph/spirv_pass.cpp
@@ -77,7 +77,7 @@ void GraphPassBase::handleGraphConstants() {
             if (tensorMap.find(resultId) == tensorMap.end()) {
                 auto &tensors = tensorMap[resultId];
                 tensors[0] = graphPipeline.getConstTensor(constantId);
-                graphLog(Severity::Info) << "%" << resultId << ": constId=" << constantId << ", tensor=" << tensors[0]
+                graphLog(Severity::Info) << '%' << resultId << ": constId=" << constantId << ", tensor=" << tensors[0]
                                          << ", " << *tensors[0] << std::endl;
             }
             break;

--- a/graph/spirv_pass_tosaspv_v100.cpp
+++ b/graph/spirv_pass_tosaspv_v100.cpp
@@ -366,7 +366,7 @@ void GraphPassTosaSpv100::handleArgmax(const Instruction *opExtInst, const std::
     const auto &nanMode = getConstScalar<uint32_t>(opExtInst->GetInOperand(3));
     const auto &inputId = opExtInst->GetInOperand(4);
 
-    graphLog(Severity::Info) << "OpExtInst result=%" << resultId << "," << debugName << ", axis=" << axis
+    graphLog(Severity::Info) << "OpExtInst result=%" << resultId << ',' << debugName << ", axis=" << axis
                              << ", nanMode=" << nanMode << ", input=%" << inputId.AsId() << std::endl;
 
     graphPipeline.makeArgmax(getTensor(inputId), getTensor(*opExtInst), axis, nanMode, debugName);
@@ -381,7 +381,7 @@ void GraphPassTosaSpv100::handleArithmeticRightShift(const Instruction *opExtIns
     const auto &inputId1 = opExtInst->GetInOperand(3);
     const auto &inputId2 = opExtInst->GetInOperand(4);
 
-    graphLog(Severity::Info) << "OpExtInst result=%" << resultId << "," << debugName << ", round=" << round
+    graphLog(Severity::Info) << "OpExtInst result=%" << resultId << ',' << debugName << ", round=" << round
                              << ", input1=%" << inputId1.AsId() << ", input2=%" << inputId2.AsId() << std::endl;
 
     graphPipeline.makeArithmeticRightShift(getTensor(inputId1), getTensor(inputId2), getTensor(*opExtInst), round,
@@ -418,7 +418,7 @@ void GraphPassTosaSpv100::handleCast(const Instruction *opExtInst, const std::st
     const auto &resultId = opExtInst->result_id();
     const auto &inputId = opExtInst->GetInOperand(2);
 
-    graphLog(Severity::Info) << "OpExtInst result=%" << resultId << "," << debugName << ", input=%" << inputId.AsId()
+    graphLog(Severity::Info) << "OpExtInst result=%" << resultId << ',' << debugName << ", input=%" << inputId.AsId()
                              << std::endl;
 
     graphPipeline.makeCast(getTensor(inputId), getTensor(*opExtInst), debugName);
@@ -450,7 +450,7 @@ void GraphPassTosaSpv100::handleClamp(const Instruction *opExtInst, const std::s
     const auto nanMode = getConstScalar<uint32_t>(opExtInst->GetInOperand(4));
     const auto &inputId = opExtInst->GetInOperand(5);
 
-    graphLog(Severity::Info) << "OpExtInst result=%" << resultId << "," << debugName << ", minVal=" << minVal
+    graphLog(Severity::Info) << "OpExtInst result=%" << resultId << ',' << debugName << ", minVal=" << minVal
                              << ", maxVal=" << maxVal << ", nanMode=" << nanMode << ", input=%" << inputId.AsId()
                              << std::endl;
 
@@ -471,7 +471,7 @@ void GraphPassTosaSpv100::handleConcat(const Instruction *opExtInst, const std::
         inputsStr += ", input" + std::to_string(i - 3) + "=%" + std::to_string(opExtInst->GetInOperand(i).AsId());
     }
 
-    graphLog(Severity::Info) << "OpExtInst result=%" << resultId << "," << debugName << ", axis=" << axis << inputsStr
+    graphLog(Severity::Info) << "OpExtInst result=%" << resultId << ',' << debugName << ", axis=" << axis << inputsStr
                              << std::endl;
 
     graphPipeline.makeConcat(inputs, getTensor(*opExtInst), axis, debugName);
@@ -494,7 +494,7 @@ void GraphPassTosaSpv100::handleConv2D(const Instruction *opExtInst, const std::
     const auto &inputZeroPoint = getConstVector<int8_t>(opExtInst->GetInOperand(10));
     const auto &weightZeroPoint = getConstVector<int8_t>(opExtInst->GetInOperand(11));
 
-    graphLog(Severity::Info) << "OpExtInst result=%" << resultId << "," << debugName << ", pad=" << pad
+    graphLog(Severity::Info) << "OpExtInst result=%" << resultId << ',' << debugName << ", pad=" << pad
                              << ", stride=" << stride << ", dilation=" << dilation << ", accType=" << accType
                              << ", localBound=" << localBound << ", input=%" << inputId.AsId() << ", weight=%"
                              << weightId.AsId() << ", bias=%" << biasId.AsId() << ", inputZeroPoint=" << inputZeroPoint
@@ -521,7 +521,7 @@ void GraphPassTosaSpv100::handleConv3D(const Instruction *opExtInst, const std::
     const auto &inputZeroPoint = getConstVector<int8_t>(opExtInst->GetInOperand(10));
     const auto &weightZeroPoint = getConstVector<int8_t>(opExtInst->GetInOperand(11));
 
-    graphLog(Severity::Info) << "OpExtInst result=%" << resultId << "," << debugName << ", pad=" << pad
+    graphLog(Severity::Info) << "OpExtInst result=%" << resultId << ',' << debugName << ", pad=" << pad
                              << ", stride=" << stride << ", dilation=" << dilation << ", accType=" << accType
                              << ", localBound=" << localBound << ", input=%" << inputId.AsId() << ", weight=%"
                              << weightId.AsId() << ", bias=%" << biasId.AsId() << ", inputZeroPoint=" << inputZeroPoint
@@ -548,7 +548,7 @@ void GraphPassTosaSpv100::handleDepthwiseConv2D(const Instruction *opExtInst, co
     const auto &inputZeroPoint = getConstVector<int8_t>(opExtInst->GetInOperand(10));
     const auto &weightZeroPoint = getConstVector<int8_t>(opExtInst->GetInOperand(11));
 
-    graphLog(Severity::Info) << "OpExtInst result=%" << resultId << "," << debugName << ", pad=" << pad
+    graphLog(Severity::Info) << "OpExtInst result=%" << resultId << ',' << debugName << ", pad=" << pad
                              << ", stride=" << stride << ", dilation=" << dilation << ", accType=" << accType
                              << ", localBound=" << localBound << ", input=%" << inputId.AsId() << ", weight=%"
                              << weightId.AsId() << ", bias=%" << biasId.AsId() << ", inputZeroPoint=" << inputZeroPoint
@@ -586,7 +586,7 @@ void GraphPassTosaSpv100::handleElementwiseUnary(
     const auto &resultId = opExtInst->result_id();
     const auto &inputId1 = opExtInst->GetInOperand(2);
 
-    graphLog(Severity::Info) << "OpExtInst result=%" << resultId << "," << debugName << ", input1=%" << inputId1.AsId()
+    graphLog(Severity::Info) << "OpExtInst result=%" << resultId << ',' << debugName << ", input1=%" << inputId1.AsId()
                              << std::endl;
 
     std::invoke(function, &graphPipeline, getTensor(inputId1), getTensor(*opExtInst), debugName);
@@ -602,7 +602,7 @@ void GraphPassTosaSpv100::handleFft2D(const Instruction *opExtInst, const std::s
     const auto &inputRealId = opExtInst->GetInOperand(4);
     const auto &inputImagId = opExtInst->GetInOperand(5);
 
-    graphLog(Severity::Info) << "OpExtInst result=%" << resultId << "," << debugName << ", inverse=" << inverse
+    graphLog(Severity::Info) << "OpExtInst result=%" << resultId << ',' << debugName << ", inverse=" << inverse
                              << ", localBound=" << localBound << ", inputReal=%" << inputRealId.AsId()
                              << ", inputImag=%" << inputImagId.AsId() << std::endl;
 
@@ -618,7 +618,7 @@ void GraphPassTosaSpv100::handleGather(const Instruction *opExtInst, const std::
     const auto &valuesId = opExtInst->GetInOperand(2);
     const auto &indicesId = opExtInst->GetInOperand(3);
 
-    graphLog(Severity::Info) << "OpExtInst result=%" << resultId << "," << debugName << ", values=%" << valuesId.AsId()
+    graphLog(Severity::Info) << "OpExtInst result=%" << resultId << ',' << debugName << ", values=%" << valuesId.AsId()
                              << ", indices=%" << indicesId.AsId() << std::endl;
 
     graphPipeline.makeGather(getTensor(valuesId), getTensor(indicesId), getTensor(*opExtInst), debugName);
@@ -634,7 +634,7 @@ void GraphPassTosaSpv100::handleMatmul(const Instruction *opExtInst, const std::
     const auto &input1ZeroPoint = getConstVector<int8_t>(opExtInst->GetInOperand(4));
     const auto &input2ZeroPoint = getConstVector<int8_t>(opExtInst->GetInOperand(5));
 
-    graphLog(Severity::Info) << "OpExtInst result=%" << resultId << "," << debugName << ", input1=%" << inputId1.AsId()
+    graphLog(Severity::Info) << "OpExtInst result=%" << resultId << ',' << debugName << ", input1=%" << inputId1.AsId()
                              << ", input2=%" << inputId2.AsId() << ", input1ZeroPoint=" << input1ZeroPoint
                              << ", input2ZeroPoint=" << input2ZeroPoint << std::endl;
 
@@ -651,7 +651,7 @@ void GraphPassTosaSpv100::handleMaximum(const Instruction *opExtInst, const std:
     const auto &inputId1 = opExtInst->GetInOperand(3);
     const auto &inputId2 = opExtInst->GetInOperand(4);
 
-    graphLog(Severity::Info) << "OpExtInst result=%" << resultId << "," << debugName << ", nanMode=" << nanMode
+    graphLog(Severity::Info) << "OpExtInst result=%" << resultId << ',' << debugName << ", nanMode=" << nanMode
                              << ", input1=%" << inputId1.AsId() << ", input2=%" << inputId2.AsId() << std::endl;
 
     graphPipeline.makeMaximum(getTensor(inputId1), getTensor(inputId2), getTensor(*opExtInst), nanMode, debugName);
@@ -668,7 +668,7 @@ void GraphPassTosaSpv100::handleMaxPool2D(const Instruction *opExtInst, const st
     const auto &nanMode = getConstScalar<uint32_t>(opExtInst->GetInOperand(5));
     const auto &inputId = opExtInst->GetInOperand(6);
 
-    graphLog(Severity::Info) << "OpExtInst result=%" << resultId << "," << debugName << ", kernel=" << kernel
+    graphLog(Severity::Info) << "OpExtInst result=%" << resultId << ',' << debugName << ", kernel=" << kernel
                              << ", stride=" << stride << ", pad=" << pad << ", nanMode=" << nanMode << ", input=%"
                              << inputId.AsId() << std::endl;
 
@@ -684,7 +684,7 @@ void GraphPassTosaSpv100::handleMinimum(const Instruction *opExtInst, const std:
     const auto &inputId1 = opExtInst->GetInOperand(3);
     const auto &inputId2 = opExtInst->GetInOperand(4);
 
-    graphLog(Severity::Info) << "OpExtInst result=%" << resultId << "," << debugName << ", nanMode=" << nanMode
+    graphLog(Severity::Info) << "OpExtInst result=%" << resultId << ',' << debugName << ", nanMode=" << nanMode
                              << ", input1=%" << inputId1.AsId() << ", input2=%" << inputId2.AsId() << std::endl;
 
     graphPipeline.makeMinimum(getTensor(inputId1), getTensor(inputId2), getTensor(*opExtInst), nanMode, debugName);
@@ -699,7 +699,7 @@ void GraphPassTosaSpv100::handleMul(const Instruction *opExtInst, const std::str
     const auto &inputId2 = opExtInst->GetInOperand(3);
     const auto &shift = getConstVector<uint8_t>(opExtInst->GetInOperand(4));
 
-    graphLog(Severity::Info) << "OpExtInst result=%" << resultId << "," << debugName << ", input1=%" << inputId1.AsId()
+    graphLog(Severity::Info) << "OpExtInst result=%" << resultId << ',' << debugName << ", input1=%" << inputId1.AsId()
                              << ", input2=%" << inputId2.AsId() << ", shift=" << shift << std::endl;
 
     graphPipeline.makeMul(getTensor(inputId1), getTensor(inputId2), getTensor(*opExtInst), shift[0], debugName);
@@ -714,7 +714,7 @@ void GraphPassTosaSpv100::handleNegate(const Instruction *opExtInst, const std::
     const auto &inputZeroPoint = getConstVector<int32_t>(opExtInst->GetInOperand(3));
     const auto &outputZeroPoint = getConstVector<int32_t>(opExtInst->GetInOperand(4));
 
-    graphLog(Severity::Info) << "OpExtInst result=%" << resultId << "," << debugName << ", input=%" << inputId.AsId()
+    graphLog(Severity::Info) << "OpExtInst result=%" << resultId << ',' << debugName << ", input=%" << inputId.AsId()
                              << ", inputZeroPoint=" << inputZeroPoint << ", outputZeroPoint=" << outputZeroPoint
                              << std::endl;
 
@@ -784,7 +784,7 @@ void GraphPassTosaSpv100::handlePad(const Instruction *opExtInst, const std::str
         padConstInt = int32_t(padConst);
     }
 
-    graphLog(Severity::Info) << "OpExtInst result=" << resultId << "," << debugName << ", padding=" << padding
+    graphLog(Severity::Info) << "OpExtInst result=" << resultId << ',' << debugName << ", padding=" << padding
                              << ", padConst=" << std::fixed << std::setprecision(0) << padConst << ", input=%"
                              << inputId.AsId() << std::endl;
 
@@ -808,7 +808,7 @@ void GraphPassTosaSpv100::handleRescale(const Instruction *opExtInst, const std:
     const auto &inputZeroPoint = getConstVector<int32_t>(opExtInst->GetInOperand(10));
     const auto &outputZeroPoint = getConstVector<int32_t>(opExtInst->GetInOperand(11));
 
-    graphLog(Severity::Info) << "OpExtInst result=" << resultId << "," << debugName << ", scale32=" << scale32
+    graphLog(Severity::Info) << "OpExtInst result=" << resultId << ',' << debugName << ", scale32=" << scale32
                              << ", roundingRound=" << roundingMode << ", perChannel=" << perChannel
                              << ", inputUnsigned=" << inputUnsigned << ", outputUnsigned=" << outputUnsigned
                              << ", input=%" << inputId.AsId() << ", multiplier=" << multiplier << ", shift=" << shift
@@ -849,7 +849,7 @@ void GraphPassTosaSpv100::handleReduceMax(const Instruction *opExtInst, const st
     const auto &nanMode = getConstScalar<uint32_t>(opExtInst->GetInOperand(3));
     const auto &inputId = opExtInst->GetInOperand(4);
 
-    graphLog(Severity::Info) << "OpExtInst result=%" << resultId << "," << debugName << ", axis=" << axis
+    graphLog(Severity::Info) << "OpExtInst result=%" << resultId << ',' << debugName << ", axis=" << axis
                              << ", nanMode=" << nanMode << ", input=%" << inputId.AsId() << std::endl;
 
     graphPipeline.makeReduceMax(getTensor(inputId), getTensor(*opExtInst), axis, nanMode, debugName);
@@ -864,7 +864,7 @@ void GraphPassTosaSpv100::handleReduceMin(const Instruction *opExtInst, const st
     const auto &nanMode = getConstScalar<uint32_t>(opExtInst->GetInOperand(3));
     const auto &inputId = opExtInst->GetInOperand(4);
 
-    graphLog(Severity::Info) << "OpExtInst result=%" << resultId << "," << debugName << ", axis=" << axis
+    graphLog(Severity::Info) << "OpExtInst result=%" << resultId << ',' << debugName << ", axis=" << axis
                              << ", nanMode=" << nanMode << ", input=%" << inputId.AsId() << std::endl;
 
     graphPipeline.makeReduceMin(getTensor(inputId), getTensor(*opExtInst), axis, nanMode, debugName);
@@ -878,7 +878,7 @@ void GraphPassTosaSpv100::handleReshape(const Instruction *opExtInst, const std:
     const auto &inputId = opExtInst->GetInOperand(2);
     const auto &shape = getConstVector(opExtInst->GetInOperand(3));
 
-    graphLog(Severity::Info) << "OpExtInst result=%" << resultId << "," << debugName << ", input=%" << inputId.AsId()
+    graphLog(Severity::Info) << "OpExtInst result=%" << resultId << ',' << debugName << ", input=%" << inputId.AsId()
                              << ", shape=" << shape << std::endl;
 
     graphPipeline.makeReshape(getTensor(inputId), getTensor(*opExtInst), debugName);
@@ -895,7 +895,7 @@ void GraphPassTosaSpv100::handleResize(const Instruction *opExtInst, const std::
     const auto &offset = getConstVector<int32_t>(opExtInst->GetInOperand(5));
     const auto &border = getConstVector<int32_t>(opExtInst->GetInOperand(6));
 
-    graphLog(Severity::Info) << "OpExtInst result=%" << resultId << "," << debugName << ", scale=" << scale
+    graphLog(Severity::Info) << "OpExtInst result=%" << resultId << ',' << debugName << ", scale=" << scale
                              << ", offset=" << offset << ", border=" << border << ", mode=" << mode << ", input=%"
                              << inputId.AsId() << std::endl;
 
@@ -910,7 +910,7 @@ void GraphPassTosaSpv100::handleReverse(const Instruction *opExtInst, const std:
     const auto &axis = getConstScalar<uint32_t>(opExtInst->GetInOperand(2));
     const auto &inputId = opExtInst->GetInOperand(3);
 
-    graphLog(Severity::Info) << "OpExtInst result=%" << resultId << "," << debugName << ", axis=" << axis << ", input=%"
+    graphLog(Severity::Info) << "OpExtInst result=%" << resultId << ',' << debugName << ", axis=" << axis << ", input=%"
                              << inputId.AsId() << std::endl;
 
     graphPipeline.makeReverse(getTensor(inputId), getTensor(*opExtInst), axis, debugName);
@@ -924,7 +924,7 @@ void GraphPassTosaSpv100::handleRfft2D(const Instruction *opExtInst, const std::
     const auto &localBound = getBoolConstant(opExtInst->GetInOperand(2));
     const auto &inputId = opExtInst->GetInOperand(3);
 
-    graphLog(Severity::Info) << "OpExtInst result=%" << resultId << "," << debugName << ", localBound=" << localBound
+    graphLog(Severity::Info) << "OpExtInst result=%" << resultId << ',' << debugName << ", localBound=" << localBound
                              << ", input=%" << inputId.AsId() << std::endl;
 
     graphPipeline.makeRfft2D(getTensor(inputId), getTensor(*opExtInst, 0), getTensor(*opExtInst, 1), debugName);
@@ -939,7 +939,7 @@ void GraphPassTosaSpv100::handleScatter(const Instruction *opExtInst, const std:
     const auto &indicesId = opExtInst->GetInOperand(3);
     const auto &inputId = opExtInst->GetInOperand(4);
 
-    graphLog(Severity::Info) << "OpExtInst result=%" << resultId << "," << debugName << ", valuesIn=%" << inputId.AsId()
+    graphLog(Severity::Info) << "OpExtInst result=%" << resultId << ',' << debugName << ", valuesIn=%" << inputId.AsId()
                              << ", indices=%" << indicesId.AsId() << ", input=%" << inputId.AsId() << std::endl;
 
     graphPipeline.makeScatter(getTensor(inputId), getTensor(valuesInId), getTensor(indicesId), getTensor(*opExtInst),
@@ -955,7 +955,7 @@ void GraphPassTosaSpv100::handleSelect(const Instruction *opExtInst, const std::
     const auto &inputId2 = opExtInst->GetInOperand(3);
     const auto &inputId3 = opExtInst->GetInOperand(4);
 
-    graphLog(Severity::Info) << "OpExtInst result=%" << resultId << "," << debugName << ", input1=%" << inputId1.AsId()
+    graphLog(Severity::Info) << "OpExtInst result=%" << resultId << ',' << debugName << ", input1=%" << inputId1.AsId()
                              << ", input2=%" << inputId2.AsId() << ", input3=%" << inputId3.AsId() << std::endl;
 
     graphPipeline.makeSelect(getTensor(inputId1), getTensor(inputId2), getTensor(inputId3), getTensor(*opExtInst),
@@ -971,7 +971,7 @@ void GraphPassTosaSpv100::handleSlice(const Instruction *opExtInst, const std::s
     const auto &start = getConstVector(opExtInst->GetInOperand(3));
     const auto &size = getConstVector(opExtInst->GetInOperand(4));
 
-    graphLog(Severity::Info) << "OpExtInst result=%" << resultId << "," << debugName << " , input=%" << inputId.AsId()
+    graphLog(Severity::Info) << "OpExtInst result=%" << resultId << ',' << debugName << " , input=%" << inputId.AsId()
                              << ", start=" << start << ", size=" << size << std::endl;
 
     graphPipeline.makeSlice(getTensor(inputId), getTensor(*opExtInst), start, debugName);
@@ -985,7 +985,7 @@ void GraphPassTosaSpv100::handleTable(const Instruction *opExtInst, const std::s
     const auto &inputId = opExtInst->GetInOperand(2);
     const auto &table = getOrMakeCompositeTensor(opExtInst->GetInOperand(3).AsId());
 
-    graphLog(Severity::Info) << "OpExtInst result=%" << resultId << "," << debugName << ", input=%" << inputId.AsId()
+    graphLog(Severity::Info) << "OpExtInst result=%" << resultId << ',' << debugName << ", input=%" << inputId.AsId()
                              << ", table=" << table << std::endl;
 
     graphPipeline.makeTable(getTensor(inputId), getTensor(*opExtInst), table, debugName);
@@ -999,7 +999,7 @@ void GraphPassTosaSpv100::handleTile(const Instruction *opExtInst, const std::st
     const auto &inputId = opExtInst->GetInOperand(2);
     const auto &multiples = getConstVector(opExtInst->GetInOperand(3));
 
-    graphLog(Severity::Info) << "OpExtInst result=%" << resultId << "," << debugName << ", input=%" << inputId.AsId()
+    graphLog(Severity::Info) << "OpExtInst result=%" << resultId << ',' << debugName << ", input=%" << inputId.AsId()
                              << ", multiples=" << multiples << std::endl;
 
     graphPipeline.makeTile(getTensor(inputId), getTensor(*opExtInst), debugName);
@@ -1013,7 +1013,7 @@ void GraphPassTosaSpv100::handleTranspose(const Instruction *opExtInst, const st
     const auto &perms = getConstVector(opExtInst->GetInOperand(2));
     const auto &inputId = opExtInst->GetInOperand(3);
 
-    graphLog(Severity::Info) << "OpExtInst result=%" << resultId << "," << debugName << ", perms=" << perms
+    graphLog(Severity::Info) << "OpExtInst result=%" << resultId << ',' << debugName << ", perms=" << perms
                              << ", input=%" << inputId.AsId() << std::endl;
 
     graphPipeline.makeTranspose(getTensor(inputId), getTensor(*opExtInst), perms, debugName);
@@ -1035,7 +1035,7 @@ void GraphPassTosaSpv100::handleTransposeConv2D(const Instruction *opExtInst, co
     const auto &inputZeroPoint = getConstVector<int8_t>(opExtInst->GetInOperand(9));
     const auto &weightZeroPoint = getConstVector<int8_t>(opExtInst->GetInOperand(10));
 
-    graphLog(Severity::Info) << "OpExtInst result=" << resultId << "," << debugName << " , outPad=" << outPad
+    graphLog(Severity::Info) << "OpExtInst result=" << resultId << ',' << debugName << " , outPad=" << outPad
                              << ", stride=" << stride << ", accType=" << accType << ", localBound=" << localBound
                              << ", input=%" << inputId.AsId() << ", weight=%" << weightId.AsId() << ", bias=%"
                              << biasId.AsId() << ", inputZeroPoint=" << inputZeroPoint

--- a/graph/tensor.cpp
+++ b/graph/tensor.cpp
@@ -87,7 +87,7 @@ std::shared_ptr<Tensor> TensorDescriptor::makeTensor(const std::shared_ptr<Tenso
 
     auto tensor = std::make_shared<Tensor>(_this->loader, _this->device, _this, tensorARM, tensorViewARM);
 
-    graphLog(Severity::Debug) << "Create tensor. tensor=" << tensor << " " << *tensor << std::endl;
+    graphLog(Severity::Debug) << "Create tensor. tensor=" << tensor << ' ' << *tensor << std::endl;
 
     return tensor;
 }
@@ -327,7 +327,7 @@ VkTensorViewARM TensorDescriptor::createTensorViewARM(const VkTensorARM tensor, 
 }
 
 Log &operator<<(Log &os, const Tensor &tensor) {
-    return os << "tensorARM=" << tensor.getVkTensorARM() << " " << *tensor.getTensorDescriptor();
+    return os << "tensorARM=" << tensor.getVkTensorARM() << ' ' << *tensor.getTensorDescriptor();
 }
 
 Log &operator<<(Log &os, const TensorDescriptor &tensor) {

--- a/tensor/CMakeLists.txt
+++ b/tensor/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright 2023-2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-FileCopyrightText: Copyright 2023-2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -23,6 +23,15 @@ target_link_libraries(VkLayer_Tensor PRIVATE
     VkLayer_Common
     spirv-cross-core
     spirv-cross-glsl)
+
+set(TENSOR_VERSION_HEADER "${CMAKE_CURRENT_BINARY_DIR}/generated/version.hpp")
+mlsdk_generate_version_header(
+    TARGET VkLayer_Tensor
+    SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/../common/version.hpp.in"
+    DESTINATION "${TENSOR_VERSION_HEADER}"
+    DEPENDENCIES
+        ${VMEL_VERSION_DEPS}
+)
 
 install(TARGETS VkLayer_Tensor EXPORT ${ML_SDK_EL_PACKAGE_NAME}Config)
 

--- a/tensor/tensor_layer.cpp
+++ b/tensor/tensor_layer.cpp
@@ -10,12 +10,13 @@
 
 #include "mlel/vulkan_layer.hpp"
 
-#include "tensor_log.hpp"
-
 #include "descriptor_binding.hpp"
 #include "tensor_arm.hpp"
+#include "tensor_log.hpp"
 #include "tensor_processor.hpp"
 #include "tensor_view.hpp"
+#include "version.hpp"
+
 #include <limits>
 #include <memory>
 #include <variant>
@@ -987,6 +988,8 @@ vkNegotiateLoaderLayerInterfaceVersion(VkNegotiateLayerInterface *pNegotiateLaye
     if (pNegotiateLayerInterface->loaderLayerInterfaceVersion < 2) {
         return VK_ERROR_INITIALIZATION_FAILED;
     }
+
+    tensorLog(Severity::Info) << mlsdk::el::details::version << std::endl;
 
     pNegotiateLayerInterface->loaderLayerInterfaceVersion = 2;
     pNegotiateLayerInterface->pfnGetInstanceProcAddr = TensorLayer::vkGetInstanceProcAddr;

--- a/tests/common_tests.cpp
+++ b/tests/common_tests.cpp
@@ -50,8 +50,8 @@ TEST(MLEmulationLayerLog, Vectors) {
     const std::vector<std::string> strVector{"Hello", "World", "!"};
     const std::vector<int> intVector{1, 2, 3, 4, 5};
 
-    testLog(Severity::Error) << strVector << "\n";
-    testLog(Severity::Error) << intVector << "\n";
+    testLog(Severity::Error) << strVector << '\n';
+    testLog(Severity::Error) << intVector << '\n';
 }
 
 TEST(MLEmulationLayerLog, LineNumbers) {

--- a/utilities/pipeline.cpp
+++ b/utilities/pipeline.cpp
@@ -44,7 +44,7 @@ void GraphPipelineConstantTensor::print() const {
             std::cout << std::endl << std::setw(8) << i << ": ";
         }
 
-        std::cout << std::setw(2) << static_cast<unsigned>(_data[i]) << " ";
+        std::cout << std::setw(2) << static_cast<unsigned>(_data[i]) << ' ';
     }
 
     std::cout << std::endl;
@@ -375,7 +375,7 @@ void GraphPipeline::printGraphPipelineSessionMemory() const {
                 std::cout << std::endl << std::setw(8) << i << ": ";
             }
 
-            std::cout << std::setw(2) << static_cast<unsigned>(p[i]) << " ";
+            std::cout << std::setw(2) << static_cast<unsigned>(p[i]) << ' ';
         }
 
         std::cout << std::endl;

--- a/utilities/tensor.cpp
+++ b/utilities/tensor.cpp
@@ -146,7 +146,7 @@ void Tensor::print() const {
             std::cout << std::endl << std::setw(8) << i << ": ";
         }
 
-        std::cout << std::setw(2) << static_cast<unsigned>(p[i]) << " ";
+        std::cout << std::setw(2) << static_cast<unsigned>(p[i]) << ' ';
     }
 
     std::cout << std::endl;


### PR DESCRIPTION
- Log version information at layer initialization.
- Add version information to SPIRV-Cross dependency.
- Improve logging Use char for single character literals. Use string_view to avoid string copies.

Change-Id: Ia239bf3699a28d794883ac243647bd739c2e2609