### PR TITLE
Handle specialization constants in graph lowering

### DIFF
--- a/graph/graph_layer.cpp
+++ b/graph/graph_layer.cpp
@@ -25,8 +25,10 @@
 
 #include <chrono>
 #include <cstdlib>
+#include <cstring>
 #include <optional>
 #include <string_view>
+#include <unordered_map>
 
 using namespace mlsdk::el::compute;
 using namespace mlsdk::el::compute::graph_op;
@@ -56,6 +58,44 @@ bool hasVersionPrefix(std::string_view name, std::string_view prefix, size_t dig
     }
 
     return name[prefix.size() + digitCount] == '.' && isDigit(name[prefix.size() + digitCount + 1]);
+}
+
+std::unordered_map<uint32_t, std::vector<uint32_t>>
+makeSpecConstantDefaultValues(const VkSpecializationInfo &specializationInfo) {
+    std::unordered_map<uint32_t, std::vector<uint32_t>> values;
+    values.reserve(specializationInfo.mapEntryCount);
+
+    for (uint32_t i = 0; i < specializationInfo.mapEntryCount; i++) {
+        const auto &entry = specializationInfo.pMapEntries[i];
+
+        if (entry.size == 0) {
+            values.emplace(entry.constantID, std::vector<uint32_t>{});
+            continue;
+        }
+
+        const auto wordCount = static_cast<size_t>((entry.size + sizeof(uint32_t) - 1) / sizeof(uint32_t));
+        std::vector<uint32_t> words(wordCount, 0u);
+        std::memcpy(words.data(), static_cast<const char *>(specializationInfo.pData) + entry.offset, entry.size);
+
+        values.emplace(entry.constantID, std::move(words));
+    }
+
+    return values;
+}
+
+void registerSpecConstantDefaultPasses(spvtools::Optimizer &optimizer, const VkSpecializationInfo *specializationInfo) {
+    if (specializationInfo == nullptr) {
+        return;
+    }
+
+    const auto specConstantDefaultValues = makeSpecConstantDefaultValues(*specializationInfo);
+    if (specConstantDefaultValues.empty()) {
+        return;
+    }
+
+    optimizer.RegisterPass(spvtools::CreateSetSpecConstantDefaultValuePass(specConstantDefaultValues));
+    optimizer.RegisterPass(spvtools::CreateFreezeSpecConstantValuePass());
+    optimizer.RegisterPass(spvtools::CreateFoldSpecConstantOpAndCompositePass());
 }
 } // namespace
 
