### PR TITLE
Treats a null reduced-float PAD constant as zero

### DIFF
--- a/graph/spirv_pass_tosaspv_v100.cpp
+++ b/graph/spirv_pass_tosaspv_v100.cpp
@@ -747,42 +747,46 @@ void GraphPassTosaSpv100::handlePad(const Instruction *opExtInst, const std::str
             scalar = composite->GetComponents()[0];
         }
 
-        const auto *floatConstant = scalar->AsFloatConstant();
-        if (floatConstant == nullptr) {
-            throw std::runtime_error(
-                "Unsupported PAD constant encoding, expected scalar or composite constant. Format: " +
-                std::to_string(vkFormat) + ", is composite: " + (composite != nullptr ? "true" : "false"));
-        }
-        const auto *floatType = floatConstant->type()->AsFloat();
-        if (vkFormat == VK_FORMAT_R16_SFLOAT_FPENCODING_BFLOAT16_ARM) {
-            if (!GraphPassBase::isBFloat16(floatType)) {
-                throw std::runtime_error("Unsupported BF16 PAD constant encoding, floatType: " +
-                                         std::string(floatType->str()));
+        if (scalar->AsNullConstant() != nullptr) {
+            padConst = 0.0;
+        } else {
+            const auto *floatConstant = scalar->AsFloatConstant();
+            if (floatConstant == nullptr) {
+                throw std::runtime_error(
+                    "Unsupported PAD constant encoding, expected scalar, null, or composite constant. Format: " +
+                    std::to_string(vkFormat) + ", is composite: " + (composite != nullptr ? "true" : "false"));
             }
+            const auto *floatType = floatConstant->type()->AsFloat();
+            if (vkFormat == VK_FORMAT_R16_SFLOAT_FPENCODING_BFLOAT16_ARM) {
+                if (!GraphPassBase::isBFloat16(floatType)) {
+                    throw std::runtime_error("Unsupported BF16 PAD constant encoding, floatType: " +
+                                             std::string(floatType->str()));
+                }
 
-            const auto bf16 = uint16_t(floatConstant->words()[0]);
-            const uint32_t fp32Bits = uint32_t(bf16) << 16;
-            float fp32Value = 0.0f;
-            std::memcpy(&fp32Value, &fp32Bits, sizeof(fp32Bits));
-            padConst = real_t(fp32Value);
-        } else if (vkFormat == VK_FORMAT_R8_SFLOAT_FPENCODING_FLOAT8E5M2_ARM) {
-            if (!GraphPassBase::isFloat8E5M2(floatType)) {
-                throw std::runtime_error("Unsupported FLOAT8E5M2 PAD constant encoding, floatType: " +
-                                         std::string(floatType->str()));
+                const auto bf16 = uint16_t(floatConstant->words()[0]);
+                const uint32_t fp32Bits = uint32_t(bf16) << 16;
+                float fp32Value = 0.0f;
+                std::memcpy(&fp32Value, &fp32Bits, sizeof(fp32Bits));
+                padConst = real_t(fp32Value);
+            } else if (vkFormat == VK_FORMAT_R8_SFLOAT_FPENCODING_FLOAT8E5M2_ARM) {
+                if (!GraphPassBase::isFloat8E5M2(floatType)) {
+                    throw std::runtime_error("Unsupported FLOAT8E5M2 PAD constant encoding, floatType: " +
+                                             std::string(floatType->str()));
+                }
+
+                const auto f8 = uint8_t(floatConstant->words()[0]);
+                const auto &fp = reinterpret_cast<const float8_e5m2 &>(f8);
+                padConst = real_t(fp);
+            } else if (vkFormat == VK_FORMAT_R8_SFLOAT_FPENCODING_FLOAT8E4M3_ARM) {
+                if (!GraphPassBase::isFloat8E4M3(floatType)) {
+                    throw std::runtime_error("Unsupported FLOAT8E4M3 PAD constant encoding, floatType: " +
+                                             std::string(floatType->str()));
+                }
+
+                const auto f8 = uint8_t(floatConstant->words()[0]);
+                const auto &fp = reinterpret_cast<const float8_e4m3 &>(f8);
+                padConst = real_t(fp);
             }
-
-            const auto f8 = uint8_t(floatConstant->words()[0]);
-            const auto &fp = reinterpret_cast<const float8_e5m2 &>(f8);
-            padConst = real_t(fp);
-        } else if (vkFormat == VK_FORMAT_R8_SFLOAT_FPENCODING_FLOAT8E4M3_ARM) {
-            if (!GraphPassBase::isFloat8E4M3(floatType)) {
-                throw std::runtime_error("Unsupported FLOAT8E4M3 PAD constant encoding, floatType: " +
-                                         std::string(floatType->str()));
-            }
-
-            const auto f8 = uint8_t(floatConstant->words()[0]);
-            const auto &fp = reinterpret_cast<const float8_e4m3 &>(f8);
-            padConst = real_t(fp);
         }
     } else if (vkFormat == VK_FORMAT_R32_SINT) {
         const auto &padConstVector = getConstVector<int32_t>(opExtInst->GetInOperand(4));


### PR DESCRIPTION
The old PAD path only accepted scalar/composite float constants. The fix in graph/spirv_pass_tosaspv_v100.cpp now treats a null reduced-float PAD constant as zero before decoding bf16/fp8 payloads.

Change-Id: I3de78fd4070e550e7e4ab60131e3730221a42ce6