### PR TITLE
Avoid creating a temp vector when not needed

### DIFF
--- a/tensor/tensor_layer.cpp
+++ b/tensor/tensor_layer.cpp
@@ -46,10 +46,10 @@ class TensorDevice : public Device {
 /*******************************************************************************
  * Hash calculation
  *******************************************************************************/
-inline std::size_t spirvHash(const std::vector<uint32_t> &spirv) {
-    std::size_t hash = spirv.size();
-    for (const auto &i : spirv) {
-        hash ^= std::hash<uint32_t>()(i) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
+std::size_t spirvHash(const uint32_t *spirvCode, std::size_t spirvSize) {
+    std::size_t hash = spirvSize;
+    for (std::size_t i = 0; i < spirvSize; ++i) {
+        hash ^= std::hash<uint32_t>()(spirvCode[i]) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
     }
     return hash;
 }
@@ -344,9 +344,9 @@ class TensorLayer : public VulkanLayerImpl {
                                                     VkShaderModule *pShaderModule) {
         auto handle = VulkanLayerImpl::getHandle(device);
         if (pCreateInfo != nullptr && pCreateInfo->pCode != nullptr && pCreateInfo->codeSize > 0) {
-            std::vector<uint32_t> spirvSource = {pCreateInfo->pCode,
-                                                 pCreateInfo->pCode + pCreateInfo->codeSize / sizeof(uint32_t)};
-            const std::size_t hashCode = spirvHash(spirvSource);
+            const uint32_t *spirvCode = pCreateInfo->pCode;
+            const std::size_t spirvSize = pCreateInfo->codeSize / sizeof(uint32_t);
+            const std::size_t hashCode = spirvHash(spirvCode, spirvSize);
             bool hasCacheEntry;
             std::size_t shaderModuleCodeSize = 0;
             const uint32_t *shaderModulepCode = nullptr;
@@ -362,7 +362,8 @@ class TensorLayer : public VulkanLayerImpl {
             }
 
             if (!hasCacheEntry) {
-                TensorProcessor tensorProcessor(spirvSource);
+                std::vector<uint32_t> spirvSource = {spirvCode, spirvCode + spirvSize};
+                const TensorProcessor tensorProcessor(std::move(spirvSource));
                 if (!tensorProcessor.isValidShader()) {
                     return VK_ERROR_UNKNOWN;
                 }
@@ -423,9 +424,10 @@ class TensorLayer : public VulkanLayerImpl {
                 continue;
             }
             // Check if the shader uses tensors
-            std::vector<uint32_t> spirvSource = {
-                pShaderCreateInfo->pCode, pShaderCreateInfo->pCode + pShaderCreateInfo->codeSize / sizeof(uint32_t)};
-            TensorProcessor tensorProcessor(spirvSource);
+            const uint32_t *spirvCode = pShaderCreateInfo->pCode;
+            const std::size_t spirvSize = pShaderCreateInfo->codeSize / sizeof(uint32_t);
+            std::vector<uint32_t> spirvSource = {spirvCode, spirvCode + spirvSize};
+            const TensorProcessor tensorProcessor(std::move(spirvSource));
             if (!tensorProcessor.isValidShader()) {
                 return VK_ERROR_UNKNOWN;
             }
@@ -441,7 +443,7 @@ class TensorLayer : public VulkanLayerImpl {
             // Replace tensors with buffers in shader
             {
                 scopedMutex l(globalMutex);
-                std::size_t hashCode = spirvHash(spirvSource);
+                std::size_t hashCode = spirvHash(spirvCode, spirvSize);
                 auto &spirvSourceNew = spirvCache[hashCode];
                 if (spirvSourceNew.empty()) {
                     spirvSourceNew = tensorProcessor.getNewSpirv();

--- a/tensor/tensor_processor.cpp
+++ b/tensor/tensor_processor.cpp
@@ -19,7 +19,7 @@ using namespace mlsdk::el::log;
 
 namespace mlsdk::el::layer {
 
-TensorProcessor::TensorProcessor(const std::vector<uint32_t> &spirv_) : m_spirv{spirv_} {
+TensorProcessor::TensorProcessor(std::vector<uint32_t> spirv_) : m_spirv{std::move(spirv_)} {
     try {
         m_spirvCompiler = std::make_unique<CompilerTensorAsBuffer>(m_spirv);
         bool hasTensor = m_spirvCompiler->hasTensors();

--- a/tensor/tensor_processor.hpp
+++ b/tensor/tensor_processor.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2023-2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2023-2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
  * SPDX-License-Identifier: Apache-2.0
  *
  */
@@ -14,9 +14,7 @@
 namespace mlsdk::el::layer {
 class TensorProcessor {
   public:
-    static constexpr size_t TENSOR_MAX_ACCESS_BYTES = 32;
-
-    explicit TensorProcessor(const std::vector<uint32_t> &spirv_);
+    explicit TensorProcessor(std::vector<uint32_t> spirv_);
     bool isTensorComputeShader() const;
     bool isValidShader() const;
     std::vector<uint32_t> getNewSpirv() const;


### PR DESCRIPTION
- Use pointer and size to calculate spirv hash, only create vector when needed.
- Use move semantics.

Change-Id: I05480c9aefc6424c49f21ad9ecee470043456002