### PR TITLE
test: Deduplicate computeQueueSupportsTimestampQueries

### DIFF
--- a/tests/graph/optical_flow_tests.cpp
+++ b/tests/graph/optical_flow_tests.cpp
@@ -21,6 +21,7 @@
 #include <vector>
 
 using namespace mlsdk::el::utilities;
+using mlsdk::el::tests::computeQueueSupportsTimestampQueries;
 using mlsdk::el::tests::ScopedEnvironment;
 
 namespace {
@@ -50,14 +51,6 @@ std::shared_ptr<Device> createDevice() {
     auto physicalDevice = std::make_shared<PhysicalDevice>(instance, extensions);
 
     return std::make_shared<Device>(physicalDevice, extensions, &features2);
-}
-
-bool computeQueueSupportsTimestampQueries(const std::shared_ptr<Device> &device) {
-    const auto &physicalDevice = device->getPhysicalDevice();
-    const auto queueFamilyIndex = physicalDevice->getComputeFamilyIndex();
-    const auto queueFamilyProperties = (&(*physicalDevice)).getQueueFamilyProperties();
-    return queueFamilyIndex < queueFamilyProperties.size() &&
-           queueFamilyProperties[queueFamilyIndex].timestampValidBits != 0;
 }
 
 std::string queryPipelineTextProperty(const std::shared_ptr<Device> &device, VkPipeline pipeline,

--- a/tests/test_utils.hpp
+++ b/tests/test_utils.hpp
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include "mlel/device.hpp"
 #include <optional>
 #include <string>
 
@@ -28,5 +29,13 @@ class ScopedEnvironment {
     std::string name;
     std::optional<std::string> oldValue;
 };
+
+inline bool computeQueueSupportsTimestampQueries(const std::shared_ptr<mlsdk::el::utilities::Device> &device) {
+    const auto &physicalDevice = device->getPhysicalDevice();
+    const auto queueFamilyIndex = physicalDevice->getComputeFamilyIndex();
+    const auto queueFamilyProperties = (&(*physicalDevice)).getQueueFamilyProperties();
+    return queueFamilyIndex < queueFamilyProperties.size() &&
+           queueFamilyProperties[queueFamilyIndex].timestampValidBits != 0;
+}
 
 } // namespace mlsdk::el::tests

--- a/tests/vulkan.cpp
+++ b/tests/vulkan.cpp
@@ -41,6 +41,7 @@
 #include <vector>
 
 using namespace mlsdk::el::utilities;
+using mlsdk::el::tests::computeQueueSupportsTimestampQueries;
 using mlsdk::el::tests::ScopedEnvironment;
 
 /*******************************************************************************
@@ -324,14 +325,6 @@ std::shared_ptr<Device> createDevice() {
     auto physicalDevice = std::make_shared<PhysicalDevice>(instance, extensions);
 
     return std::make_shared<Device>(physicalDevice, extensions, &features2);
-}
-
-bool computeQueueSupportsTimestampQueries(const std::shared_ptr<Device> &device) {
-    const auto &physicalDevice = device->getPhysicalDevice();
-    const auto queueFamilyIndex = physicalDevice->getComputeFamilyIndex();
-    const auto queueFamilyProperties = (&(*physicalDevice)).getQueueFamilyProperties();
-    return queueFamilyIndex < queueFamilyProperties.size() &&
-           queueFamilyProperties[queueFamilyIndex].timestampValidBits != 0;
 }
 
 struct ProfilingGraph {


### PR DESCRIPTION
Move computeQueueSupportsTimestampQueries to test_utils.hpp to prevent duplication.

Change-Id: I8c629b42aa2382c1ebbc71e857054aa273655917