### PR TITLE
fix: Update image aliasing strides

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,7 +5,12 @@
 ## Unreleased
 
 ### Build, Packaging & Developer Experience
- - Updated Emulation Layer `--version` output to report the package version and include git revision and dependency revision information
+
+- Updated Emulation Layer `--version` output to report the package version and include git revision and dependency revision information
+
+### Bug Fixes
+
+- Fixed linear tensor/image aliasing to honor padded image row and depth pitches.
 
 ## Version 0.10.0 – *Optical Flow, Graph Profiling & Runtime Refinement*
 

--- a/tensor/tensor_arm.cpp
+++ b/tensor/tensor_arm.cpp
@@ -5,6 +5,8 @@
  */
 #include "tensor_arm.hpp"
 
+#include "tensor_arm_detail.hpp"
+
 #include "mlel/utils.hpp"
 
 #include <numeric>
@@ -52,8 +54,7 @@ TensorARM::TensorInfo::TensorInfo(const VkTensorCreateInfoARM &createInfo) {
         throw std::runtime_error(std::string("Tensor dimension count not supported: ") +
                                  std::to_string(desc.dimensionCount));
     }
-    isOptimalTilingAliasing =
-        (desc.usage & VK_TENSOR_USAGE_IMAGE_ALIASING_BIT_ARM) && desc.tiling == VK_TENSOR_TILING_OPTIMAL_ARM;
+    usesImageAliasing = tensor_arm_detail::usesImageAliasing(desc);
 
     usage = convertToBufferUsageFlags(desc.usage);
     flags = convertToBufferCreateFlags(createInfo.flags);
@@ -143,7 +144,7 @@ void TensorARM::updateAliasedTensorInfo(const Device &dev, VkImage image) {
         throw std::runtime_error("Tensor rank should be 2, 3 or 4 to alias with image.");
     }
 
