### PR TITLE
Handle profiling for reused command buffers

### DIFF
--- a/graph/graph_layer.cpp
+++ b/graph/graph_layer.cpp
@@ -666,6 +666,9 @@ class GraphLayer : public VulkanLayerImpl {
         auto handle = VulkanLayerImpl::getHandle(queue);
         const auto commandBuffers = getCommandBuffers(submitCount, pSubmits);
         const bool shouldProfile = handle->profiler && handle->profiler->hasProfiledCommandBuffers(commandBuffers);
+        if (shouldProfile) {
+            handle->profiler->prepareCommandBuffersForSubmit(commandBuffers);
+        }
 
         const auto result = handle->loader->vkQueueSubmit(queue, submitCount, pSubmits, fence);
         if (result == VK_SUCCESS && shouldProfile) {
@@ -680,6 +683,9 @@ class GraphLayer : public VulkanLayerImpl {
         auto handle = VulkanLayerImpl::getHandle(queue);
         const auto commandBuffers = getCommandBuffers(submitCount, pSubmits);
         const bool shouldProfile = handle->profiler && handle->profiler->hasProfiledCommandBuffers(commandBuffers);
+        if (shouldProfile) {
+            handle->profiler->prepareCommandBuffersForSubmit(commandBuffers);
+        }
 
         const auto result = handle->loader->vkQueueSubmit2(queue, submitCount, pSubmits, fence);
         if (result == VK_SUCCESS && shouldProfile) {
@@ -694,6 +700,9 @@ class GraphLayer : public VulkanLayerImpl {
         auto handle = VulkanLayerImpl::getHandle(queue);
         const auto commandBuffers = getCommandBuffers(submitCount, pSubmits);
         const bool shouldProfile = handle->profiler && handle->profiler->hasProfiledCommandBuffers(commandBuffers);
+        if (shouldProfile) {
+            handle->profiler->prepareCommandBuffersForSubmit(commandBuffers);
+        }
 
         const auto submit =
             handle->loader->vkQueueSubmit2KHR ? handle->loader->vkQueueSubmit2KHR : handle->loader->vkQueueSubmit2;

--- a/graph/graph_profiler.cpp
+++ b/graph/graph_profiler.cpp
@@ -229,6 +229,39 @@ bool GraphProfiler::hasProfiledCommandBuffers(const std::vector<VkCommandBuffer>
     return state.hasProfiledCommandBuffers(commandBuffers);
 }
 
+void GraphProfiler::prepareCommandBuffersForSubmit(const std::vector<VkCommandBuffer> &commandBuffers) {
+    auto submissions = state.getSubmissionsForCommandBuffers(commandBuffers);
+    if (submissions.empty()) {
+        return;
+    }
+
+    // Simple design: reused command buffers execute the same recorded query slots again.
+    // Block until earlier submissions finish, then collect them before those slots are overwritten.
+    collectSubmissions(submissions);
+    submissions = state.getSubmissionsForCommandBuffers(commandBuffers);
+    if (submissions.empty()) {
+        return;
+    }
+
+    std::vector<VkQueue> queues;
+    queues.reserve(submissions.size());
+    for (const auto &submission : submissions) {
+        if (std::find(queues.begin(), queues.end(), submission->queue) == queues.end()) {
+            queues.push_back(submission->queue);
+        }
+    }
+
+    for (auto *const queue : queues) {
+        const VkResult waitResult = loader->vkQueueWaitIdle(queue);
+        if (waitResult == VK_SUCCESS) {
+            collectQueue(queue);
+        } else {
+            graphLog(Severity::Error) << "Failed waiting for graph profiling queue idle before command buffer reuse"
+                                      << std::endl;
+        }
+    }
+}
+
 void GraphProfiler::registerSubmit(VkQueue queue, const std::vector<VkCommandBuffer> &commandBuffers, VkFence fence) {
     state.registerSubmit(queue, commandBuffers, fence);
 }
@@ -428,6 +461,27 @@ GraphProfiler::Submissions GraphProfiler::LockedState::getSubmissionsForQueue(Vk
 }
 
 GraphProfiler::Submissions GraphProfiler::LockedState::getSubmissionsForDevice() const { return submissions; }
+
+GraphProfiler::Submissions
+GraphProfiler::LockedState::getSubmissionsForCommandBuffers(const std::vector<VkCommandBuffer> &commandBuffers) const {
+    std::lock_guard lock(mutex);
+    const auto records = getRecordsForCommandBuffersLocked(commandBuffers);
+    if (records.empty()) {
+        return {};
+    }
+
+    Submissions submitRecords;
+    for (const auto &submission : submissions) {
+        const auto hasQueryRecord = std::any_of(
+            submission->queryRecords.begin(), submission->queryRecords.end(), [&records](const auto &submissionRecord) {
+                return std::find(records.begin(), records.end(), submissionRecord) != records.end();
+            });
+        if (hasQueryRecord) {
+            submitRecords.push_back(submission);
+        }
+    }
+    return submitRecords;
+}
 
 GraphProfiler::Submissions
 GraphProfiler::LockedState::getSubmissionsForCommandBuffer(VkCommandBuffer commandBuffer) const {

--- a/graph/graph_profiler.hpp
+++ b/graph/graph_profiler.hpp
@@ -54,6 +54,7 @@ class GraphProfiler {
     makeOpticalFlowDispatchDecorator(VkPipeline dataGraphPipeline, VkCommandBuffer commandBuffer,
                                      uint32_t queueFamilyIndex, uint32_t pipelineCount);
     bool hasProfiledCommandBuffers(const std::vector<VkCommandBuffer> &commandBuffers) const;
+    void prepareCommandBuffersForSubmit(const std::vector<VkCommandBuffer> &commandBuffers);
     void registerSubmit(VkQueue queue, const std::vector<VkCommandBuffer> &commandBuffers, VkFence fence);
     void registerExecuteCommands(VkCommandBuffer commandBuffer, uint32_t commandBufferCount,
                                  const VkCommandBuffer *pCommandBuffers);
@@ -82,6 +83,7 @@ class GraphProfiler {
         Submissions getSubmissionsForFence(VkFence fence) const;
         Submissions getSubmissionsForQueue(VkQueue queue) const;
         Submissions getSubmissionsForDevice() const;
+        Submissions getSubmissionsForCommandBuffers(const std::vector<VkCommandBuffer> &commandBuffers) const;
         Submissions getSubmissionsForCommandBuffer(VkCommandBuffer commandBuffer) const;
         void completeSubmissions(const CompletedSubmissions &completedSubmissions);
         void clearCommandBuffer(VkCommandBuffer commandBuffer);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -30,52 +30,44 @@ function(mlel_add_test)
 
 endfunction()
 
+set(MLEL_UNIT_TEST_SOURCES
+    common_tests.cpp
+    spirv_pass_tests.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../graph/interval_memory_planner_detail.cpp
+    interval_memory_planner_tests.cpp
+    test_utils.cpp
+    vulkan.cpp)
 if(NOT APPLE)
-    mlel_add_test(
-        TARGET mlel_unit_tests
-        SOURCES
-            optical_flow_tests.cpp
-            common_tests.cpp
-            spirv_pass_tests.cpp
-            ${CMAKE_CURRENT_SOURCE_DIR}/../graph/interval_memory_planner_detail.cpp
-            interval_memory_planner_tests.cpp
-            test_utils.cpp
-            vulkan.cpp
-        DEFINITIONS
-            SHADER_SOURCE_DIR=${SHADER_SOURCE_DIR}
-        INCLUDE_DIRECTORIES
-            ${CMAKE_CURRENT_SOURCE_DIR}/../graph
-        LIBRARIES
-            mlelutilities
-            VkLayer_Common
-        PROPERTIES
-            ENVIRONMENT_MODIFICATION VK_LAYER_PATH=path_list_append:$<TARGET_FILE_DIR:VkLayer_Graph>
-            ENVIRONMENT_MODIFICATION LD_LIBRARY_PATH=path_list_append:$<TARGET_FILE_DIR:VkLayer_Graph>
-
-            ENVIRONMENT_MODIFICATION VK_LAYER_PATH=path_list_append:$<TARGET_FILE_DIR:VkLayer_Tensor>
-            ENVIRONMENT_MODIFICATION LD_LIBRARY_PATH=path_list_append:$<TARGET_FILE_DIR:VkLayer_Tensor>
-
-            ENVIRONMENT_MODIFICATION VK_LAYER_PATH=path_list_append:/usr/share/vulkan/explicit_layer.d
-    )
-else()
-    mlel_add_test(
-        TARGET mlel_unit_tests
-        SOURCES
-            common_tests.cpp
-            spirv_pass_tests.cpp
-            ${CMAKE_CURRENT_SOURCE_DIR}/../graph/interval_memory_planner_detail.cpp
-            interval_memory_planner_tests.cpp
-            test_utils.cpp
-            vulkan.cpp
-        DEFINITIONS
-            SHADER_SOURCE_DIR=${SHADER_SOURCE_DIR}
-        INCLUDE_DIRECTORIES
-            ${CMAKE_CURRENT_SOURCE_DIR}/../graph
-        LIBRARIES
-            mlelutilities
-            VkLayer_Common
-        PROPERTIES
-            ENVIRONMENT_MODIFICATION VK_LAYER_PATH=path_list_append:$ENV{VK_LAYER_PATH}
-            ENVIRONMENT_MODIFICATION DYLD_LIBRARY_PATH=path_list_append:$ENV{DYLD_LIBRARY_PATH}
-    )
+    list(PREPEND MLEL_UNIT_TEST_SOURCES optical_flow_tests.cpp)
 endif()
+
+
+
+if(APPLE)
+    set(MLEL_UNIT_TEST_PROPERTIES
+        ENVIRONMENT_MODIFICATION VK_LAYER_PATH=path_list_append:$ENV{VK_LAYER_PATH}
+        ENVIRONMENT_MODIFICATION DYLD_LIBRARY_PATH=path_list_append:$ENV{DYLD_LIBRARY_PATH})
+else()
+    set(MLEL_UNIT_TEST_PROPERTIES
+        ENVIRONMENT_MODIFICATION VK_LAYER_PATH=path_list_append:$<TARGET_FILE_DIR:VkLayer_Graph>
+        ENVIRONMENT_MODIFICATION LD_LIBRARY_PATH=path_list_append:$<TARGET_FILE_DIR:VkLayer_Graph>
+        ENVIRONMENT_MODIFICATION VK_LAYER_PATH=path_list_append:$<TARGET_FILE_DIR:VkLayer_Tensor>
+        ENVIRONMENT_MODIFICATION LD_LIBRARY_PATH=path_list_append:$<TARGET_FILE_DIR:VkLayer_Tensor>
+        ENVIRONMENT_MODIFICATION VK_LAYER_PATH=path_list_append:/usr/share/vulkan/explicit_layer.d)
+endif()
+
+mlel_add_test(
+    TARGET mlel_unit_tests
+    SOURCES
+        ${MLEL_UNIT_TEST_SOURCES}
+    DEFINITIONS
+        SHADER_SOURCE_DIR=${SHADER_SOURCE_DIR}
+    INCLUDE_DIRECTORIES
+        ${CMAKE_CURRENT_SOURCE_DIR}/../graph
+    LIBRARIES
+        mlelutilities
+        nlohmann_json::nlohmann_json
+        VkLayer_Common
+    PROPERTIES
+        ${MLEL_UNIT_TEST_PROPERTIES}
+)

--- a/tests/vulkan.cpp
+++ b/tests/vulkan.cpp
@@ -10,6 +10,8 @@
 
 #include <gtest/gtest.h>
 
+#include <nlohmann/json.hpp>
+
 #include "test_utils.hpp"
 
 #include "mlel/device.hpp"
@@ -412,6 +414,38 @@ void submitGraphWithoutFence(const std::shared_ptr<Device> &device, const Profil
     }
 }
 
+void submitGraphCommandBufferTwiceWithoutIntermediateWait(const std::shared_ptr<Device> &device,
+                                                          const ProfilingGraph &graph) {
+    auto [descriptorPool, descriptorSets] = graph.pipeline->createDescriptorSets(graph.descriptorMap);
+    auto commandBuffer = graph.pipeline->createCommandBuffer();
+
+    const vk::CommandBufferBeginInfo commandBufferBeginInfo{
+        vk::CommandBufferUsageFlagBits::eSimultaneousUse,
+    };
+    commandBuffer.begin(commandBufferBeginInfo);
+    graph.pipeline->dispatch(commandBuffer, descriptorSets);
+    commandBuffer.end();
+
+    vk::raii::Queue queue(&(*device), device->getPhysicalDevice()->getComputeFamilyIndex(), 0);
+    const VkCommandBuffer vkCommandBuffer = *commandBuffer;
+    const VkSubmitInfo submitInfo{
+        VK_STRUCTURE_TYPE_SUBMIT_INFO, // sType
+        nullptr,                       // pNext
+        0,                             // waitSemaphoreCount
+        nullptr,                       // pWaitSemaphores
+        nullptr,                       // pWaitDstStageMask
+        1,                             // commandBufferCount
+        &vkCommandBuffer,              // pCommandBuffers
+        0,                             // signalSemaphoreCount
+        nullptr,                       // pSignalSemaphores
+    };
+
+    const auto &vkDevice = &(*device);
+    ASSERT_EQ(vkDevice.getDispatcher()->vkQueueSubmit(*queue, 1, &submitInfo, VK_NULL_HANDLE), VK_SUCCESS);
+    ASSERT_EQ(vkDevice.getDispatcher()->vkQueueSubmit(*queue, 1, &submitInfo, VK_NULL_HANDLE), VK_SUCCESS);
+    ASSERT_EQ(vkDevice.getDispatcher()->vkQueueWaitIdle(*queue), VK_SUCCESS);
+}
+
 std::string queryPipelineTextProperty(const std::shared_ptr<Device> &device, vk::Pipeline pipeline,
                                       vk::DataGraphPipelinePropertyARM property) {
     const auto &vkDevice = &(*device);
@@ -663,6 +697,28 @@ TEST_F(MLEmulationLayerForVulkan, GraphProfilingCollectsFenceLessSubmitOnDeviceW
     submitGraphWithoutFence(device, graph, true);
 
     expectMaxPoolProfileProperty(device, graph);
+}
+
+TEST_F(MLEmulationLayerForVulkan, GraphProfilingCollectsReusedCommandBufferSubmits) {
+    ScopedEnvironment enableProfiling{"VMEL_GRAPH_PROFILING", "1"};
+
+    auto device = createDevice();
+    auto graph = makeMaxPoolProfilingGraph(device);
+    submitGraphCommandBufferTwiceWithoutIntermediateWait(device, graph);
+
+    const auto property = getProfilingProperty(device, *graph.pipeline->getPipeline());
+    ASSERT_TRUE(property.has_value());
+    const auto json = queryPipelineTextProperty(device, *graph.pipeline->getPipeline(), *property);
+    const auto parsed = nlohmann::json::parse(std::string{json.c_str()});
+    const auto &samples = parsed.at("samples");
+    ASSERT_EQ(samples.size(), 2);
+
+    EXPECT_EQ(samples.at(0).at("submission"), 0);
+    EXPECT_EQ(samples.at(1).at("submission"), 1);
+    EXPECT_NE(samples.at(0).at("cycle_count_before"), samples.at(1).at("cycle_count_before"));
+    EXPECT_NE(samples.at(0).at("cycle_count_after"), samples.at(1).at("cycle_count_after"));
+    ASSERT_EQ(parsed.at("by_operator").size(), 1);
+    EXPECT_EQ(parsed.at("by_operator").at(0).at("dispatch_count"), 2);
 }
 
 TEST_F(MLEmulationLayerForVulkan, GraphProfilingIncludesMotionEngineGraphOps) {


### PR DESCRIPTION
When a profiled command buffer was submitted more than once, each submission referenced the same recorded timestamp query slots. If collection happened after a later execution, older submissions could read overwritten timestamp values and report duplicate or incorrect samples.

Before submitting profiled command buffers, collect any pending submissions that share their query records. If those records are not ready yet, wait for the affected queues and collect them before allowing the command buffer to execute again.

Add a regression test that submits the same profiled command buffer twice before the application waits, then verifies that profiling reports two distinct samples and aggregates both executions.