### PR TITLE
Remove unused VirtualTensor state

### DIFF
--- a/graph/compute_graph_op.cpp
+++ b/graph/compute_graph_op.cpp
@@ -25,7 +25,7 @@ namespace {
 void makeAndConnectVirtualTensor(const std::shared_ptr<TensorDescriptor> &tensor,
                                  graph_op::ComputePipelineBase *descendant) {
     auto *parent = tensor->getPipeline();
-    auto virtualTensor = std::make_shared<VirtualTensor>(tensor, parent, descendant);
+    auto virtualTensor = std::make_shared<VirtualTensor>(tensor, descendant);
 
     if (parent != nullptr) {
         parent->pushDescendant(virtualTensor);

--- a/graph/tensor.cpp
+++ b/graph/tensor.cpp
@@ -338,19 +338,12 @@ Log &operator<<(Log &os, const TensorDescriptor &tensor) {
  * VirtualTensor
  *******************************************************************************/
 
-VirtualTensor::VirtualTensor(const std::shared_ptr<TensorDescriptor> &_tensor, ComputePipelineBase *_parent,
-                             ComputePipelineBase *_descendant)
-    : tensor{_tensor}, parent{_parent}, descendant{_descendant} {
+VirtualTensor::VirtualTensor(const std::shared_ptr<TensorDescriptor> &_tensor, ComputePipelineBase *_descendant)
+    : tensor{_tensor}, descendant{_descendant} {
     tensor->incrementReferenceCounter();
 }
 
-bool VirtualTensor::getVisited() const { return visited; }
-
-void VirtualTensor::setVisited(const bool _visited) { visited = _visited; }
-
 const std::shared_ptr<TensorDescriptor> &VirtualTensor::getTensor() const { return tensor; }
-
-ComputePipelineBase *VirtualTensor::getParentPipeline() const { return parent; }
 
 ComputePipelineBase *VirtualTensor::getDescendantPipeline() const { return descendant; }
 

--- a/graph/tensor.hpp
+++ b/graph/tensor.hpp
@@ -121,21 +121,14 @@ mlsdk::el::log::Log &operator<<(mlsdk::el::log::Log &os, const TensorDescriptor 
 
 class VirtualTensor {
   public:
-    VirtualTensor(const std::shared_ptr<TensorDescriptor> &_tensor, ComputePipelineBase *_parent,
-                  ComputePipelineBase *_descendant);
-
-    bool getVisited() const;
-    void setVisited(bool _visited);
+    VirtualTensor(const std::shared_ptr<TensorDescriptor> &_tensor, ComputePipelineBase *_descendant);
 
     const std::shared_ptr<TensorDescriptor> &getTensor() const;
-    ComputePipelineBase *getParentPipeline() const;
     ComputePipelineBase *getDescendantPipeline() const;
 
   private:
     std::shared_ptr<TensorDescriptor> tensor;
-    ComputePipelineBase *parent;
     ComputePipelineBase *descendant;
-    bool visited{false};
 };
 
 } // namespace mlsdk::el::compute


### PR DESCRIPTION
Drop the unused parent pipeline and visited fields from VirtualTensor, and update virtual tensor creation to pass only the descendant pipeline.

Change-Id: I7b04fb6298fbe91d71bf5d870514a042a6c91743