### PR TITLE
Avoid auto-deduced string local in getBoolConstant

### DIFF
--- a/graph/spirv_pass.cpp
+++ b/graph/spirv_pass.cpp
@@ -440,10 +440,10 @@ bool GraphPassBase::getBoolConstant(const Operand &operand) {
     const auto *constant = context()->get_constant_mgr()->FindDeclaredConstant(id);
     if (constant == nullptr) {
         const auto *instruction = get_def_use_mgr()->GetDef(id);
-        const auto opcode = instruction == nullptr ? std::string{"unknown"}
-                                                   : std::to_string(static_cast<uint32_t>(instruction->opcode()));
         throw std::runtime_error("Expected boolean constant for id %" + std::to_string(id) + ", found opcode " +
-                                 opcode);
+                                 (instruction == nullptr
+                                      ? std::string{"unknown"}
+                                      : std::to_string(static_cast<uint32_t>(instruction->opcode()))));
     }
 
     const auto *boolConstant = constant->AsBoolConstant();


### PR DESCRIPTION
Change-Id: Ib6fd107e8a4d71e302cba463e2a2222e9bf3153e