### PR TITLE
build(layers): split implementations into libraries

### DIFF
--- a/graph/CMakeLists.txt
+++ b/graph/CMakeLists.txt
@@ -3,24 +3,21 @@
 #
 
 ###############################################################################
-# Graph layer
+# MLELGraph core algorithms and utilities
 ###############################################################################
 
 add_subdirectory(shaders)
 
-add_library(VkLayer_Graph SHARED)
+add_library(MLELGraph STATIC)
 
-add_library(${ML_SDK_EL_NAMESPACE}::VkLayer_Graph ALIAS VkLayer_Graph)
+add_library(${ML_SDK_EL_NAMESPACE}::MLELGraph ALIAS MLELGraph)
 
-target_set_vulkan_exports(VkLayer_Graph)
+target_compile_options(MLELGraph PRIVATE ${VMEL_COMPILE_OPTIONS})
 
-target_compile_options(VkLayer_Graph PRIVATE ${VMEL_COMPILE_OPTIONS})
-
-target_sources(VkLayer_Graph PRIVATE
+target_sources(MLELGraph PRIVATE
     compute_graph_op.cpp
     compute_optical_flow.cpp
     compute_pipeline_common.cpp
-    graph_layer.cpp
     graph_log.cpp
     graph_profiler.cpp
     image.cpp
@@ -33,17 +30,39 @@ target_sources(VkLayer_Graph PRIVATE
     spirv_pass_tosaspv_v100.cpp
     tensor.cpp)
 
-# Generated GLSL shaders
-add_dependencies(VkLayer_Graph
+# Generated GLSL shaders dependency
+add_dependencies(MLELGraph
     mlel_generate_glsl_header)
 
-# Pre compiled SPIR-V modules
-add_dependencies(VkLayer_Graph
+# Pre-compiled SPIR-V modules dependency
+add_dependencies(MLELGraph
     mlel_generate_spv_header)
 
-target_link_libraries(VkLayer_Graph PRIVATE
+target_link_libraries(MLELGraph PUBLIC
     VkLayer_Common
     nlohmann_json::nlohmann_json)
+
+target_include_directories(MLELGraph PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
+
+###############################################################################
+# VkLayer_Graph Vulkan layer
+###############################################################################
+
+add_library(VkLayer_Graph SHARED)
+
+add_library(${ML_SDK_EL_NAMESPACE}::VkLayer_Graph ALIAS VkLayer_Graph)
+
+target_set_vulkan_exports(VkLayer_Graph)
+
+target_compile_options(VkLayer_Graph PRIVATE ${VMEL_COMPILE_OPTIONS})
+
+target_sources(VkLayer_Graph PRIVATE
+    graph_layer.cpp)
+
+target_link_libraries(VkLayer_Graph PRIVATE
+    MLELGraph)
 
 target_include_directories(VkLayer_Graph PRIVATE
     ${CMAKE_CURRENT_BINARY_DIR})

--- a/tensor/CMakeLists.txt
+++ b/tensor/CMakeLists.txt
@@ -2,6 +2,37 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+###############################################################################
+# MLELTensor core algorithms and utilities
+###############################################################################
+
+add_library(MLELTensor STATIC)
+
+add_library(${ML_SDK_EL_NAMESPACE}::MLELTensor ALIAS MLELTensor)
+
+target_compile_options(MLELTensor PRIVATE ${VMEL_COMPILE_OPTIONS})
+
+target_sources(MLELTensor PRIVATE
+    tensor_processor.cpp
+    tensor_arm.cpp
+    tensor_log.cpp
+    tensor_view.cpp
+    tensor_descriptor.cpp
+    spirv_glsl_tensor_buffer.cpp)
+
+target_link_libraries(MLELTensor PUBLIC
+    VkLayer_Common
+    spirv-cross-core
+    spirv-cross-glsl)
+
+target_include_directories(MLELTensor PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
+
+###############################################################################
+# VkLayer_Tensor Vulkan layer
+###############################################################################
+
 add_library(VkLayer_Tensor SHARED)
 
 add_library(${ML_SDK_EL_NAMESPACE}::VkLayer_Tensor ALIAS VkLayer_Tensor)
@@ -11,18 +42,10 @@ target_set_vulkan_exports(VkLayer_Tensor)
 target_compile_options(VkLayer_Tensor PRIVATE ${VMEL_COMPILE_OPTIONS})
 
 target_sources(VkLayer_Tensor PRIVATE
-    tensor_layer.cpp
-    tensor_processor.cpp
-    tensor_arm.cpp
-    tensor_log.cpp
-    tensor_view.cpp
-    tensor_descriptor.cpp
-    spirv_glsl_tensor_buffer.cpp)
+    tensor_layer.cpp)
 
 target_link_libraries(VkLayer_Tensor PRIVATE
-    VkLayer_Common
-    spirv-cross-core
-    spirv-cross-glsl)
+    MLELTensor)
 
 install(TARGETS VkLayer_Tensor EXPORT ${ML_SDK_EL_PACKAGE_NAME}Config)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -31,9 +31,6 @@ function(mlel_add_test)
 endfunction()
 
 set(MLEL_UNIT_TEST_SOURCES
-    # Source files
-    ${CMAKE_CURRENT_SOURCE_DIR}/../graph/interval_memory_planner_detail.cpp
-    # Test files
     common/common_tests.cpp
     graph/spirv_pass_tests.cpp
     graph/interval_memory_planner_tests.cpp
@@ -67,12 +64,12 @@ mlel_add_test(
         SHADER_SOURCE_DIR=${SHADER_SOURCE_DIR}
     INCLUDE_DIRECTORIES
         ${CMAKE_CURRENT_SOURCE_DIR}
-        ${CMAKE_CURRENT_SOURCE_DIR}/../graph
-        ${CMAKE_CURRENT_SOURCE_DIR}/../tensor
     LIBRARIES
         mlelutilities
         nlohmann_json::nlohmann_json
         VkLayer_Common
+        MLELGraph
+        MLELTensor
     PROPERTIES
         ${MLEL_UNIT_TEST_PROPERTIES}
 )


### PR DESCRIPTION
Move reusable graph and tensor sources into static libraries.

Keep Vulkan entry points in their shared layer targets.

Link unit tests to the reusable targets for class-level coverage.

Change-Id: I782a58b7905dfde05ee5c7b7cc7f4ada03f9ce2c