### PR TITLE
Make libs static

### DIFF
--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright 2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-FileCopyrightText: Copyright 2024,2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -75,5 +75,5 @@ function(mlsdk_generate_version_header)
     configure_file("${ARGS_SOURCE}" "${ARGS_DESTINATION}")
     get_filename_component(GEN_DIR_PATH "${ARGS_DESTINATION}" DIRECTORY)
 
-    target_include_directories(${ARGS_TARGET} PRIVATE "${GEN_DIR_PATH}")
+    target_include_directories(${ARGS_TARGET} PUBLIC "${GEN_DIR_PATH}")
 endfunction()

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -3,47 +3,44 @@
 #
 
 ###############################################################################
-# Logger
-###############################################################################
-
-add_library(VkLayer_Log INTERFACE)
-
-target_sources(VkLayer_Log INTERFACE
-    log.cpp)
-
-target_include_directories(VkLayer_Log INTERFACE
-    include)
-
-###############################################################################
 # Common
 ###############################################################################
 
-add_library(VkLayer_Common INTERFACE)
+add_library(VkLayer_Common STATIC)
 
-target_compile_options(VkLayer_Common INTERFACE ${VMEL_COMPILE_OPTIONS})
+target_compile_options(VkLayer_Common PUBLIC ${VMEL_COMPILE_OPTIONS})
 
 if(VMEL_USE_FLOAT_AS_DOUBLE)
-    target_compile_definitions(VkLayer_Common INTERFACE USE_FLOAT_AS_DOUBLE)
-    target_compile_definitions(VkLayer_Common INTERFACE real_t=float)
+    target_compile_definitions(VkLayer_Common PUBLIC USE_FLOAT_AS_DOUBLE)
+    target_compile_definitions(VkLayer_Common PUBLIC real_t=float)
 else()
-    target_compile_definitions(VkLayer_Common INTERFACE real_t=double)
+    target_compile_definitions(VkLayer_Common PUBLIC real_t=double)
 endif()
 
