### PR TITLE
fix: mark BF16/float8 tensor shader access unsupported

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -9,6 +9,13 @@
 - Updated Emulation Layer `--version` output to report the package version and include git revision and dependency revision information
 - Enabled KosmicKrisp compatibility automatically based on selected driver.
 
+### Tensor Shader Support
+
+- Disabled advertising `VK_FORMAT_FEATURE_2_TENSOR_SHADER_BIT_ARM` for BF16,
+  E4M3, and E5M2 float formats because the tensor shader translator does not
+  yet fully lower BF16 and float8 values and conversions. Tensor copy/transfer and
+  data-graph support remains advertised.
+
 ### Bug Fixes
 
 - Fixed linear tensor/image aliasing to honor padded image row and depth pitches.

--- a/tensor/tensor_layer.cpp
+++ b/tensor/tensor_layer.cpp
@@ -116,6 +116,14 @@ constexpr VkLayerProperties layerProperties = {
 
 using VulkanLayerImpl = VulkanLayer<layerProperties, extensions, requiredExtensions, TensorDevice>;
 
+namespace {
+constexpr bool isSupportedShaderTensorFormat(VkFormat format) {
+    return format != VK_FORMAT_R16_SFLOAT_FPENCODING_BFLOAT16_ARM &&
+           format != VK_FORMAT_R8_SFLOAT_FPENCODING_FLOAT8E4M3_ARM &&
+           format != VK_FORMAT_R8_SFLOAT_FPENCODING_FLOAT8E5M2_ARM;
+}
+} // namespace
+
 class TensorLayer : public VulkanLayerImpl {
   public:
     static PFN_vkVoidFunction VKAPI_CALL vkGetDeviceProcAddr(VkDevice device, const char *name) {
@@ -791,9 +799,12 @@ class TensorLayer : public VulkanLayerImpl {
             pFormatProperties->pNext, VK_STRUCTURE_TYPE_TENSOR_FORMAT_PROPERTIES_ARM);
         handle->loader->vkGetPhysicalDeviceFormatProperties2(physicalDevice, format, pFormatProperties);
         if (pTensorFormatProp) {
-            pTensorFormatProp->optimalTilingTensorFeatures =
-                VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT | VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT |
-                VK_FORMAT_FEATURE_2_TENSOR_SHADER_BIT_ARM | VK_FORMAT_FEATURE_2_TENSOR_DATA_GRAPH_BIT_ARM;
+            pTensorFormatProp->optimalTilingTensorFeatures = VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT |
+                                                             VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT |
+                                                             VK_FORMAT_FEATURE_2_TENSOR_DATA_GRAPH_BIT_ARM;
+            if (isSupportedShaderTensorFormat(format)) {
+                pTensorFormatProp->optimalTilingTensorFeatures |= VK_FORMAT_FEATURE_2_TENSOR_SHADER_BIT_ARM;
+            }
             pTensorFormatProp->linearTilingTensorFeatures = pTensorFormatProp->optimalTilingTensorFeatures;
         }
     }


### PR DESCRIPTION
Do not advertise VK_FORMAT_FEATURE_2_TENSOR_SHADER_BIT_ARM for formats whose translated shader
support is incomplete, while retaining tensor transfer and data-graph support.

Change-Id: I9825095826955f922ee716ce510eb78a22c7d5c5