### PR TITLE
Add interval memory planner

### DIFF
--- a/graph/CMakeLists.txt
+++ b/graph/CMakeLists.txt
@@ -24,6 +24,8 @@ target_sources(VkLayer_Graph PRIVATE
     graph_log.cpp
     graph_profiler.cpp
     image.cpp
+    interval_memory_planner.cpp
+    interval_memory_planner_detail.cpp
     memory_planner.cpp
     optical_flow.cpp
     pipeline_cache.cpp

--- a/graph/graph_layer.cpp
+++ b/graph/graph_layer.cpp
@@ -13,6 +13,7 @@
 #include "compute_graph_op.hpp"
 #include "graph_log.hpp"
 #include "graph_profiler.hpp"
+#include "interval_memory_planner.hpp"
 #include "memory_planner.hpp"
 #include "optical_flow.hpp"
 #include "pipeline_cache.hpp"
@@ -287,8 +288,13 @@ class DataGraphPipelineSessionARM : public Loader {
             return std::make_shared<LinearMemoryPlanner>(pipeline->graphPipeline);
         }
 
-        graphLog(Severity::Info) << "Using best-fit memory planner" << std::endl;
-        return std::make_shared<BestFitMemoryPlanner>(pipeline->graphPipeline);
+        if (envMemoryPlanner && std::string(envMemoryPlanner) == "BestFit") {
+            graphLog(Severity::Info) << "Using best-fit memory planner" << std::endl;
+            return std::make_shared<BestFitMemoryPlanner>(pipeline->graphPipeline);
+        }
+
+        graphLog(Severity::Info) << "Using interval memory planner" << std::endl;
+        return std::make_shared<IntervalMemoryPlanner>(pipeline->graphPipeline);
     }
 };
 

