### PR TITLE
Fix splat handling for constants

### DIFF
--- a/graph/spirv_pass.cpp
+++ b/graph/spirv_pass.cpp
@@ -516,9 +516,10 @@ std::vector<T> GraphPassBase::getConstVector(const spvtools::opt::Instruction *i
 
         if (isSplat) {
             const auto compositeCount = mlsdk::el::utils::getElementCount(dimensions);
-            if (values.size() != compositeCount) {
+            if (!tryExpandReplicatedPattern(values, compositeCount)) {
                 throw std::runtime_error("Unexpected replicated encoded float constant element count for id: " +
-                                         std::to_string(instruction->result_id()));
+                                         std::to_string(instruction->result_id()) + ", expected " +
+                                         std::to_string(compositeCount) + ", found " + std::to_string(values.size()));
             }
         }
     } else if (constant->AsNullConstant()) {

--- a/graph/spirv_pass.hpp
+++ b/graph/spirv_pass.hpp
@@ -28,6 +28,31 @@ namespace spvtools {
 
 namespace opt {
 
+// Helper function to expand a splat pattern in-place, if the provided values represent a replicated constant pattern.
+// Normally values contain one value that is replicated to the total element count of a composite constant, but in some
+// cases it contains a pattern that needs to be replicated (for example a vector of 2 elements [x, y] that needs to be
+// expanded to [x, y, x, y]).
+template <typename T> bool tryExpandReplicatedPattern(std::vector<T> &values, const size_t elementCount) {
+    if (values.size() == elementCount) {
+        return true;
+    }
+
+    // Verify that expansion is possible: values must not be empty and elementCount must be divisible by values.size()
+    if (values.empty() || elementCount % values.size() != 0) {
+        return false;
+    }
+
+    // This also covers the case where values.size() == 1, which is the common splat pattern with a single value to
+    // replicate.
+    const auto pattern = values;
+    values.reserve(elementCount);
+    while (values.size() < elementCount) {
+        values.insert(values.end(), pattern.begin(), pattern.end());
+    }
+
+    return true;
+}
+
 enum RoundingMode {
     SingleRound = 1,
     InexactRound = 2,
@@ -100,9 +125,10 @@ class GraphPassBase : public Pass {
             if (isSplat) {
                 const auto *tensorType = getTensorType(id);
                 const auto elemCount = getElementCount(tensorType->shape_id());
-                if (kernel.size() != elemCount) {
-                    throw std::runtime_error("Unexpected replicated constant element count for id: " +
-                                             std::to_string(id));
+                if (!tryExpandReplicatedPattern(kernel, elemCount)) {
+                    throw std::runtime_error(
+                        "Unexpected replicated constant element count for id: " + std::to_string(id) + ", expected " +
+                        std::to_string(elemCount) + ", found " + std::to_string(kernel.size()));
                 }
             }
         } else if (const auto *null = constant->AsNullConstant(); null != nullptr) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -36,6 +36,7 @@ if(NOT APPLE)
         SOURCES
             optical_flow_tests.cpp
             common_tests.cpp
+            spirv_pass_tests.cpp
             test_utils.cpp
             vulkan.cpp
         DEFINITIONS
@@ -57,6 +58,7 @@ else()
         TARGET mlel_unit_tests
         SOURCES
             common_tests.cpp
+            spirv_pass_tests.cpp
             test_utils.cpp
             vulkan.cpp
         DEFINITIONS

--- a/tests/spirv_pass_tests.cpp
+++ b/tests/spirv_pass_tests.cpp
@@ -1,0 +1,28 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+#include <gtest/gtest.h>
+
+#include "../graph/spirv_pass.hpp"
+
+#include <cstdint>
+#include <vector>
+
+namespace {
+
+TEST(MLEmulationLayerSpirvPass, ReplicatedPatternExpansionTwoToFour) {
+    std::vector<int32_t> values{1, 2};
+    ASSERT_TRUE(spvtools::opt::tryExpandReplicatedPattern(values, 4));
+    ASSERT_EQ(values, (std::vector<int32_t>{1, 2, 1, 2}));
+}
+
+TEST(MLEmulationLayerSpirvPass, ReplicatedPatternExpansionRejectsNonDivisibleCounts) { // cppcheck-suppress syntaxError
+    std::vector<int32_t> values{1, 2};
+    ASSERT_FALSE(spvtools::opt::tryExpandReplicatedPattern(values, 3));
+    ASSERT_EQ(values, (std::vector<int32_t>{1, 2}));
+}
+
+} // namespace

--- a/tests/vulkan.cpp
+++ b/tests/vulkan.cpp
@@ -1173,6 +1173,11 @@ void expectConv3DInlineEncodedConstantPipelineCreates(const std::string &shaderF
     auto inputTensor = std::make_shared<Tensor>(device, Shape{format, std::vector<int64_t>{1, 1, 1, 1, 1}});
     auto outputTensor = std::make_shared<Tensor>(device, Shape{format, std::vector<int64_t>{1, 1, 1, 1, 1}});
 
+    if (format == vk::Format::eR16SfloatFpencodingBfloat16ARM) {
+        const uint16_t inputValue = 0x3f80;
+        std::memcpy(inputTensor->data(), &inputValue, sizeof(inputValue));
+    }
+
     const GraphPipeline::DescriptorMap descriptorMap = {{
         {0, {inputTensor}},
         {1, {outputTensor}},
@@ -1181,6 +1186,7 @@ void expectConv3DInlineEncodedConstantPipelineCreates(const std::string &shaderF
     const auto spirv = assembleSpirv(fileToString(shaderFile));
     auto graphPipeline = std::make_shared<GraphPipeline>(device, descriptorMap, GraphConstants{}, spirv);
     ASSERT_NE(graphPipeline, nullptr);
+    ASSERT_NO_THROW(graphPipeline->dispatchSubmit());
 }
 
 TEST_F(MLEmulationLayerForVulkan, Conv3DInlineBFloat16ConstantRegression) {


### PR DESCRIPTION
- For replicated composite constants, if decoded payload size is 1 and expected element count is N > 1, it now expands to N by replication.
- It still throws for genuinely invalid counts (neither 1 nor N).
- Also handles repeated patterns of size M that divide N, replicating the pattern N/M times.
- Error text now includes expected/found counts for easier debugging.

Change-Id: Id2d029e112ce933eb0201ed5028d695cf3233a89