### PR TITLE
fix: Correct optical flow resource bindings

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -19,6 +19,8 @@
 ### Bug Fixes
 
 - Fixed linear tensor/image aliasing to honor padded image row and depth pitches.
+- Fixed optical-flow image/buffer alias alignment and tensor descriptor binding
+  flag substitution.
 
 ## Version 0.10.0 – *Optical Flow, Graph Profiling & Runtime Refinement*
 

--- a/graph/image.cpp
+++ b/graph/image.cpp
@@ -161,6 +161,25 @@ void Image::makeBufferAlias() {
         VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT;
     bufferInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
 
+    VkMemoryRequirements2 bufferMrqs{};
+    bufferMrqs.sType = VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2;
+    const VkDeviceBufferMemoryRequirements memInfo = {
+        VK_STRUCTURE_TYPE_DEVICE_BUFFER_MEMORY_REQUIREMENTS,
+        nullptr,
+        &bufferInfo,
+    };
+    loader_->vkGetDeviceBufferMemoryRequirements(device_, &memInfo, &bufferMrqs);
+
+    // The image and its buffer alias are bound at the same offset. That offset and
+    // allocation must therefore satisfy the requirements of both resources.
+    const auto memoryTypeBits = memoryRequirements_.memoryTypeBits & bufferMrqs.memoryRequirements.memoryTypeBits;
+    if (memoryTypeBits == 0) {
+        throw std::runtime_error("Image and buffer alias have no compatible memory type");
+    }
+    memoryRequirements_.size = std::max(memoryRequirements_.size, bufferMrqs.memoryRequirements.size);
+    memoryRequirements_.alignment = std::lcm(memoryRequirements_.alignment, bufferMrqs.memoryRequirements.alignment);
+    memoryRequirements_.memoryTypeBits = memoryTypeBits;
+
     VkResult res = loader_->vkCreateBuffer(device_, &bufferInfo, VK_NULL_HANDLE, &buffer_);
     if (res != VK_SUCCESS) {
         throw std::runtime_error("Failed to create buffer alias");

--- a/tensor/descriptor_binding.hpp
+++ b/tensor/descriptor_binding.hpp
@@ -23,9 +23,7 @@ template <typename T> inline bool hasTensor(const T &obj) {
 inline bool hasTensor(const VkDescriptorPoolSize &obj) { return obj.type == VK_DESCRIPTOR_TYPE_TENSOR_ARM; }
 
 inline std::vector<VkDescriptorSetLayoutBinding>
-substituteTensorBinding(uint32_t bindingCount, const VkDescriptorSetLayoutBinding *pBindings,
-                        const VkDescriptorSetLayoutBindingFlagsCreateInfo *bindingInfo,
-                        const bool supportsBufferUpdateAfterBind) {
+substituteTensorBinding(uint32_t bindingCount, const VkDescriptorSetLayoutBinding *pBindings) {
     std::vector<VkDescriptorSetLayoutBinding> descriptorSetLayoutBindings{pBindings, pBindings + bindingCount};
 
     // Loop over bindings and replace tensors bindings with uniform buffer for tensor descriptor (plus a storage buffer
@@ -46,16 +44,40 @@ substituteTensorBinding(uint32_t bindingCount, const VkDescriptorSetLayoutBindin
                 nullptr                                                        // VkSampler
             });
 #endif
-
-            // Preserve UPDATE_AFTER_BIND only when rewritten buffer descriptors support it.
-            if (!supportsBufferUpdateAfterBind && bindingInfo && bindingInfo->pBindingFlags) {
-                const_cast<VkDescriptorBindingFlags *>(bindingInfo->pBindingFlags)[i] &=
-                    static_cast<VkDescriptorBindingFlags>(~VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT);
-            }
         }
     }
 
     return descriptorSetLayoutBindings;
+}
+
+inline std::vector<VkDescriptorBindingFlags>
+substituteTensorBindingFlags(uint32_t bindingCount, const VkDescriptorSetLayoutBinding *pBindings,
+                             const VkDescriptorSetLayoutBindingFlagsCreateInfo &bindingInfo,
+                             const bool supportsBufferUpdateAfterBind) {
+    std::vector<VkDescriptorBindingFlags> bindingFlags(bindingCount, 0);
+    if (bindingInfo.pBindingFlags) {
+        const auto flagCount = std::min(bindingCount, bindingInfo.bindingCount);
+        std::copy_n(bindingInfo.pBindingFlags, flagCount, bindingFlags.begin());
+    }
+    if (!supportsBufferUpdateAfterBind) {
+        for (uint32_t i = 0; i < bindingCount; ++i) {
+            if (hasTensor(pBindings[i])) {
+                bindingFlags[i] &= static_cast<VkDescriptorBindingFlags>(~VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT);
+            }
+        }
+    }
+
+#ifdef EXPERIMENTAL_MOLTEN_VK_SUPPORT
+    // substituteTensorBinding appends each raw tensor storage-buffer binding after
+    // all original bindings, so append its flag in the same order.
+    for (uint32_t i = 0; i < bindingCount; ++i) {
+        if (hasTensor(pBindings[i])) {
+            bindingFlags.emplace_back(bindingFlags[i]);
+        }
+    }
+#endif
+
+    return bindingFlags;
 }
 
 inline std::tuple<std::vector<VkWriteDescriptorSet>, std::list<VkDescriptorBufferInfo>,

--- a/tensor/tensor_layer.cpp
+++ b/tensor/tensor_layer.cpp
@@ -511,23 +511,19 @@ class TensorLayer : public VulkanLayerImpl {
         const auto *bindingInfo = findType<VkDescriptorSetLayoutBindingFlagsCreateInfo>(
             pCreateInfo, VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO);
 
-        const auto bindings = descriptor_binding::substituteTensorBinding(
-            pCreateInfo->bindingCount, pCreateInfo->pBindings, bindingInfo, supportsBufferUpdateAfterBind);
+        const auto bindings =
+            descriptor_binding::substituteTensorBinding(pCreateInfo->bindingCount, pCreateInfo->pBindings);
 
-#ifdef EXPERIMENTAL_MOLTEN_VK_SUPPORT
+        const bool substituteBindingFlags =
+            bindingInfo && std::any_of(pCreateInfo->pBindings, pCreateInfo->pBindings + pCreateInfo->bindingCount,
+                                       descriptor_binding::hasTensor<VkDescriptorSetLayoutBinding>);
         std::vector<VkDescriptorBindingFlags> bindingFlags;
-        if (bindingInfo) {
-            for (uint32_t i = 0; i < pCreateInfo->bindingCount; ++i) {
-                const VkDescriptorBindingFlags bindingFlag =
-                    bindingInfo->pBindingFlags ? bindingInfo->pBindingFlags[i] : 0;
-                bindingFlags.push_back(bindingFlag);
-                bindingFlags.push_back(bindingFlag);
-            }
-        } else {
-            bindingFlags.resize(bindings.size(), 0);
+        if (substituteBindingFlags) {
+            bindingFlags = descriptor_binding::substituteTensorBindingFlags(
+                pCreateInfo->bindingCount, pCreateInfo->pBindings, *bindingInfo, supportsBufferUpdateAfterBind);
         }
 
-        const void *pNext = bindingInfo ? bindingInfo->pNext : pCreateInfo->pNext;
+        const void *pNext = substituteBindingFlags ? bindingInfo->pNext : pCreateInfo->pNext;
         const VkDescriptorSetLayoutBindingFlagsCreateInfo bindingFlagsCreateInfo{
             VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO,
             pNext,
@@ -536,21 +532,12 @@ class TensorLayer : public VulkanLayerImpl {
         };
 
         const VkDescriptorSetLayoutCreateInfo newCreateInfo{
-            pCreateInfo->sType,        // type
-            &bindingFlagsCreateInfo,   // next
-            pCreateInfo->flags,        // flags
-            uint32_t(bindings.size()), // binding count
-            bindings.data(),           // bindings
+            pCreateInfo->sType,                                       // type
+            substituteBindingFlags ? &bindingFlagsCreateInfo : pNext, // next
+            pCreateInfo->flags,                                       // flags
+            uint32_t(bindings.size()),                                // binding count
+            bindings.data(),                                          // bindings
         };
-#else
-        const VkDescriptorSetLayoutCreateInfo newCreateInfo{
-            pCreateInfo->sType,        // type
-            pCreateInfo->pNext,        // next
-            pCreateInfo->flags,        // flags
-            uint32_t(bindings.size()), // binding count
-            bindings.data(),           // bindings
-        };
-#endif
 
         return handle->loader->vkCreateDescriptorSetLayout(device, &newCreateInfo, pAllocator, pSetLayout);
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -34,6 +34,7 @@ set(MLEL_UNIT_TEST_SOURCES
     common/common_tests.cpp
     graph/spirv_pass_tests.cpp
     graph/interval_memory_planner_tests.cpp
+    tensor/descriptor_binding_tests.cpp
     tensor/tensor_arm_tests.cpp
     test_utils.cpp
     vulkan.cpp)

--- a/tests/tensor/descriptor_binding_tests.cpp
+++ b/tests/tensor/descriptor_binding_tests.cpp
@@ -1,0 +1,78 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+#include <gtest/gtest.h>
+
+#include "descriptor_binding.hpp"
+
+#include <vector>
+
+namespace {
+
+TEST(TensorDescriptors, NonTensorBindingFlagsAreNotDuplicated) {
+    const std::vector<VkDescriptorSetLayoutBinding> bindings{
+        {0, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
+        {1, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
+        {2, VK_DESCRIPTOR_TYPE_SAMPLER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
+    };
+    const std::vector<VkDescriptorBindingFlags> flags{
+        VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT,
+        VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT,
+        0,
+    };
+    const VkDescriptorSetLayoutBindingFlagsCreateInfo bindingInfo{
+        VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO,
+        nullptr,
+        static_cast<uint32_t>(flags.size()),
+        flags.data(),
+    };
+
+    const auto substitutedBindings = mlsdk::el::layer::descriptor_binding::substituteTensorBinding(
+        static_cast<uint32_t>(bindings.size()), bindings.data());
+    const auto substitutedFlags = mlsdk::el::layer::descriptor_binding::substituteTensorBindingFlags(
+        static_cast<uint32_t>(bindings.size()), bindings.data(), bindingInfo, true);
+
+    EXPECT_EQ(substitutedBindings.size(), bindings.size());
+    EXPECT_EQ(substitutedFlags, flags);
+}
+
+TEST(TensorDescriptors, TensorBindingFlagsFollowAppendedBufferAlias) { // cppcheck-suppress syntaxError
+    const std::vector<VkDescriptorSetLayoutBinding> bindings{
+        {0, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
+        {1, VK_DESCRIPTOR_TYPE_TENSOR_ARM, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
+    };
+    const std::vector<VkDescriptorBindingFlags> flags{
+        VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT,
+        VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT | VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT,
+    };
+    const VkDescriptorSetLayoutBindingFlagsCreateInfo bindingInfo{
+        VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO,
+        nullptr,
+        static_cast<uint32_t>(flags.size()),
+        flags.data(),
+    };
+
+    const auto substitutedBindings = mlsdk::el::layer::descriptor_binding::substituteTensorBinding(
+        static_cast<uint32_t>(bindings.size()), bindings.data());
+    const auto substitutedFlags = mlsdk::el::layer::descriptor_binding::substituteTensorBindingFlags(
+        static_cast<uint32_t>(bindings.size()), bindings.data(), bindingInfo, false);
+    const auto expectedTensorFlags = VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT;
+
+#ifdef EXPERIMENTAL_MOLTEN_VK_SUPPORT
+    ASSERT_EQ(substitutedBindings.size(), 3u);
+    ASSERT_EQ(substitutedFlags.size(), 3u);
+    EXPECT_EQ(substitutedBindings.back().descriptorType, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
+    EXPECT_EQ(substitutedFlags.back(), expectedTensorFlags);
+#else
+    ASSERT_EQ(substitutedBindings.size(), 2u);
+    ASSERT_EQ(substitutedFlags.size(), 2u);
+#endif
+    EXPECT_EQ(substitutedFlags[0], flags[0]);
+    EXPECT_EQ(substitutedFlags[1], expectedTensorFlags);
+    EXPECT_EQ(flags[1], VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT | VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT);
+}
+
+} // namespace


### PR DESCRIPTION
Fix memory alignment and prevent tensor binding flag duplication. Added regression tests. Enables NFRU on MoltenVK.

Change-Id: I5f292269f16cba58ae099a220b20c9e494b65558