--- a/graph/interval_memory_planner.cpp
+++ b/graph/interval_memory_planner.cpp
@@ -1,0 +1,167 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+/*******************************************************************************
+ * Includes
+ *******************************************************************************/
+
+#include "interval_memory_planner.hpp"
+
+#include "graph_log.hpp"
+#include "mlel/utils.hpp"
+
+#include <algorithm>
+#include <map>
+#include <set>
+#include <utility>
+#include <vector>
+
+using namespace mlsdk::el::log;
+using namespace mlsdk::el::utils;
+
+namespace mlsdk::el::compute::graph_op {
+namespace {
+
+using LiveRange = std::pair<uint32_t, uint32_t>;
+using LiveRanges = std::map<std::shared_ptr<TensorDescriptor>, LiveRange>;
+using SessionTensors = std::set<std::shared_ptr<TensorDescriptor>>;
+using TensorIds = std::map<size_t, std::shared_ptr<TensorDescriptor>>;
+using TensorOrder = std::map<std::shared_ptr<TensorDescriptor>, size_t>;
+using UnseenAllocations = std::vector<details::UnseenAllocation>;
+
+VkDeviceSize alignedSize(const std::shared_ptr<TensorDescriptor> &tensor, const VkDeviceSize alignment) {
+    return roundUp(tensor->getMemoryRequirementsSize(), alignment);
+}
+
+void extendTensorLiveRange(const std::shared_ptr<TensorDescriptor> &tensor, const uint32_t executionIndex,
+                           const SessionTensors &sessionTensors, LiveRanges &liveRanges) {
+    if (sessionTensors.find(tensor) == sessionTensors.end()) {
+        return;
+    }
+
+    auto [it, inserted] = liveRanges.emplace(tensor, std::make_pair(executionIndex, executionIndex));
+    if (!inserted) {
+        it->second.first = std::min(it->second.first, executionIndex);
+        it->second.second = std::max(it->second.second, executionIndex);
+    }
+}
+
+void extendPipelineTensorLiveRanges(const ComputePipelineBase &pipeline, const uint32_t executionIndex,
+                                    const SessionTensors &sessionTensors, LiveRanges &liveRanges) {
+    const auto extend = [&](const auto &tensor) {
+        extendTensorLiveRange(tensor->getTensor(), executionIndex, sessionTensors, liveRanges);
+    };
+
+    const auto &parents = pipeline.getParents();
+    std::for_each(parents.begin(), parents.end(), extend);
+
+    const auto &descendants = pipeline.getDescendants();
+    std::for_each(descendants.begin(), descendants.end(), extend);
+}
+
+std::vector<details::LiveInterval> createLiveIntervals(const std::shared_ptr<GraphPipeline> &graphPipeline,
+                                                       const VkDeviceSize alignment, TensorIds &tensorIds,
+                                                       UnseenAllocations &unseenTensors) {
+    const auto &tensors = graphPipeline->getTensors();
+    const SessionTensors sessionTensors(tensors.begin(), tensors.end());
+    TensorOrder tensorOrder;
+    LiveRanges liveRanges;
+
+    for (size_t i = 0; i < tensors.size(); ++i) {
+        tensorOrder[tensors[i]] = i;
+        tensorIds[i] = tensors[i];
+    }
+
+    uint32_t executionIndex = 0;
+    extendPipelineTensorLiveRanges(graphPipeline->getInputs(), executionIndex++, sessionTensors, liveRanges);
+
+    for (const auto &pipeline : graphPipeline->getPipelines()) {
+        extendPipelineTensorLiveRanges(*pipeline, executionIndex++, sessionTensors, liveRanges);
+    }
+
+    extendPipelineTensorLiveRanges(graphPipeline->getOutputs(), executionIndex, sessionTensors, liveRanges);
+
+    std::vector<details::LiveInterval> intervals;
+    intervals.reserve(liveRanges.size());
+    for (const auto &[tensor, interval] : liveRanges) {
+        const auto tensorOrderIt = tensorOrder.find(tensor);
+        if (tensorOrderIt == tensorOrder.end()) {
+            continue;
+        }
+
+        const auto order = tensorOrderIt->second;
+        intervals.push_back({order, interval.first, interval.second, alignedSize(tensor, alignment), order});
+    }
+
+    unseenTensors.clear();
+    for (const auto &tensor : tensors) {
+        if (liveRanges.find(tensor) == liveRanges.end()) {
+            unseenTensors.push_back({tensorOrder.at(tensor), alignedSize(tensor, alignment)});
+        }
+    }
+
+    return intervals;
+}
+
+} // namespace
+
+/*******************************************************************************
+ * IntervalMemoryPlanner
+ *******************************************************************************/
+
+IntervalMemoryPlanner::IntervalMemoryPlanner(const std::shared_ptr<GraphPipeline> &_graphPipeline)
+    : MemoryPlanner(_graphPipeline) {
+    const auto alignment = std::get<0>(memoryRequirements);
+
+    TensorIds tensorIds;
+    UnseenAllocations unseenTensors;
+    auto intervals = createLiveIntervals(graphPipeline, alignment, tensorIds, unseenTensors);
+    const auto allocationPlan = details::allocateIntervals(std::move(intervals), unseenTensors, alignment);
+
+    memorySize = allocationPlan.memorySize;
+    for (const auto &[id, offset] : allocationPlan.offsets) {
+        tensorOffsets[tensorIds.at(id)] = offset;
+    }
+
+    graphLog(Severity::Info) << "Memory usage after interval allocation: " << memorySize << std::endl;
+}
+
+VkMemoryRequirements IntervalMemoryPlanner::getGraphPipelineSessionMemoryRequirements() const {
+    const auto [alignment, memoryTypeBits] = memoryRequirements;
+
+    VkMemoryRequirements requirements = {
+        memorySize,
+        alignment,
+        memoryTypeBits,
+    };
+
+    return requirements;
+}
+
+void IntervalMemoryPlanner::bindGraphPipelineSessionMemory(VkDeviceMemory memory, VkDeviceSize offset,
+                                                           const ComputeDescriptorSetMap &descriptorSetsMapping) {
+    std::set<VkTensorARM> tensorSet;
+    for ([[maybe_unused]] const auto &[_, descriptorSet] : descriptorSetsMapping) {
+        for (const auto &tensor : descriptorSet->getTensors()) {
+            auto *const tensorARM = tensor->getVkTensorARM();
+            if (tensorSet.find(tensorARM) != tensorSet.end()) {
+                continue;
+            }
+
+            const auto tensorOffset = tensorOffsets.find(tensor->getTensorDescriptor());
+            if (tensorOffset == tensorOffsets.end()) {
+                continue;
+            }
+
+            // To avoid duplicates
+            tensorSet.insert(tensorARM);
+
+            (void)tensor->bindTensorMemory(memory, offset + tensorOffset->second);
+        }
+    }
+}
+
+} // namespace mlsdk::el::compute::graph_op

