### PR TITLE
feat: configure Vulkan portability subset only when necessary

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,7 @@
 ### Build, Packaging & Developer Experience
 
 - Updated Emulation Layer `--version` output to report the package version and include git revision and dependency revision information
+- Enabled KosmicKrisp compatibility automatically based on selected driver.
 
 ### Bug Fixes
 

--- a/common/include/mlel/utils.hpp
+++ b/common/include/mlel/utils.hpp
@@ -41,6 +41,8 @@ inline void replaceAll(std::string &str, std::string_view pattern, std::string_v
     }
 }
 
+bool hasExtension(const std::vector<vk::ExtensionProperties> &extensionProperties, std::string_view extension);
+
 /// Gets the total number of elements in a tensor given its dimensions, throws if result is negative.
 size_t getElementCount(const std::vector<int64_t> &dimensions);
 

--- a/common/utils.cpp
+++ b/common/utils.cpp
@@ -11,6 +11,7 @@
 #include "mlel/utils.hpp"
 #include "mlel/log.hpp"
 
+#include <algorithm>
 #include <functional>
 #include <numeric>
 
@@ -24,6 +25,12 @@ namespace mlsdk::el::utils {
 namespace {
 Log layerLog("VMEL_COMMON_SEVERITY", "Layer");
 } // namespace
+
+bool hasExtension(const std::vector<vk::ExtensionProperties> &extensionProperties, std::string_view extension) {
+    return std::any_of(extensionProperties.begin(), extensionProperties.end(), [&](const auto &property) {
+        return std::string_view{property.extensionName.data()} == extension;
+    });
+}
 
 size_t getElementCount(const std::vector<int64_t> &dimensions) {
     auto result = std::accumulate(dimensions.begin(), dimensions.end(), int64_t(1), std::multiplies<int64_t>());

--- a/tests/vulkan.cpp
+++ b/tests/vulkan.cpp
@@ -21,6 +21,7 @@
 
 #include <spirv-tools/libspirv.hpp>
 #include <vulkan/vulkan.hpp>
+#include <vulkan/vulkan_beta.h>
 
 #include <algorithm>
 #include <array>
@@ -68,11 +69,12 @@ vk::raii::Instance createInstance(vk::raii::Context &ctx, std::vector<const char
         VK_MAKE_API_VERSION(1, 3, 0, 0), // engine version
         VK_API_VERSION_1_3,              // api version
     };
-    vk::InstanceCreateFlags flags;
-#ifdef EXPERIMENTAL_MOLTEN_VK_SUPPORT
-    enabledExtensions.push_back(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME);
-    flags = vk::InstanceCreateFlagBits::eEnumeratePortabilityKHR;
-#endif
+    vk::InstanceCreateFlags flags{};
+    const auto extensionProperties = ctx.enumerateInstanceExtensionProperties();
+    if (mlsdk::el::utils::hasExtension(extensionProperties, VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME)) {
+        enabledExtensions.push_back(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME);
+        flags = vk::InstanceCreateFlagBits::eEnumeratePortabilityKHR;
+    }
 
     const vk::InstanceCreateInfo instanceCreateInfo{
         flags,                                           // flags
@@ -89,17 +91,9 @@ vk::raii::Instance createInstance(vk::raii::Context &ctx, std::vector<const char
 bool hasExtensionProperties(const vk::raii::PhysicalDevice &physicalDevice,
                             const std::vector<const char *> &extensions) {
     const auto extensionProperties = physicalDevice.enumerateDeviceExtensionProperties();
-
-    for (const auto &extension : extensions) {
-        auto it = std::find_if(extensionProperties.begin(), extensionProperties.end(), [&](const auto &property) {
-            return std::strcmp(property.extensionName, extension) == 0;
-        });
-        if (it == extensionProperties.end()) {
-            return false;
-        }
-    }
-
-    return true;
+    return std::all_of(extensions.begin(), extensions.end(), [&](const auto &extension) {
+        return mlsdk::el::utils::hasExtension(extensionProperties, extension);
+    });
 }
 
 std::array<const float, 16> queuePriorities = {1.0f};
@@ -125,31 +119,34 @@ std::vector<vk::DeviceQueueCreateInfo> getQueueCreateInfo(const vk::raii::Physic
     return queueCreateInfo;
 }
 
-std::tuple<vk::raii::Device, vk::raii::PhysicalDevice> createDevice(vk::raii::Instance &instance,
-                                                                    std::vector<const char *> enabledLayers = {},
-                                                                    std::vector<const char *> enabledExtensions = {}) {
+std::tuple<vk::raii::Device, vk::raii::PhysicalDevice>
+createDevice(vk::raii::Instance &instance, std::vector<const char *> enabledLayers = {},
+             const std::vector<const char *> &enabledExtensions = {}) {
     for (const auto &physicalDevice : vk::raii::PhysicalDevices{instance}) {
         // Verify that device supports compute queues
         const auto queueCreateInfo = getQueueCreateInfo(physicalDevice, vk::QueueFlagBits::eCompute);
         if (queueCreateInfo.empty()) {
             continue;
         }
-#ifdef EXPERIMENTAL_MOLTEN_VK_SUPPORT
-        enabledExtensions.push_back("VK_KHR_portability_subset");
-#endif
+        auto deviceExtensions = enabledExtensions;
+        const auto extensionProperties = physicalDevice.enumerateDeviceExtensionProperties();
+        if (mlsdk::el::utils::hasExtension(extensionProperties, VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME)) {
+            deviceExtensions.push_back(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
+        }
+
         // Verify that device supports all enabled extensions
-        if (!hasExtensionProperties(physicalDevice, enabledExtensions)) {
+        if (!hasExtensionProperties(physicalDevice, deviceExtensions)) {
             continue;
         }
 
         const vk::DeviceCreateInfo deviceCreateInfo{
-            {},                                              // flags
-            static_cast<uint32_t>(queueCreateInfo.size()),   // queue create info count
-            queueCreateInfo.data(),                          // queue create infos
-            static_cast<uint32_t>(enabledLayers.size()),     // enabled layer count
-            enabledLayers.data(),                            // enabled layers
-            static_cast<uint32_t>(enabledExtensions.size()), // enabled extension count
-            enabledExtensions.data(),                        // enabled extensions
+            {},                                             // flags
+            static_cast<uint32_t>(queueCreateInfo.size()),  // queue create info count
+            queueCreateInfo.data(),                         // queue create infos
+            static_cast<uint32_t>(enabledLayers.size()),    // enabled layer count
+            enabledLayers.data(),                           // enabled layers
+            static_cast<uint32_t>(deviceExtensions.size()), // enabled extension count
+            deviceExtensions.data(),                        // enabled extensions
         };
 
         return {vk::raii::Device{physicalDevice, deviceCreateInfo}, physicalDevice};

--- a/utilities/device.cpp
+++ b/utilities/device.cpp
@@ -9,6 +9,9 @@
  *******************************************************************************/
 
 #include "mlel/device.hpp"
+#include "mlel/utils.hpp"
+
+#include <vulkan/vulkan_beta.h>
 
 #include <algorithm>
 #include <map>
@@ -35,11 +38,12 @@ vk::raii::Instance Instance::createInstance(const std::vector<const char *> &lay
         VK_MAKE_VERSION(1, 3, 0), // api version
     };
     std::vector<const char *> exts = extensions;
-    vk::InstanceCreateFlags flags;
-#ifdef EXPERIMENTAL_MOLTEN_VK_SUPPORT
-    exts.push_back(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME);
-    flags = vk::InstanceCreateFlagBits::eEnumeratePortabilityKHR;
-#endif
+    vk::InstanceCreateFlags flags{};
+    const auto extensionProperties = context->enumerateInstanceExtensionProperties();
+    if (utils::hasExtension(extensionProperties, VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME)) {
+        exts.push_back(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME);
+        flags = vk::InstanceCreateFlagBits::eEnumeratePortabilityKHR;
+    }
     const vk::InstanceCreateInfo instanceCreateInfo{
         flags,                                // flags
         &applicationInfo,                     // application info
@@ -133,17 +137,8 @@ std::vector<uint32_t> PhysicalDevice::getMemoryTypeIndices(const vk::MemoryPrope
 bool PhysicalDevice::hasExtensionProperties(const vk::raii::PhysicalDevice &vkPhysicalDevice,
                                             const std::vector<const char *> &extensions) const {
     const auto extensionProperties = vkPhysicalDevice.enumerateDeviceExtensionProperties();
-
-    for (const auto &extension : extensions) {
-        auto it = std::find_if(extensionProperties.begin(), extensionProperties.end(), [&](const auto &property) {
-            return std::strcmp(property.extensionName, extension) == 0;
-        });
-        if (it == extensionProperties.end()) {
-            return false;
-        }
-    }
-
-    return true;
+    return std::all_of(extensions.begin(), extensions.end(),
+                       [&](const auto &extension) { return utils::hasExtension(extensionProperties, extension); });
 }
 
 std::vector<vk::raii::PhysicalDevice> PhysicalDevice::enumeratePhysicalDevices() const {
@@ -256,9 +251,12 @@ vk::raii::Device Device::createDevice(const std::vector<const char *> &layers,
                                       const std::vector<const char *> &extensions, const void *deviceFeatures) const {
     auto queueCreateInfo = physicalDevice->getQueueCreateInfo(vk::QueueFlagBits::eCompute);
     std::vector<const char *> exts = extensions;
-#ifdef EXPERIMENTAL_MOLTEN_VK_SUPPORT
-    exts.push_back("VK_KHR_portability_subset");
-#endif
+    const auto &vkPhysicalDevice = &(*physicalDevice);
+    const auto extensionProperties = vkPhysicalDevice.enumerateDeviceExtensionProperties();
+    if (utils::hasExtension(extensionProperties, VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME)) {
+        exts.push_back(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
+    }
+
     const vk::DeviceCreateInfo deviceCreateInfo{
         {},                                            // flags
         static_cast<uint32_t>(queueCreateInfo.size()), // queue create info count
@@ -270,7 +268,7 @@ vk::raii::Device Device::createDevice(const std::vector<const char *> &layers,
         nullptr,                                       // Don't set pEnabledFeatures here!
         deviceFeatures                                 // Attach deviceFeatures via pNext
     };
-    vk::raii::Device vkDevice(&(*physicalDevice), deviceCreateInfo);
+    vk::raii::Device vkDevice(vkPhysicalDevice, deviceCreateInfo);
 
     return vkDevice;
 }


### PR DESCRIPTION
Checks whether driver requests portability subset rather than defaulting to it on Darwin.

Change-Id: I359597fe6a3dcd7ca8965435c1861cc95220d03a