-    if (m_info.isOptimalTilingAliasing) {
+    if (m_info.usesImageAliasing) {
         const VkImageSubresource imageSubresource = {
             VK_IMAGE_ASPECT_COLOR_BIT,
             0,
@@ -151,14 +152,7 @@ void TensorARM::updateAliasedTensorInfo(const Device &dev, VkImage image) {
         };
         VkSubresourceLayout imageSubresourceLayout{};
         dev.loader->vkGetImageSubresourceLayout(dev.device, image, &imageSubresource, &imageSubresourceLayout);
-        if (rank == 4) {
-            // alias to 3D image
-            m_info.strides[0] = static_cast<int64_t>(imageSubresourceLayout.depthPitch);
-            m_info.strides[1] = static_cast<int64_t>(imageSubresourceLayout.rowPitch);
-        } else if (rank == 3) {
-            // alias to 2D image
-            m_info.strides[0] = static_cast<int64_t>(imageSubresourceLayout.rowPitch);
-        }
+        tensor_arm_detail::updateAliasedStrides(rank, m_info.strides, imageSubresourceLayout);
     }
 }
 

--- a/tensor/tensor_arm.hpp
+++ b/tensor/tensor_arm.hpp
@@ -31,7 +31,7 @@ class TensorARM {
         VkBufferUsageFlags usage = 0;
         VkBufferCreateFlags flags = 0;
         VkFormat format = VK_FORMAT_UNDEFINED;
-        bool isOptimalTilingAliasing = false;
+        bool usesImageAliasing = false;
 
         static VkBufferCreateFlags convertToBufferCreateFlags(VkTensorCreateFlagsARM flags);
         static VkBufferUsageFlags convertToBufferUsageFlags(VkTensorUsageFlagsARM usage);

--- a/tensor/tensor_arm_detail.hpp
+++ b/tensor/tensor_arm_detail.hpp
@@ -1,0 +1,32 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+#pragma once
+
+#include <vulkan/vulkan.h>
+
+#include <cstdint>
+#include <vector>
+
+namespace mlsdk::el::layer::tensor_arm_detail {
+
+inline bool usesImageAliasing(const VkTensorDescriptionARM &description) {
+    return (description.usage & VK_TENSOR_USAGE_IMAGE_ALIASING_BIT_ARM) != 0;
+}
+
+inline void updateAliasedStrides(const std::size_t rank, std::vector<int64_t> &strides,
+                                 const VkSubresourceLayout &imageLayout) {
+    if (rank == 4) {
+        // alias to 3D image
+        strides[0] = static_cast<int64_t>(imageLayout.depthPitch);
+        strides[1] = static_cast<int64_t>(imageLayout.rowPitch);
+    } else if (rank == 3) {
+        // alias to 2D image
+        strides[0] = static_cast<int64_t>(imageLayout.rowPitch);
+    }
+}
+
+} // namespace mlsdk::el::layer::tensor_arm_detail

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -37,6 +37,7 @@ set(MLEL_UNIT_TEST_SOURCES
     common/common_tests.cpp
     graph/spirv_pass_tests.cpp
     graph/interval_memory_planner_tests.cpp
+    tensor/tensor_arm_tests.cpp
     test_utils.cpp
     vulkan.cpp)
 if(NOT APPLE)
@@ -67,6 +68,7 @@ mlel_add_test(
     INCLUDE_DIRECTORIES
         ${CMAKE_CURRENT_SOURCE_DIR}
         ${CMAKE_CURRENT_SOURCE_DIR}/../graph
+        ${CMAKE_CURRENT_SOURCE_DIR}/../tensor
     LIBRARIES
         mlelutilities
         nlohmann_json::nlohmann_json

--- a/tests/shader/tensor_image_alias.comp
+++ b/tests/shader/tensor_image_alias.comp
@@ -1,0 +1,24 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#version 460
+#extension GL_EXT_shader_explicit_arithmetic_types_int8 : require
+#extension GL_EXT_shader_8bit_storage : require
+#extension GL_ARM_tensors : require
+
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+layout(set = 0, binding = 0) uniform tensorARM<uint8_t, 3> imageTensor;
+
+void main() {
+    uint x = gl_GlobalInvocationID.x;
+    uint y = gl_GlobalInvocationID.y;
+    if (x >= tensorSizeARM(imageTensor, 1) || y >= tensorSizeARM(imageTensor, 0)) {
+        return;
+    }
+
+    uint coords[3] = uint[](y, x, 0u);
+    uint8_t value = uint8_t((y + 1u) * 16u + x);
+    tensorWriteARM(imageTensor, coords, value);
+}

--- a/tests/tensor/tensor_arm_tests.cpp
+++ b/tests/tensor/tensor_arm_tests.cpp
@@ -1,0 +1,39 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+#include <gtest/gtest.h>
+
+#include "tensor_arm_detail.hpp"
+
+#include <vector>
+
+namespace {
+
+TEST(TensorARM, LinearImageAliasingUsesImageRowPitch) {
+    const std::vector<int64_t> dimensions{4, 8, 1};
+    std::vector<int64_t> strides{8, 1, 1};
+    const VkTensorDescriptionARM description{
+        VK_STRUCTURE_TYPE_TENSOR_DESCRIPTION_ARM,
+        nullptr,
+        VK_TENSOR_TILING_LINEAR_ARM,
+        VK_FORMAT_R8_UNORM,
+        static_cast<uint32_t>(dimensions.size()),
+        dimensions.data(),
+        strides.data(),
+        VK_TENSOR_USAGE_IMAGE_ALIASING_BIT_ARM,
+    };
+    const VkSubresourceLayout imageLayout{
+        0, 64, 16, 64, 64,
+    };
+
+    ASSERT_TRUE(mlsdk::el::layer::tensor_arm_detail::usesImageAliasing(description));
+
+    mlsdk::el::layer::tensor_arm_detail::updateAliasedStrides(dimensions.size(), strides, imageLayout);
+
+    EXPECT_EQ(strides[0], static_cast<int64_t>(imageLayout.rowPitch));
+}
+
+} // namespace

--- a/tests/vulkan.cpp
+++ b/tests/vulkan.cpp
@@ -1862,6 +1862,103 @@ TEST_F(MLEmulationLayerForVulkan, CreateTensorComputePipeline) {
 }
 #endif
 
+TEST_F(MLEmulationLayerForVulkan, LinearTensorImageAliasingUsesImageRowPitch) {
+    constexpr uint32_t width = 7;
+    constexpr uint32_t height = 4;
+    const std::vector<int64_t> dimensions{height, width, 1};
+
+    auto device = createDevice();
+    vk::raii::DeviceMemory aliasedMemory{nullptr};
+
+    const vk::TensorDescriptionARM tensorDescription{
+        vk::TensorTilingARM::eLinear,
+        vk::Format::eR8Uint,
+        static_cast<uint32_t>(dimensions.size()),
+        dimensions.data(),
+        nullptr,
+        vk::TensorUsageFlagBitsARM::eShader | vk::TensorUsageFlagBitsARM::eImageAliasing,
+    };
+    const vk::TensorCreateInfoARM tensorCreateInfo{
+        {}, &tensorDescription, vk::SharingMode::eExclusive, 0, nullptr,
+    };
+    vk::raii::TensorARM destinationTensor{&(*device), tensorCreateInfo};
+
+    vk::ImageCreateInfo imageCreateInfo{};
+    imageCreateInfo.setImageType(vk::ImageType::e2D)
+        .setFormat(vk::Format::eR8Uint)
+        .setExtent(vk::Extent3D{width, height, 1})
+        .setMipLevels(1)
+        .setArrayLayers(1)
+        .setSamples(vk::SampleCountFlagBits::e1)
+        .setTiling(vk::ImageTiling::eLinear)
+        .setUsage(vk::ImageUsageFlagBits::eTransferSrc | vk::ImageUsageFlagBits::eTensorAliasingARM)
+        .setSharingMode(vk::SharingMode::eExclusive)
+        .setInitialLayout(vk::ImageLayout::eUndefined);
+    vk::raii::Image image{&(*device), imageCreateInfo};
+
+    const vk::TensorMemoryRequirementsInfoARM tensorRequirementsInfo{*destinationTensor};
+    const auto tensorRequirements = (&(*device)).getTensorMemoryRequirementsARM(tensorRequirementsInfo);
+    const auto imageRequirements = image.getMemoryRequirements();
+    const auto memoryTypeBits = tensorRequirements.memoryRequirements.memoryTypeBits & imageRequirements.memoryTypeBits;
+    const auto memoryTypeIndices = device->getPhysicalDevice()->getMemoryTypeIndices(
+        vk::MemoryPropertyFlagBits::eHostVisible | vk::MemoryPropertyFlagBits::eHostCoherent, memoryTypeBits);
+    ASSERT_FALSE(memoryTypeIndices.empty());
+
+    const vk::MemoryAllocateFlagsInfo allocateFlags{vk::MemoryAllocateFlagBits::eDeviceAddress};
+    const vk::MemoryAllocateInfo allocateInfo{
+        std::max(tensorRequirements.memoryRequirements.size, imageRequirements.size),
+        memoryTypeIndices.front(),
+        &allocateFlags,
+    };
+    aliasedMemory = vk::raii::DeviceMemory{&(*device), allocateInfo};
+    image.bindMemory(*aliasedMemory, 0);
+    const vk::BindTensorMemoryInfoARM bindTensorInfo{*destinationTensor, *aliasedMemory, 0};
+    (&(*device)).bindTensorMemoryARM(bindTensorInfo);
+
+    const vk::ImageSubresource subresource{vk::ImageAspectFlagBits::eColor, 0, 0};
+    const auto imageLayout = image.getSubresourceLayout(subresource);
+    if (imageLayout.rowPitch == width) {
+        GTEST_SKIP() << "The Vulkan driver did not pad the linear image row pitch";
+    }
+
+    auto *mappedMemory = static_cast<uint8_t *>(aliasedMemory.mapMemory(0, VK_WHOLE_SIZE));
+    std::fill(mappedMemory, mappedMemory + allocateInfo.allocationSize, uint8_t{0});
+    aliasedMemory.unmapMemory();
+
+    const vk::TensorViewCreateInfoARM tensorViewCreateInfo{
+        {},
+        *destinationTensor,
+        vk::Format::eR8Uint,
+    };
+    vk::raii::TensorViewARM tensorView{&(*device), tensorViewCreateInfo};
+
+    auto placeholderTensor = std::make_shared<Tensor>(device, Shape{vk::Format::eR8Uint, dimensions});
+    const TensorComputePipeline::DescriptorMap descriptorMap = {{{0, {placeholderTensor}}}};
+    const auto spirv = mlsdk::el::utils::glslToSpirv(fileToString("tensor_image_alias.comp"));
+    TensorComputePipeline computePipeline{device, descriptorMap, spirv};
+    auto [descriptorPool, descriptorSets] = computePipeline.createDescriptorSets(descriptorMap);
+
+    const vk::WriteDescriptorSetTensorARM tensorWriteInfo{
+        1,
+        &(*tensorView),
+    };
+    const vk::WriteDescriptorSet descriptorWrite{
+        *descriptorSets.front(), 0, 0, 1, vk::DescriptorType::eTensorARM, nullptr, nullptr, nullptr, &tensorWriteInfo,
+    };
+    (&(*device)).updateDescriptorSets({descriptorWrite}, {});
+    computePipeline.dispatchSubmit(descriptorSets, width, height, 1);
+
+    mappedMemory = static_cast<uint8_t *>(aliasedMemory.mapMemory(0, VK_WHOLE_SIZE));
+    for (uint32_t y = 0; y < height; ++y) {
+        for (uint32_t x = 0; x < width; ++x) {
+            const auto expected = static_cast<uint8_t>((y + 1) * 16 + x);
+            EXPECT_EQ(mappedMemory[imageLayout.offset + y * imageLayout.rowPitch + x], expected)
+                << "Mismatch at image coordinate (" << x << ", " << y << ")";
+        }
+    }
+    aliasedMemory.unmapMemory();
+}
+
 TEST_F(MLEmulationLayerForVulkan, ShapeGetElementOffsetNonPacked) {
     const Shape shape{vk::Format::eR64Sint, {2, 3, 4}, {160, 40, 8}};
 

--- a/utilities/include/mlel/pipeline.hpp
+++ b/utilities/include/mlel/pipeline.hpp
@@ -160,6 +160,7 @@ class TensorComputePipeline : public PipelineBase {
                           const std::vector<uint32_t> &_spirv);
 
     void dispatchSubmit(uint32_t _x, uint32_t _y, uint32_t _z);
+    void dispatchSubmit(const vk::raii::DescriptorSets &descriptorSets, uint32_t _x, uint32_t _y, uint32_t _z);
 
   private:
     vk::raii::Pipeline createPipeline() const;

--- a/utilities/pipeline.cpp
+++ b/utilities/pipeline.cpp
@@ -510,6 +510,12 @@ TensorComputePipeline::TensorComputePipeline(std::shared_ptr<Device> &_device, c
 void TensorComputePipeline::dispatchSubmit(uint32_t _x, uint32_t _y, uint32_t _z) {
     [[maybe_unused]] auto [_, descriptorSets] = createDescriptorSets(descriptorMap);
 
+    dispatchSubmit(descriptorSets, _x, _y, _z);
+}
+
+void TensorComputePipeline::dispatchSubmit(const vk::raii::DescriptorSets &descriptorSets, uint32_t _x, uint32_t _y,
+                                           uint32_t _z) {
+
     auto commandBuffer = createCommandBuffer();
 
     const vk::CommandBufferBeginInfo commandBufferBeginInfo{


### PR DESCRIPTION
Linear tensors using image aliasing retained packed strides because the alias metadata was updated only for optimal tiling. Tensor accesses then disagreed with padded linear image row and depth pitches, distorting image sampling.

Detect aliasing from the tensor usage bit and update strides from the image subresource layout. Add a regression test for padded row pitches.

Change-Id: I73378a210195d795324ba5500700bcc93531a690