--- a/graph/interval_memory_planner.hpp
+++ b/graph/interval_memory_planner.hpp
@@ -1,0 +1,65 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+#pragma once
+
+/*******************************************************************************
+ * Includes
+ *******************************************************************************/
+
+#include "memory_planner.hpp"
+
+#include <map>
+#include <memory>
+#include <vector>
+#include <vulkan/vulkan_core.h>
+
+namespace mlsdk::el::compute::graph_op {
+
+namespace details {
+
+struct LiveInterval {
+    size_t id;
+    uint32_t first;
+    uint32_t last;
+    VkDeviceSize size;
+    size_t order;
+};
+
+struct UnseenAllocation {
+    size_t id;
+    VkDeviceSize size;
+};
+
+struct AllocationPlan {
+    VkDeviceSize memorySize{0};
+    std::map<size_t, VkDeviceSize> offsets;
+};
+
+AllocationPlan allocateIntervals(std::vector<LiveInterval> intervals, const std::vector<UnseenAllocation> &unseen,
+                                 VkDeviceSize alignment);
+
+} // namespace details
+
+/*******************************************************************************
+ * IntervalMemoryPlanner
+ *******************************************************************************/
+
+class IntervalMemoryPlanner : public MemoryPlanner {
+  public:
+    explicit IntervalMemoryPlanner(const std::shared_ptr<GraphPipeline> &_graphPipeline);
+    ~IntervalMemoryPlanner() override = default;
+
+    VkMemoryRequirements getGraphPipelineSessionMemoryRequirements() const override;
+    void bindGraphPipelineSessionMemory(VkDeviceMemory memory, VkDeviceSize offset,
+                                        const ComputeDescriptorSetMap &descriptorSets) override;
+
+  private:
+    VkDeviceSize memorySize{0};
+    std::map<std::shared_ptr<TensorDescriptor>, VkDeviceSize> tensorOffsets;
+};
+
+} // namespace mlsdk::el::compute::graph_op