@@ -701,6 +741,8 @@ class GraphLayer : public VulkanLayerImpl {
                 spvtools::Optimizer optimizer{SPV_ENV_UNIVERSAL_1_6};
 
                 // Register passes
+                registerSpecConstantDefaultPasses(optimizer,
+                                                  dataGraphPipelineShaderModuleCreateInfo->pSpecializationInfo);
                 optimizer.RegisterPass(spvtools::CreateGraphPass<spvtools::opt::GraphPassTosaSpv100>(*graphPipeline));
 
                 // Run passes

--- a/graph/spirv_pass.cpp
+++ b/graph/spirv_pass.cpp
@@ -436,8 +436,24 @@ VkFormat GraphPassBase::getVkFormat(const analysis::Type *type) const {
 }
 
 bool GraphPassBase::getBoolConstant(const Operand &operand) {
-    const auto *constant = context()->get_constant_mgr()->FindDeclaredConstant(operand.AsId());
-    return constant->AsBoolConstant()->value();
+    const auto id = operand.AsId();
+    const auto *constant = context()->get_constant_mgr()->FindDeclaredConstant(id);
+    if (constant == nullptr) {
+        const auto *instruction = get_def_use_mgr()->GetDef(id);
+        const auto opcode = instruction == nullptr ? std::string{"unknown"}
+                                                   : std::to_string(static_cast<uint32_t>(instruction->opcode()));
+        throw std::runtime_error("Expected boolean constant for id %" + std::to_string(id) + ", found opcode " +
+                                 opcode);
+    }
+
+    const auto *boolConstant = constant->AsBoolConstant();
+    if (boolConstant == nullptr) {
+        throw std::runtime_error("Expected boolean constant for id %" + std::to_string(id) +
+                                 ", found constant type kind " +
+                                 std::to_string(static_cast<uint32_t>(constant->type()->kind())));
+    }
+
+    return boolConstant->value();
 }
 
 // Disabled until needed

--- a/tests/shader/arshift_specbool.spvasm
+++ b/tests/shader/arshift_specbool.spvasm
@@ -1,0 +1,53 @@
+;
+; SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates
+; SPDX-License-Identifier: Apache-2.0
+;
+               OpCapability GraphARM
+               OpCapability TensorsARM
+               OpCapability Shader
+               OpCapability VulkanMemoryModel
+               OpCapability Int16
+               OpExtension "SPV_ARM_graph"
+               OpExtension "SPV_ARM_tensors"
+               OpExtension "SPV_KHR_vulkan_memory_model"
+         %20 = OpExtInstImport "TOSA.001000.1"
+               OpMemoryModel Logical Vulkan
+               OpName %in0 "in0"
+               OpName %in1 "in1"
+               OpName %out0 "out0"
+               OpName %main "spec_arshift"
+               OpDecorate %in0 Binding 0
+               OpDecorate %in0 DescriptorSet 0
+               OpDecorate %in1 Binding 1
+               OpDecorate %in1 DescriptorSet 0
+               OpDecorate %out0 Binding 2
+               OpDecorate %out0 DescriptorSet 0
+               OpDecorate %roundc SpecId 0
+; types
+     %uint = OpTypeInt 32 0
+    %boolt = OpTypeBool
+   %int16t = OpTypeInt 16 1
+   %uint16t = OpTypeInt 16 0
+   %uint_1 = OpConstant %uint 1
+   %uint_4 = OpConstant %uint 4
+%arr_u1_u = OpTypeArray %uint %uint_1
+    %dims = OpConstantComposite %arr_u1_u %uint_4
+   %tensor = OpTypeTensorARM %uint16t %uint_1 %dims
+%ptr_uc_ts = OpTypePointer UniformConstant %tensor
+; specialization bool controlling rounding
+   %roundc = OpSpecConstantFalse %boolt
+; variables
+       %in0 = OpVariable %ptr_uc_ts UniformConstant
+       %in1 = OpVariable %ptr_uc_ts UniformConstant
+       %out0 = OpVariable %ptr_uc_ts UniformConstant
+; graph
+  %graph_t = OpTypeGraphARM 2 %tensor %tensor %tensor
+  %uint_0  = OpConstant %uint 0
+  %uint_1x = OpConstant %uint 1
+               OpGraphEntryPointARM %main "spec_arshift" %in0 %in1 %out0
+       %main = OpGraphARM %graph_t
+        %g0 = OpGraphInputARM %tensor %uint_0
+        %g1 = OpGraphInputARM %tensor %uint_1x
+        %r0 = OpExtInst %tensor %20 ARITHMETIC_RIGHT_SHIFT %roundc %g0 %g1
+               OpGraphSetOutputARM %r0 %uint_0
+               OpGraphEndARM

--- a/tests/vulkan.cpp
+++ b/tests/vulkan.cpp
@@ -1913,6 +1913,139 @@ TEST_F(MLEmulationLayerForVulkan, PipelineCreationFeedback) {
     ASSERT_GT(creationFeedback.duration, 0);
 }
 
+TEST_F(MLEmulationLayerForVulkan, SpecConstBoolDoesNotBlockLowering) {
+    auto device = createDevice();
+
+    constexpr vk::Format kTensorFormat = vk::Format::eR16Uint;
+    constexpr int64_t kTensorLength = 4;
+    constexpr uint32_t kBindingInput = 0u;
+    constexpr uint32_t kBindingShift = 1u;
+    constexpr uint32_t kBindingOutput = 2u;
+    constexpr uint32_t kSpecIdRound = 0u;
+
+    // Create three tensors: 1D R16Sint of length 4 for inputs and output
+    auto inputTensor = std::make_shared<Tensor>(device, Shape{kTensorFormat, std::vector<int64_t>{kTensorLength}});
+    auto shiftTensor = std::make_shared<Tensor>(device, Shape{kTensorFormat, std::vector<int64_t>{kTensorLength}});
+    auto outputTensor = std::make_shared<Tensor>(device, Shape{kTensorFormat, std::vector<int64_t>{kTensorLength}});
+
+    const GraphPipeline::DescriptorMap descriptorMap = {{
+        {kBindingInput, {inputTensor}},
+        {kBindingShift, {shiftTensor}},
+        {kBindingOutput, {outputTensor}},
+    }};
+
+    const auto spirv = assembleSpirv(fileToString("arshift_specbool.spvasm"));
+
+    // Build resource infos for pipeline creation
+    std::vector<vk::DataGraphPipelineResourceInfoARM> graphPipelineResourceInfos;
+    constexpr size_t kResourceInfoCapacity = 3u; // input, shift, output
+    graphPipelineResourceInfos.reserve(kResourceInfoCapacity);
+    uint32_t set = 0;
+    for (const auto &bindingMap : descriptorMap) {
+        for (const auto &[binding, tensors] : bindingMap) {
+            for (uint32_t i = 0; i < tensors.size(); i++) {
+                graphPipelineResourceInfos.push_back(vk::DataGraphPipelineResourceInfoARM{
+                    set,                                // descriptor set
+                    binding,                            // binding
+                    i,                                  // array element
+                    &tensors[i]->getTensorDescription() // next
+                });
+            }
+        }
+        set++;
+    }
+
+    // Shader module
+    const vk::ShaderModuleCreateInfo info{
+        {},                                                     // flags
+        static_cast<uint32_t>(spirv.size() * sizeof(uint32_t)), // code size
+        spirv.data()                                            // code
+    };
+    vk::raii::ShaderModule shaderModule{&(*device), info};
+
+    // Descriptor set layouts
+    std::vector<vk::raii::DescriptorSetLayout> descriptorSetLayouts;
+    descriptorSetLayouts.reserve(descriptorMap.size());
+    for (const auto &bindingMap : descriptorMap) {
+        std::vector<vk::DescriptorSetLayoutBinding> descriptorSetLayoutBindings;
+        descriptorSetLayoutBindings.reserve(bindingMap.size());
+        for (const auto &[binding, tensors] : bindingMap) {
+            descriptorSetLayoutBindings.push_back(vk::DescriptorSetLayoutBinding{
+                binding,                        // binding
+                vk::DescriptorType::eTensorARM, // descriptor type
+                uint32_t(tensors.size()),       // descriptor count
+                vk::ShaderStageFlagBits::eAll,  // stage flags
+            });
+        }
+
+        std::vector<vk::DescriptorBindingFlags> descriptorBindingFlags(descriptorSetLayoutBindings.size(),
+                                                                       vk::DescriptorBindingFlagBits::eUpdateAfterBind);
+
+        const vk::DescriptorSetLayoutBindingFlagsCreateInfo descriptorSetBindingFlagsCreateInfo{
+            static_cast<uint32_t>(descriptorBindingFlags.size()), // binding count
+            descriptorBindingFlags.data(),                        // binding flags
+        };
+
+        const vk::DescriptorSetLayoutCreateInfo descriptorSetLayoutCreateInfo{
+            vk::DescriptorSetLayoutCreateFlagBits::eUpdateAfterBindPool, // flags
+            static_cast<uint32_t>(descriptorSetLayoutBindings.size()),   // binding count
+            descriptorSetLayoutBindings.data(),                          // bindings
+            &descriptorSetBindingFlagsCreateInfo,                        // next
+        };
+
+        descriptorSetLayouts.push_back(vk::raii::DescriptorSetLayout(&(*device), descriptorSetLayoutCreateInfo));
+    }
+
+    std::vector<vk::DescriptorSetLayout> vkDescriptorSetLayouts;
+    vkDescriptorSetLayouts.reserve(descriptorSetLayouts.size());
+    std::transform(descriptorSetLayouts.begin(), descriptorSetLayouts.end(), std::back_inserter(vkDescriptorSetLayouts),
+                   [](const auto &layout) { return *layout; });
+
+    const vk::PipelineLayoutCreateInfo pipelineLayoutCreateInfo{
+        {},                                                   // flags
+        static_cast<uint32_t>(vkDescriptorSetLayouts.size()), // descriptor set layout count
+        vkDescriptorSetLayouts.data()                         // descriptor set layouts
+    };
+    vk::raii::PipelineLayout pipelineLayout{&(*device), pipelineLayoutCreateInfo};
+
+    // Specialization constant for SpecId 0 (bool round). Vulkan expects 4 bytes for bool specialization.
+    constexpr uint32_t specRoundTrue = 1u;
+    constexpr uint32_t kMapEntryCount = 1u;
+    const vk::SpecializationMapEntry mapEntry{kSpecIdRound, /*offset*/ 0u, /*size*/ sizeof(uint32_t)};
+    const vk::SpecializationInfo specInfo{
+        kMapEntryCount,   // mapEntryCount
+        &mapEntry,        // pMapEntries
+        sizeof(uint32_t), // dataSize
+        &specRoundTrue    // pData
+    };
+
+    vk::PipelineCreationFeedback creationFeedback{};
+    const vk::PipelineCreationFeedbackCreateInfo feedbackCreateInfo{&creationFeedback, 0, nullptr, nullptr};
+
+    const vk::DataGraphPipelineShaderModuleCreateInfoARM shaderModuleCreateInfo{
+        *shaderModule,       // shader module
+        "Graph Pipeline",    // name
+        &specInfo,           // specialization info (non-null to trigger spec-const passes)
+        0,                   // constant count
+        nullptr,             // constants
+        &feedbackCreateInfo, // next
+    };
+
+    const vk::DataGraphPipelineCreateInfoARM graphPipelineCreateInfo{
+        {},                                          // flags
+        *pipelineLayout,                             // pipeline layout
+        uint32_t(graphPipelineResourceInfos.size()), // resource info count
+        graphPipelineResourceInfos.data(),           // resource infos
+        &shaderModuleCreateInfo,                     // next
+    };
+
+    // Creating the pipeline runs our optimizer passes including spec-const defaults and folding
+    vk::raii::Pipeline pipeline{&(*device), nullptr, nullptr, graphPipelineCreateInfo};
+
+    ASSERT_TRUE(creationFeedback.flags & vk::PipelineCreationFeedbackFlagBits::eValid);
+    ASSERT_GT(creationFeedback.duration, 0);
+}
+
 TEST_F(MLEmulationLayerForVulkan, GetDataGraphPipelineAvailablePropertiesARM) {
     const auto device = createDevice();
     const auto &vkDevice = &(*device);


### PR DESCRIPTION
Apply VkSpecializationInfo before TOSA lowering and run SPIR-V passes so that specialized values are visible to our pass. This prevents boolean spec-consts from reaching TOSA operand handling as unresolved and fixes a crash in data-graph CTS specialization-constant cases.