### PR TITLE
test: skip profiling tests on KosmicKrisp

### DIFF
--- a/tests/graph/optical_flow_tests.cpp
+++ b/tests/graph/optical_flow_tests.cpp
@@ -52,6 +52,14 @@ std::shared_ptr<Device> createDevice() {
     return std::make_shared<Device>(physicalDevice, extensions, &features2);
 }
 
+bool computeQueueSupportsTimestampQueries(const std::shared_ptr<Device> &device) {
+    const auto &physicalDevice = device->getPhysicalDevice();
+    const auto queueFamilyIndex = physicalDevice->getComputeFamilyIndex();
+    const auto queueFamilyProperties = (&(*physicalDevice)).getQueueFamilyProperties();
+    return queueFamilyIndex < queueFamilyProperties.size() &&
+           queueFamilyProperties[queueFamilyIndex].timestampValidBits != 0;
+}
+
 std::string queryPipelineTextProperty(const std::shared_ptr<Device> &device, VkPipeline pipeline,
                                       vk::DataGraphPipelinePropertyARM property) {
     const auto &vkDevice = &(*device);
@@ -722,6 +730,9 @@ TEST(MLEmulationLayerOpticalFlowForVulkan, ProfilingPropertyIncludesOpticalFlowS
     ScopedEnvironment enableProfiling{"VMEL_GRAPH_PROFILING", "1"};
 
     const auto device = createDevice();
+    if (!computeQueueSupportsTimestampQueries(device)) {
+        GTEST_SKIP() << "Compute queue family does not support timestamp queries";
+    }
     OpticalFlow::Config cfg;
     cfg.enableHint = true;
     cfg.enableCost = true;

--- a/tests/vulkan.cpp
+++ b/tests/vulkan.cpp
@@ -329,6 +329,14 @@ std::shared_ptr<Device> createDevice() {
     return std::make_shared<Device>(physicalDevice, extensions, &features2);
 }
 
+bool computeQueueSupportsTimestampQueries(const std::shared_ptr<Device> &device) {
+    const auto &physicalDevice = device->getPhysicalDevice();
+    const auto queueFamilyIndex = physicalDevice->getComputeFamilyIndex();
+    const auto queueFamilyProperties = (&(*physicalDevice)).getQueueFamilyProperties();
+    return queueFamilyIndex < queueFamilyProperties.size() &&
+           queueFamilyProperties[queueFamilyIndex].timestampValidBits != 0;
+}
+
 struct ProfilingGraph {
     GraphPipeline::DescriptorMap descriptorMap;
     std::shared_ptr<GraphPipeline> pipeline;
@@ -673,6 +681,9 @@ TEST_F(MLEmulationLayerForVulkan, GraphProfilingQueryableProperty) {
     ScopedEnvironment enableProfiling{"VMEL_GRAPH_PROFILING", "1"};
 
     auto device = createDevice();
+    if (!computeQueueSupportsTimestampQueries(device)) {
+        GTEST_SKIP() << "Compute queue family does not support timestamp queries";
+    }
     auto graph = makeMaxPoolProfilingGraph(device);
     graph.pipeline->dispatchSubmit();
 
@@ -683,6 +694,9 @@ TEST_F(MLEmulationLayerForVulkan, GraphProfilingCollectsFenceLessSubmitOnQueueWa
     ScopedEnvironment enableProfiling{"VMEL_GRAPH_PROFILING", "1"};
 
     auto device = createDevice();
+    if (!computeQueueSupportsTimestampQueries(device)) {
+        GTEST_SKIP() << "Compute queue family does not support timestamp queries";
+    }
     auto graph = makeMaxPoolProfilingGraph(device);
     submitGraphWithoutFence(device, graph, false);
 
@@ -693,6 +707,9 @@ TEST_F(MLEmulationLayerForVulkan, GraphProfilingCollectsFenceLessSubmitOnDeviceW
     ScopedEnvironment enableProfiling{"VMEL_GRAPH_PROFILING", "1"};
 
     auto device = createDevice();
+    if (!computeQueueSupportsTimestampQueries(device)) {
+        GTEST_SKIP() << "Compute queue family does not support timestamp queries";
+    }
     auto graph = makeMaxPoolProfilingGraph(device);
     submitGraphWithoutFence(device, graph, true);
 
@@ -703,6 +720,9 @@ TEST_F(MLEmulationLayerForVulkan, GraphProfilingCollectsReusedCommandBufferSubmi
     ScopedEnvironment enableProfiling{"VMEL_GRAPH_PROFILING", "1"};
 
     auto device = createDevice();
+    if (!computeQueueSupportsTimestampQueries(device)) {
+        GTEST_SKIP() << "Compute queue family does not support timestamp queries";
+    }
     auto graph = makeMaxPoolProfilingGraph(device);
     submitGraphCommandBufferTwiceWithoutIntermediateWait(device, graph);
 
@@ -725,6 +745,9 @@ TEST_F(MLEmulationLayerForVulkan, GraphProfilingIncludesMotionEngineGraphOps) {
     ScopedEnvironment enableProfiling{"VMEL_GRAPH_PROFILING", "1"};
 
     auto device = createDevice();
+    if (!computeQueueSupportsTimestampQueries(device)) {
+        GTEST_SKIP() << "Compute queue family does not support timestamp queries";
+    }
     auto graph = makeRawSadProfilingGraph(device);
     graph.pipeline->dispatchSubmit();
 


### PR DESCRIPTION
KosmicKrisp reports timestampValidBits == 0 for its compute queue. Since unable to record before/after timestamps, tests should be skipped otherwise an error is thrown.

Change-Id: I11819d4b183fc3d100ed8c05d7477b37233ff4b5