--- a/graph/interval_memory_planner_detail.cpp
+++ b/graph/interval_memory_planner_detail.cpp
@@ -1,0 +1,125 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+/*******************************************************************************
+ * Includes
+ *******************************************************************************/
+
+#include "interval_memory_planner.hpp"
+
+#include "mlel/utils.hpp"
+
+#include <algorithm>
+#include <queue>
+#include <set>
+#include <vector>
+
+using namespace mlsdk::el::utils;
+
+namespace mlsdk::el::compute::graph_op::details {
+namespace {
+
+struct ActiveAllocation {
+    uint32_t last;
+    VkDeviceSize offset;
+    VkDeviceSize size;
+    size_t order;
+};
+
+struct ActiveAllocationEndsFirst {
+    bool operator()(const ActiveAllocation &left, const ActiveAllocation &right) const {
+        if (left.last != right.last) {
+            return left.last > right.last;
+        }
+
+        return left.order > right.order;
+    }
+};
+
+struct FreeBlock {
+    VkDeviceSize offset;
+    VkDeviceSize size;
+    size_t order;
+};
+
+struct FreeBlockSmallestFitFirst {
+    bool operator()(const FreeBlock &left, const FreeBlock &right) const {
+        if (left.size != right.size) {
+            return left.size < right.size;
+        }
+
+        return left.order < right.order;
+    }
+};
+
+using FreeBlocks = std::multiset<FreeBlock, FreeBlockSmallestFitFirst>;
+
+VkDeviceSize allocateFromFreeBlocks(FreeBlocks &freeBlocks, const VkDeviceSize size) {
+    auto freeBlock = freeBlocks.lower_bound({0, size, 0});
+    if (freeBlock == freeBlocks.end()) {
+        return VK_WHOLE_SIZE;
+    }
+
+    const auto offset = freeBlock->offset;
+    if (freeBlock->size > size) {
+        freeBlocks.insert({freeBlock->offset + size, freeBlock->size - size, freeBlock->order});
+    }
+    freeBlocks.erase(freeBlock);
+
+    return offset;
+}
+
+} // namespace
+
+AllocationPlan allocateIntervals(std::vector<LiveInterval> intervals, const std::vector<UnseenAllocation> &unseen,
+                                 const VkDeviceSize alignment) {
+    std::stable_sort(intervals.begin(), intervals.end(), [](const auto &left, const auto &right) {
+        if (left.first != right.first) {
+            return left.first < right.first;
+        }
+
+        if (left.size != right.size) {
+            return left.size > right.size;
+        }
+
+        return left.order < right.order;
+    });
+
+    AllocationPlan plan;
+    std::priority_queue<ActiveAllocation, std::vector<ActiveAllocation>, ActiveAllocationEndsFirst> activeAllocations;
+    FreeBlocks freeBlocks;
+    size_t freeBlockOrder = 0;
+
+    for (const auto &interval : intervals) {
+        while (!activeAllocations.empty() && activeAllocations.top().last < interval.first) {
+            const auto expired = activeAllocations.top();
+            activeAllocations.pop();
+
+            freeBlocks.insert({expired.offset, expired.size, freeBlockOrder++});
+        }
+
+        auto offset = allocateFromFreeBlocks(freeBlocks, interval.size);
+        if (offset == VK_WHOLE_SIZE) {
+            offset = roundUp(plan.memorySize, alignment);
+            plan.memorySize = offset + interval.size;
+        }
+
+        plan.offsets[interval.id] = offset;
+        activeAllocations.push({interval.last, offset, interval.size, interval.order});
+    }
+
+    for (const auto &allocation : unseen) {
+        const auto offset = roundUp(plan.memorySize, alignment);
+        plan.offsets[allocation.id] = offset;
+        plan.memorySize = offset + allocation.size;
+    }
+
+    plan.memorySize = roundUp(plan.memorySize, alignment);
+
+    return plan;
+}
+
+} // namespace mlsdk::el::compute::graph_op::details

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -37,10 +37,14 @@ if(NOT APPLE)
             optical_flow_tests.cpp
             common_tests.cpp
             spirv_pass_tests.cpp
+            ${CMAKE_CURRENT_SOURCE_DIR}/../graph/interval_memory_planner_detail.cpp
+            interval_memory_planner_tests.cpp
             test_utils.cpp
             vulkan.cpp
         DEFINITIONS
             SHADER_SOURCE_DIR=${SHADER_SOURCE_DIR}
+        INCLUDE_DIRECTORIES
+            ${CMAKE_CURRENT_SOURCE_DIR}/../graph
         LIBRARIES
             mlelutilities
             VkLayer_Common
@@ -59,10 +63,14 @@ else()
         SOURCES
             common_tests.cpp
             spirv_pass_tests.cpp
+            ${CMAKE_CURRENT_SOURCE_DIR}/../graph/interval_memory_planner_detail.cpp
+            interval_memory_planner_tests.cpp
             test_utils.cpp
             vulkan.cpp
         DEFINITIONS
             SHADER_SOURCE_DIR=${SHADER_SOURCE_DIR}
+        INCLUDE_DIRECTORIES
+            ${CMAKE_CURRENT_SOURCE_DIR}/../graph
         LIBRARIES
             mlelutilities
             VkLayer_Common

