### PR TITLE
Make constant helper result types explicit

### DIFF
--- a/graph/spirv_pass.cpp
+++ b/graph/spirv_pass.cpp
@@ -125,7 +125,7 @@ void GraphPassBase::handleInputsAndOutputs(const Instruction &opGraphEntryPoint)
         const auto resultId = opGraphInputARM->result_id();
 
         // External id from the graph entry point
-        const auto inputIndex = getConstScalar(opGraphInputARM->GetOperand(2));
+        const auto inputIndex = getConstScalar<int64_t>(opGraphInputARM->GetOperand(2));
         const uint32_t arrayIndex =
             opGraphInputARM->NumOperands() > 3 ? getConstScalar<uint32_t>(opGraphInputARM->GetOperand(3)) : 0;
         auto inputTensor = getTensor(inputs[inputIndex], arrayIndex);
@@ -147,7 +147,7 @@ void GraphPassBase::handleInputsAndOutputs(const Instruction &opGraphEntryPoint)
         const auto *instruction = get_def_use_mgr()->GetDef(opGraphSetOutputARM->GetOperand(0).AsId());
 
         // The external tensor id from the graph entry point
-        const auto outputIndex = getConstScalar(opGraphSetOutputARM->GetOperand(1));
+        const auto outputIndex = getConstScalar<int64_t>(opGraphSetOutputARM->GetOperand(1));
         const uint32_t arrayIndex =
             opGraphSetOutputARM->NumOperands() > 2 ? getConstScalar<uint32_t>(opGraphSetOutputARM->GetOperand(2)) : 0;
         auto outputTensor = getTensor(outputs[outputIndex], arrayIndex);