-target_include_directories(VkLayer_Common INTERFACE
+target_include_directories(VkLayer_Common PUBLIC
     include)
 
-target_include_directories(VkLayer_Common SYSTEM INTERFACE
+target_include_directories(VkLayer_Common SYSTEM PUBLIC
     ${SPIRV_TOOLS_PATH}
     ${spirv-tools_BINARY_DIR})
 
-target_sources(VkLayer_Common INTERFACE
+target_sources(VkLayer_Common PRIVATE
+    log.cpp
     utils.cpp)
 
-target_link_libraries(VkLayer_Common INTERFACE
-    VkLayer_Log
+target_link_libraries(VkLayer_Common PUBLIC
     Vulkan::Headers
     SPIRV-Tools
     SPIRV-Tools-opt
     glslang::glslang
     glslang::glslang-default-resource-limits
     glslang::SPIRV)
+
+set(COMMON_VERSION_HEADER "${CMAKE_CURRENT_BINARY_DIR}/generated/version.hpp")
+mlsdk_generate_version_header(
+    TARGET VkLayer_Common
+    SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/version.hpp.in"
+    DESTINATION "${COMMON_VERSION_HEADER}"
+    DEPENDENCIES
+        ${VMEL_VERSION_DEPS}
+)

--- a/graph/CMakeLists.txt
+++ b/graph/CMakeLists.txt
@@ -44,15 +44,6 @@ target_link_libraries(VkLayer_Graph PRIVATE
 target_include_directories(VkLayer_Graph PRIVATE
     ${CMAKE_CURRENT_BINARY_DIR})
 
-set(GRAPH_VERSION_HEADER "${CMAKE_CURRENT_BINARY_DIR}/generated/version.hpp")
-mlsdk_generate_version_header(
-    TARGET VkLayer_Graph
-    SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/../common/version.hpp.in"
-    DESTINATION "${GRAPH_VERSION_HEADER}"
-    DEPENDENCIES
-        ${VMEL_VERSION_DEPS}
-)
-
 install(TARGETS VkLayer_Graph EXPORT ${ML_SDK_EL_PACKAGE_NAME}Config)
 
 # Generate VkLayer_Graph.json

--- a/tensor/CMakeLists.txt
+++ b/tensor/CMakeLists.txt
@@ -24,15 +24,6 @@ target_link_libraries(VkLayer_Tensor PRIVATE
     spirv-cross-core
     spirv-cross-glsl)
 
-set(TENSOR_VERSION_HEADER "${CMAKE_CURRENT_BINARY_DIR}/generated/version.hpp")
-mlsdk_generate_version_header(
-    TARGET VkLayer_Tensor
-    SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/../common/version.hpp.in"
-    DESTINATION "${TENSOR_VERSION_HEADER}"
-    DEPENDENCIES
-        ${VMEL_VERSION_DEPS}
-)
-
 install(TARGETS VkLayer_Tensor EXPORT ${ML_SDK_EL_PACKAGE_NAME}Config)
 
 # Generate VkLayer_Tensor.json

--- a/utilities/CMakeLists.txt
+++ b/utilities/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright 2023-2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-FileCopyrightText: Copyright 2023-2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -8,6 +8,8 @@
 
 add_library(mlelutilities STATIC)
 
+target_compile_options(mlelutilities PUBLIC ${VMEL_COMPILE_OPTIONS})
+
 target_sources(mlelutilities PRIVATE
     device.cpp
     pipeline.cpp
@@ -16,7 +18,7 @@ target_sources(mlelutilities PRIVATE
 target_include_directories(mlelutilities PUBLIC include)
 
 target_link_libraries(mlelutilities PUBLIC
-    VkLayer_Log
+    VkLayer_Common
     Vulkan::Headers
     SPIRV-Tools
     glslang::glslang

--- a/utilities/device.cpp
+++ b/utilities/device.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2023-2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2023-2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
  * SPDX-License-Identifier: Apache-2.0
  *
  */
@@ -49,8 +49,8 @@ vk::raii::Instance Instance::createInstance(const std::vector<const char *> &lay
         exts.data(),                          // enabled extensions
     };
 
-    vk::raii::Instance instance(*context, instanceCreateInfo);
-    return instance;
+    vk::raii::Instance vkInstance(*context, instanceCreateInfo);
+    return vkInstance;
 }
 
 /*******************************************************************************
@@ -130,9 +130,9 @@ std::vector<uint32_t> PhysicalDevice::getMemoryTypeIndices(const vk::MemoryPrope
     return memoryTypeIndices;
 }
 
-bool PhysicalDevice::hasExtensionProperties(const vk::raii::PhysicalDevice &physicalDevice,
+bool PhysicalDevice::hasExtensionProperties(const vk::raii::PhysicalDevice &vkPhysicalDevice,
                                             const std::vector<const char *> &extensions) const {
-    const auto extensionProperties = physicalDevice.enumerateDeviceExtensionProperties();
+    const auto extensionProperties = vkPhysicalDevice.enumerateDeviceExtensionProperties();
 
     for (const auto &extension : extensions) {
         auto it = std::find_if(extensionProperties.begin(), extensionProperties.end(), [&](const auto &property) {
@@ -169,7 +169,7 @@ vk::raii::PhysicalDevice PhysicalDevice::createPhysicalDevice(const std::vector<
         physicalDevices.push_back(currentPhysicalDevice);
     }
 
-    std::sort(physicalDevices.begin(), physicalDevices.end(), [this](const auto &left, const auto &right) {
+    std::sort(physicalDevices.begin(), physicalDevices.end(), [](const auto &left, const auto &right) {
         // Select discrete GPU
         if (left.getProperties().deviceType != right.getProperties().deviceType) {
             std::map<vk::PhysicalDeviceType, int> priority = {
@@ -270,9 +270,9 @@ vk::raii::Device Device::createDevice(const std::vector<const char *> &layers,
         nullptr,                                       // Don't set pEnabledFeatures here!
         deviceFeatures                                 // Attach deviceFeatures via pNext
     };
-    vk::raii::Device device(&(*physicalDevice), deviceCreateInfo);
+    vk::raii::Device vkDevice(&(*physicalDevice), deviceCreateInfo);
 
-    return device;
+    return vkDevice;
 }
 
 } // namespace mlsdk::el::utilities

--- a/utilities/include/mlel/device.hpp
+++ b/utilities/include/mlel/device.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2023-2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2023-2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
  * SPDX-License-Identifier: Apache-2.0
  *
  */
@@ -51,7 +51,7 @@ class PhysicalDevice {
                                                uint32_t memoryTypeBits = 0xffffffff) const;
 
   private:
-    bool hasExtensionProperties(const vk::raii::PhysicalDevice &physicalDevice,
+    bool hasExtensionProperties(const vk::raii::PhysicalDevice &vkPhysicalDevice,
                                 const std::vector<const char *> &extensions) const;
 
     std::vector<vk::raii::PhysicalDevice> enumeratePhysicalDevices() const;

--- a/utilities/include/mlel/pipeline.hpp
+++ b/utilities/include/mlel/pipeline.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2023-2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2023-2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
  * SPDX-License-Identifier: Apache-2.0
  *
  */
@@ -56,7 +56,7 @@ class GraphConstants {
 
     std::vector<vk::DataGraphPipelineConstantARM> getGraphPipelineConstants() const;
     const std::map<uint32_t, std::shared_ptr<GraphPipelineConstantTensor>> &operator&() const;
-    GraphPipelineConstantTensor &operator[](size_t size);
+    GraphPipelineConstantTensor &operator[](uint32_t id);
 
   private:
     std::map<uint32_t, std::shared_ptr<GraphPipelineConstantTensor>> constants;

--- a/utilities/pipeline.cpp
+++ b/utilities/pipeline.cpp
@@ -90,7 +90,7 @@ const std::map<uint32_t, std::shared_ptr<GraphPipelineConstantTensor>> &GraphCon
     return constants;
 }
 
-GraphPipelineConstantTensor &GraphConstants::operator[](size_t size) { return *constants[size]; }
+GraphPipelineConstantTensor &GraphConstants::operator[](uint32_t id) { return *constants[id]; }
 
 /*******************************************************************************
  * PipelineBase
@@ -177,7 +177,7 @@ vk::raii::DescriptorPool PipelineBase::createDescriptorPool() const {
 }
 
 std::vector<vk::raii::DescriptorSetLayout> PipelineBase::createDescriptorSetLayouts() const {
-    std::vector<vk::raii::DescriptorSetLayout> descriptorSetLayouts;
+    std::vector<vk::raii::DescriptorSetLayout> vkDescriptorSetLayouts;
 
     for (const auto &bindingMap : descriptorMap) {
         std::vector<vk::DescriptorSetLayoutBinding> descriptorSetLayoutBindings;
@@ -207,21 +207,21 @@ std::vector<vk::raii::DescriptorSetLayout> PipelineBase::createDescriptorSetLayo
             &descriptorSetBindingFlagsCreateInfo,                        // next
         };
 
-        descriptorSetLayouts.push_back(vk::raii::DescriptorSetLayout(&(*device), descriptorSetLayoutCreateInfo));
+        vkDescriptorSetLayouts.push_back(vk::raii::DescriptorSetLayout(&(*device), descriptorSetLayoutCreateInfo));
     }
 
-    return descriptorSetLayouts;
+    return vkDescriptorSetLayouts;
 }
 
 PipelineBase::PoolAndSet PipelineBase::createDescriptorSets(const DescriptorMap &_descriptorMap) const {
-    auto descriptorPool = createDescriptorPool();
+    auto vkDescriptorPool = createDescriptorPool();
 
     std::vector<vk::DescriptorSetLayout> vkDescriptorSetLayouts;
     std::transform(descriptorSetLayouts.begin(), descriptorSetLayouts.end(), std::back_inserter(vkDescriptorSetLayouts),
                    [](const auto &layout) { return *layout; });
 
     const vk::DescriptorSetAllocateInfo descriptorSetAllocateInfo{
-        descriptorPool,                          // descriptor pool
+        vkDescriptorPool,                        // descriptor pool
         uint32_t(vkDescriptorSetLayouts.size()), // descriptor set layout count
         vkDescriptorSetLayouts.data()            // descriptor set layouts
     };
@@ -230,7 +230,7 @@ PipelineBase::PoolAndSet PipelineBase::createDescriptorSets(const DescriptorMap 
 
     updateDescriptorSet(descriptorSets, _descriptorMap);
 
-    return {std::move(descriptorPool), std::move(descriptorSets)};
+    return {std::move(vkDescriptorPool), std::move(descriptorSets)};
 }
 
 std::shared_ptr<vk::raii::PipelineLayout> PipelineBase::createPipelineLayout() const {
@@ -316,7 +316,7 @@ void GraphPipeline::dispatch(const vk::raii::CommandBuffer &commandBuffer,
 }
 
 void GraphPipeline::dispatchSubmit() {
-    auto [descriptorPool, descriptorSets] = createDescriptorSets(descriptorMap);
+    [[maybe_unused]] auto [_, descriptorSets] = createDescriptorSets(descriptorMap);
 
     auto commandBuffer = createCommandBuffer();
 
@@ -340,7 +340,7 @@ void GraphPipeline::dispatchUpdateSubmit() {
 
     commandBuffer.begin(commandBufferBeginInfo);
 
-    auto [descriptorPool, descriptorSets] = createDescriptorSets(descriptorMap);
+    [[maybe_unused]] auto [_, descriptorSets] = createDescriptorSets(descriptorMap);
     dispatch(commandBuffer, descriptorSets);
 
     // Update just one of them to prove the point
@@ -506,7 +506,7 @@ TensorComputePipeline::TensorComputePipeline(std::shared_ptr<Device> &_device, c
     : PipelineBase(_device, _descriptorMap, _spirv), pipeline{createPipeline()} {}
 
 void TensorComputePipeline::dispatchSubmit(uint32_t _x, uint32_t _y, uint32_t _z) {
-    auto [descriptorPool, descriptorSets] = createDescriptorSets(descriptorMap);
+    [[maybe_unused]] auto [_, descriptorSets] = createDescriptorSets(descriptorMap);
 
     auto commandBuffer = createCommandBuffer();
 

--- a/utilities/tensor.cpp
+++ b/utilities/tensor.cpp
@@ -28,7 +28,7 @@ const std::vector<int64_t> &Shape::getDimensions() const { return dimensions; }
 
 const std::vector<int64_t> &Shape::getStrides() const { return strides; };
 
-size_t Shape::getSize() const { return dimensions[0] * strides[0]; }
+size_t Shape::getSize() const { return static_cast<size_t>(dimensions[0] * strides[0]); }
 
 size_t Shape::elementCount() const { return utils::getElementCount(dimensions); }
 
@@ -36,10 +36,12 @@ size_t Shape::getElementOffset(size_t index) const {
     std::vector<size_t> coordinates(dimensions.size());
     size_t byteOffset = 0;
 
-    for (int i = dimensions.size() - 1; i >= 0; i--) {
-        coordinates[i] = index % dimensions[i];
-        index /= dimensions[i];
-        byteOffset += coordinates[i] * strides[i];
+    for (auto it = dimensions.rbegin(); it != dimensions.rend(); ++it) {
+        const auto i = static_cast<size_t>(it - dimensions.rbegin());
+        const auto dimension = static_cast<size_t>(dimensions[i]);
+        coordinates[i] = index % dimension;
+        index /= dimension;
+        byteOffset += static_cast<size_t>(coordinates[i]) * static_cast<size_t>(strides[i]);
     }
 
     return byteOffset;
@@ -52,17 +54,17 @@ std::vector<int64_t> Shape::createStrides(const std::vector<int64_t> &_strides) 
         }
         throw std::runtime_error("Stride size should be equal to dimension size.");
     }
-    std::vector<int64_t> strides;
-    strides.resize(dimensions.size());
+    std::vector<int64_t> result;
+    result.resize(dimensions.size());
 
-    if (!strides.empty()) {
-        strides.back() = getFormatSize();
-        for (size_t i = strides.size() - 1; i > 0; i--) {
-            strides[i - 1] = strides[i] * dimensions[i];
+    if (!result.empty()) {
+        result.back() = static_cast<int64_t>(getFormatSize());
+        for (size_t i = result.size() - 1; i > 0; i--) {
+            result[i - 1] = result[i] * dimensions[i];
         }
     }
 
-    return strides;
+    return result;
 }
 
 size_t Shape::getFormatSize() const { return vk::blockSize(format); }
@@ -155,7 +157,7 @@ void Tensor::print() const {
 
 vk::raii::TensorARM Tensor::createTensor(bool useForCopy) const {
     const auto flags = useForCopy ? vk::TensorUsageFlagBitsARM::eShader : vk::TensorUsageFlagsARM{};
-    const vk::TensorDescriptionARM tensorDescription{
+    const vk::TensorDescriptionARM vkTensorDescription{
         vk::TensorTilingARM::eLinear,           // tiling
         shape.getFormat(),                      // format
         uint32_t(shape.getDimensions().size()), // dimensions count
@@ -166,7 +168,7 @@ vk::raii::TensorARM Tensor::createTensor(bool useForCopy) const {
 
     const vk::TensorCreateInfoARM tensorCreateInfo{
         {},                          // flags
-        &tensorDescription,          // tensor description
+        &vkTensorDescription,        // tensor description
         vk::SharingMode::eExclusive, // sharing mode
         0,                           // queue family index count
     };
@@ -183,9 +185,9 @@ vk::MemoryRequirements Tensor::getTensorMemoryRequirements() const {
     const vk::TensorMemoryRequirementsInfoARM requirementsInfo{
         *tensor,
     };
-    vk::MemoryRequirements2 memoryRequirements = (&(*device)).getTensorMemoryRequirementsARM(requirementsInfo);
+    vk::MemoryRequirements2 vkMemoryRequirements = (&(*device)).getTensorMemoryRequirementsARM(requirementsInfo);
 
-    return memoryRequirements.memoryRequirements;
+    return vkMemoryRequirements.memoryRequirements;
 }
 
 void *Tensor::bindAndMapTensor() const {
@@ -195,9 +197,9 @@ void *Tensor::bindAndMapTensor() const {
         {}              // memory offset
     };
     (&(*device)).bindTensorMemoryARM(bindInfo);
-    void *pointer = deviceMemory->mapMemory({}, VK_WHOLE_SIZE, {});
+    void *ptr = deviceMemory->mapMemory({}, VK_WHOLE_SIZE, {});
 
-    return pointer;
+    return ptr;
 }
 
 vk::raii::TensorViewARM Tensor::createTensorView() const {
@@ -206,13 +208,13 @@ vk::raii::TensorViewARM Tensor::createTensorView() const {
         *tensor,           // tensor
         shape.getFormat(), // format
     };
-    vk::raii::TensorViewARM tensorView{&(*device), tensorViewCreateInfo};
+    vk::raii::TensorViewARM vkTensorView{&(*device), tensorViewCreateInfo};
 
-    return tensorView;
+    return vkTensorView;
 }
 
 vk::TensorDescriptionARM Tensor::createTensorDescription() const {
-    vk::TensorDescriptionARM tensorDescription{
+    vk::TensorDescriptionARM vkTensorDescription{
         vk::TensorTilingARM::eLinear,                        // tiling
         shape.getFormat(),                                   // format
         static_cast<uint32_t>(shape.getDimensions().size()), // dimension count
@@ -221,7 +223,7 @@ vk::TensorDescriptionARM Tensor::createTensorDescription() const {
         vk::TensorUsageFlagBitsARM::eDataGraph               // usage
     };
 
-    return tensorDescription;
+    return vkTensorDescription;
 }
 
 } // namespace mlsdk::el::utilities


### PR DESCRIPTION
- Common source files in the emulation layer are now compiled into a static library, instead of interface libraries. This simplifies the build process by only building each file once.
- Fix code issues related to previously missing compile options.
- Rename variables to avoid shadowing of members.

Change-Id: I418d5354ea025b867024388845264c2cd21ca1c4