--- a/tests/interval_memory_planner_tests.cpp
+++ b/tests/interval_memory_planner_tests.cpp
@@ -1,0 +1,108 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+#include <gtest/gtest.h>
+
+#include "interval_memory_planner.hpp"
+
+#include <vector>
+
+namespace {
+
+namespace planner = mlsdk::el::compute::graph_op::details;
+
+TEST(IntervalMemoryPlanner, NonOverlappingTensorsReuseMemory) {
+    std::vector<planner::LiveInterval> intervals{
+        {0, 0, 0, 64, 0},
+        {1, 1, 1, 64, 1},
+    };
+    const std::vector<planner::UnseenAllocation> unseen;
+    const auto plan = planner::allocateIntervals(intervals, unseen, 16);
+
+    ASSERT_EQ(plan.offsets.at(0), 0u);
+    ASSERT_EQ(plan.offsets.at(1), plan.offsets.at(0));
+    ASSERT_EQ(plan.memorySize, 64u);
+}
+
+TEST(IntervalMemoryPlanner, OverlappingTensorsDoNotAlias) { // cppcheck-suppress syntaxError
+    std::vector<planner::LiveInterval> intervals{
+        {0, 0, 2, 64, 0},
+        {1, 1, 3, 64, 1},
+    };
+    const std::vector<planner::UnseenAllocation> unseen;
+    const auto plan = planner::allocateIntervals(intervals, unseen, 16);
+
+    ASSERT_NE(plan.offsets.at(0), plan.offsets.at(1));
+    ASSERT_EQ(plan.memorySize, 128u);
+}
+
+TEST(IntervalMemoryPlanner, SplitsOversizedFreeBlocks) {
+    std::vector<planner::LiveInterval> intervals{
+        {0, 0, 0, 128, 0},
+        {1, 1, 2, 64, 1},
+        {2, 1, 2, 64, 2},
+    };
+    const std::vector<planner::UnseenAllocation> unseen;
+    const auto plan = planner::allocateIntervals(intervals, unseen, 16);
+
+    ASSERT_EQ(plan.offsets.at(0), 0u);
+    ASSERT_EQ(plan.offsets.at(1), 0u);
+    ASSERT_EQ(plan.offsets.at(2), 64u);
+    ASSERT_EQ(plan.memorySize, 128u);
+}
+
+TEST(IntervalMemoryPlanner, DoesNotCoalesceAdjacentFreeBlocks) {
+    std::vector<planner::LiveInterval> intervals{
+        {0, 0, 0, 64, 0},
+        {1, 0, 0, 64, 1},
+        {2, 1, 1, 128, 2},
+    };
+    const std::vector<planner::UnseenAllocation> unseen;
+    const auto plan = planner::allocateIntervals(intervals, unseen, 16);
+
+    ASSERT_EQ(plan.offsets.at(0), 0u);
+    ASSERT_EQ(plan.offsets.at(1), 64u);
+    ASSERT_EQ(plan.offsets.at(2), 128u);
+    ASSERT_EQ(plan.memorySize, 256u);
+}
+
+TEST(IntervalMemoryPlanner, UnseenTensorsReceiveUniqueStorage) {
+    std::vector<planner::LiveInterval> intervals{
+        {0, 0, 0, 64, 0},
+    };
+    const std::vector<planner::UnseenAllocation> unseen{
+        {1, 32},
+        {2, 32},
+    };
+    const auto plan = planner::allocateIntervals(intervals, unseen, 16);
+
+    ASSERT_EQ(plan.offsets.at(0), 0u);
+    ASSERT_EQ(plan.offsets.at(1), 64u);
+    ASSERT_EQ(plan.offsets.at(2), 96u);
+    ASSERT_NE(plan.offsets.at(1), plan.offsets.at(2));
+    ASSERT_EQ(plan.memorySize, 128u);
+}
+
+TEST(IntervalMemoryPlanner, ExternalTensorsAreNotIncludedInSessionAllocation) {
+    constexpr size_t sessionTensor = 0;
+    constexpr size_t unseenSessionTensor = 1;
+    constexpr size_t externalTensor = 2;
+
+    std::vector<planner::LiveInterval> intervals{
+        {sessionTensor, 0, 0, 64, 0},
+    };
+    const std::vector<planner::UnseenAllocation> unseen{
+        {unseenSessionTensor, 64},
+    };
+    const auto plan = planner::allocateIntervals(intervals, unseen, 16);
+
+    ASSERT_NE(plan.offsets.find(sessionTensor), plan.offsets.end());
+    ASSERT_NE(plan.offsets.find(unseenSessionTensor), plan.offsets.end());
+    ASSERT_EQ(plan.offsets.find(externalTensor), plan.offsets.end());
+    ASSERT_EQ(plan.memorySize, 128u);
+}
+
+} // namespace


### PR DESCRIPTION
Introduce a separate interval-based session memory planner that derives tensor lifetimes from graph pipeline execution order and reuses expired tensor storage with a smallest-fit free block set.


Change-Id: Icff23d37176b6fb93313357930402591136a3d4d