--- a/graph/spirv_pass.hpp
+++ b/graph/spirv_pass.hpp
@@ -66,11 +66,11 @@ class GraphPassBase : public Pass {
     // Temp implementation until debug info is truly available
     std::string extractDebugInfoFromSPV(const Instruction *, const std::string &defaultname) { return defaultname; }
 
-    template <typename T = uint32_t> std::vector<T> getConstVector(const Operand &operand) const {
+    template <typename T> std::vector<T> getConstVector(const Operand &operand) const {
         return getConstVector<T>(operand.AsId());
     }
 
-    template <typename T = uint32_t>
+    template <typename T>
     void getFlattenedCompositeConstant(const spvtools::opt::analysis::CompositeConstant *composite,
                                        std::vector<T> &kernel) const {
         const auto &components = composite->GetComponents();
@@ -108,8 +108,7 @@ class GraphPassBase : public Pass {
         }
     }
 
-    template <typename T = uint32_t>
-    void appendConstantVectorFromInstruction(uint32_t id, std::vector<T> &kernel) const {
+    template <typename T> void appendConstantVectorFromInstruction(uint32_t id, std::vector<T> &kernel) const {
         const auto *instruction = context()->get_def_use_mgr()->GetDef(id);
         if (!instruction) {
             throw std::runtime_error("Missing definition for constant id: " + std::to_string(id));
@@ -143,7 +142,7 @@ class GraphPassBase : public Pass {
         }
     }
 
-    template <typename T = uint32_t> std::vector<T> getTensorConstantVectorFromInstruction(uint32_t id) const {
+    template <typename T> std::vector<T> getTensorConstantVectorFromInstruction(uint32_t id) const {
         const auto *instruction = context()->get_def_use_mgr()->GetDef(id);
         if (!instruction) {
             throw std::runtime_error("Missing definition for constant id: " + std::to_string(id));
@@ -163,7 +162,7 @@ class GraphPassBase : public Pass {
         return kernel;
     }
 
-    template <typename T = uint32_t> std::vector<T> getConstVector(const uint32_t id) const {
+    template <typename T> std::vector<T> getConstVector(const uint32_t id) const {
         const auto *constant = context()->get_constant_mgr()->FindDeclaredConstant(id);
         std::vector<T> kernel;
 
@@ -206,11 +205,11 @@ class GraphPassBase : public Pass {
         return kernel;
     }
 
-    template <typename T = int64_t> T getConstScalar(const Operand &operand) const {
+    template <typename T> T getConstScalar(const Operand &operand) const {
         return getConstScalar<T>(context()->get_constant_mgr()->FindDeclaredConstant(operand.AsId()));
     }
 
-    template <typename T = int64_t> T getConstScalar(const analysis::Constant *constant) const {
+    template <typename T> T getConstScalar(const analysis::Constant *constant) const {
         const auto *intConstant = constant->AsIntConstant();
         if (intConstant) {
             const auto *type = intConstant->type()->AsInteger();

--- a/graph/spirv_pass_tosaspv_v100.cpp
+++ b/graph/spirv_pass_tosaspv_v100.cpp
@@ -876,7 +876,7 @@ void GraphPassTosaSpv100::handleReshape(const Instruction *opExtInst, const std:
 
     const auto &resultId = opExtInst->result_id();
     const auto &inputId = opExtInst->GetInOperand(2);
-    const auto &shape = getConstVector(opExtInst->GetInOperand(3));
+    const auto &shape = getConstVector<uint32_t>(opExtInst->GetInOperand(3));
 
     graphLog(Severity::Info) << "OpExtInst result=%" << resultId << ',' << debugName << ", input=%" << inputId.AsId()
                              << ", shape=" << shape << std::endl;
@@ -968,8 +968,8 @@ void GraphPassTosaSpv100::handleSlice(const Instruction *opExtInst, const std::s
 
     const auto &resultId = opExtInst->result_id();
     const auto &inputId = opExtInst->GetInOperand(2);
-    const auto &start = getConstVector(opExtInst->GetInOperand(3));
-    const auto &size = getConstVector(opExtInst->GetInOperand(4));
+    const auto &start = getConstVector<uint32_t>(opExtInst->GetInOperand(3));
+    const auto &size = getConstVector<uint32_t>(opExtInst->GetInOperand(4));
 
     graphLog(Severity::Info) << "OpExtInst result=%" << resultId << ',' << debugName << " , input=%" << inputId.AsId()
                              << ", start=" << start << ", size=" << size << std::endl;
@@ -997,7 +997,7 @@ void GraphPassTosaSpv100::handleTile(const Instruction *opExtInst, const std::st
 
     const auto &resultId = opExtInst->result_id();
     const auto &inputId = opExtInst->GetInOperand(2);
-    const auto &multiples = getConstVector(opExtInst->GetInOperand(3));
+    const auto &multiples = getConstVector<uint32_t>(opExtInst->GetInOperand(3));
 
     graphLog(Severity::Info) << "OpExtInst result=%" << resultId << ',' << debugName << ", input=%" << inputId.AsId()
                              << ", multiples=" << multiples << std::endl;
@@ -1010,7 +1010,7 @@ void GraphPassTosaSpv100::handleTranspose(const Instruction *opExtInst, const st
     assert(opExtInst->NumInOperands() == 4);
 
     const auto &resultId = opExtInst->result_id();
-    const auto &perms = getConstVector(opExtInst->GetInOperand(2));
+    const auto &perms = getConstVector<uint32_t>(opExtInst->GetInOperand(2));
     const auto &inputId = opExtInst->GetInOperand(3);
 
     graphLog(Severity::Info) << "OpExtInst result=%" << resultId << ',' << debugName << ", perms=" << perms
@@ -1051,12 +1051,12 @@ void GraphPassTosaSpv100::handleMinSad(const Instruction *opExtInst, const std::
     assert(opExtInst->NumInOperands() == 11);
 
     const auto &resultId = opExtInst->result_id();
-    const auto &kernelSizes = getConstVector(opExtInst->GetInOperand(2));
-    const auto &searchWindowSizes = getConstVector(opExtInst->GetInOperand(3));
-    const auto &inputStrides = getConstVector(opExtInst->GetInOperand(4));
-    const auto &windowStrides = getConstVector(opExtInst->GetInOperand(5));
-    const auto &windowOffsets = getConstVector(opExtInst->GetInOperand(6));
-    const auto &padding = getConstVector(opExtInst->GetInOperand(7));
+    const auto &kernelSizes = getConstVector<uint32_t>(opExtInst->GetInOperand(2));
+    const auto &searchWindowSizes = getConstVector<uint32_t>(opExtInst->GetInOperand(3));
+    const auto &inputStrides = getConstVector<uint32_t>(opExtInst->GetInOperand(4));
+    const auto &windowStrides = getConstVector<uint32_t>(opExtInst->GetInOperand(5));
+    const auto &windowOffsets = getConstVector<uint32_t>(opExtInst->GetInOperand(6));
+    const auto &padding = getConstVector<uint32_t>(opExtInst->GetInOperand(7));
     const auto &searchPattern = getConstScalar<uint32_t>(opExtInst->GetInOperand(8));
     const auto &input0Id = opExtInst->GetInOperand(9);
     const auto &input1Id = opExtInst->GetInOperand(10);
@@ -1078,12 +1078,12 @@ void GraphPassTosaSpv100::handleMinSadCost(const Instruction *opExtInst, const s
     assert(opExtInst->NumInOperands() == 11);
 
     const auto &resultId = opExtInst->result_id();
-    const auto &kernelSizes = getConstVector(opExtInst->GetInOperand(2));
-    const auto &searchWindowSizes = getConstVector(opExtInst->GetInOperand(3));
-    const auto &inputStrides = getConstVector(opExtInst->GetInOperand(4));
-    const auto &windowStrides = getConstVector(opExtInst->GetInOperand(5));
-    const auto &windowOffsets = getConstVector(opExtInst->GetInOperand(6));
-    const auto &padding = getConstVector(opExtInst->GetInOperand(7));
+    const auto &kernelSizes = getConstVector<uint32_t>(opExtInst->GetInOperand(2));
+    const auto &searchWindowSizes = getConstVector<uint32_t>(opExtInst->GetInOperand(3));
+    const auto &inputStrides = getConstVector<uint32_t>(opExtInst->GetInOperand(4));
+    const auto &windowStrides = getConstVector<uint32_t>(opExtInst->GetInOperand(5));
+    const auto &windowOffsets = getConstVector<uint32_t>(opExtInst->GetInOperand(6));
+    const auto &padding = getConstVector<uint32_t>(opExtInst->GetInOperand(7));
     const auto &searchPattern = getConstScalar<uint32_t>(opExtInst->GetInOperand(8));
     const auto &input0Id = opExtInst->GetInOperand(9);
     const auto &input1Id = opExtInst->GetInOperand(10);
@@ -1105,12 +1105,12 @@ void GraphPassTosaSpv100::handleRawSad(const Instruction *opExtInst, const std::
     assert(opExtInst->NumInOperands() == 10);
 
     const auto &resultId = opExtInst->result_id();
-    const auto &kernelSizes = getConstVector(opExtInst->GetInOperand(2));
-    const auto &searchWindowSizes = getConstVector(opExtInst->GetInOperand(3));
-    const auto &inputStrides = getConstVector(opExtInst->GetInOperand(4));
-    const auto &windowStrides = getConstVector(opExtInst->GetInOperand(5));
-    const auto &windowOffsets = getConstVector(opExtInst->GetInOperand(6));
-    const auto &padding = getConstVector(opExtInst->GetInOperand(7));
+    const auto &kernelSizes = getConstVector<uint32_t>(opExtInst->GetInOperand(2));
+    const auto &searchWindowSizes = getConstVector<uint32_t>(opExtInst->GetInOperand(3));
+    const auto &inputStrides = getConstVector<uint32_t>(opExtInst->GetInOperand(4));
+    const auto &windowStrides = getConstVector<uint32_t>(opExtInst->GetInOperand(5));
+    const auto &windowOffsets = getConstVector<uint32_t>(opExtInst->GetInOperand(6));
+    const auto &padding = getConstVector<uint32_t>(opExtInst->GetInOperand(7));
     const auto &input0Id = opExtInst->GetInOperand(8);
     const auto &input1Id = opExtInst->GetInOperand(9);
 


### PR DESCRIPTION
Remove default template arguments from GraphPassBase constant decoding helpers. The previous defaults differed between vector and scalar helpers, with getConstVector defaulting to uint32_t and getConstScalar defaulting to int64_t, which made call sites harder to reason about.

Spell out the intended result type at call sites that previously relied on those defaults.