### PR TITLE
fix(graph): split oversized Conv2D spatial dispatches

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -21,8 +21,8 @@
 - Fixed linear tensor/image aliasing to honor padded image row and depth pitches.
 - Fixed optical-flow image/buffer alias alignment and tensor descriptor binding
   flag substitution.
-- Split Conv2D output channels across multiple dispatches when the Z workgroup
-  count exceeds the physical-device limit.
+- Split oversized Conv2D workloads across multiple dispatches when any workgroup
+  count exceeds the corresponding physical-device limit.
 
 ### Bug Fixes
 

--- a/graph/compute_graph_op.cpp
+++ b/graph/compute_graph_op.cpp
@@ -916,13 +916,13 @@ Conv2D::Conv2D(const std::shared_ptr<VULKAN_HPP_NAMESPACE::detail::DispatchLoade
                const std::shared_ptr<TensorDescriptor> &_output, const std::shared_ptr<TensorDescriptor> &_weights,
                const std::shared_ptr<TensorDescriptor> &_biases, const std::vector<int32_t> &_pad,
                const std::vector<int32_t> &_stride, const std::vector<int32_t> &_dilation, const int8_t _inputZeroPoint,
-               const int8_t _weightZeroPoint, const uint32_t _accType, const uint32_t _maxGroupCountZ,
+               const int8_t _weightZeroPoint, const uint32_t _accType, const std::array<uint32_t, 3> &_maxGroupCount,
                const std::string &debugName)
     : ComputePipeline(_loader, _device, createDescriptorMap(_input, _output, _weights, _biases),
                       {&pushConstant, sizeof(pushConstant)}, _pipelineCache,
                       createSpirv(_pipelineCache, _input, _output, _weights, _accType), debugName),
       pushConstant{createPushConstant(_pad, _stride, _dilation, _inputZeroPoint, _weightZeroPoint)},
-      maxGroupCountZ{_maxGroupCountZ} {}
+      maxGroupCount{_maxGroupCount} {}
 
 Conv2D::PushConstant Conv2D::createPushConstant(const std::vector<int32_t> &pad, const std::vector<int32_t> &stride,
                                                 const std::vector<int32_t> &dilation, const int8_t inputZeroPoint,
@@ -944,7 +944,7 @@ Conv2D::PushConstant Conv2D::createPushConstant(const std::vector<int32_t> &pad,
             dilation[0],
             dilation[1],
         },
-        0,
+        {0, 0, 0},
     };
 
     return constant;
@@ -999,18 +999,26 @@ void Conv2D::cmdDispatch(VkCommandBuffer commandBuffer) {
     // Get first output tensor
     const auto &tensor = pipelineLayout->getTensorForSet(0);
     const auto &dimensions = tensor->getDimensions();
-    const auto groupCountX = divideRoundUp(static_cast<uint32_t>(dimensions[0] * dimensions[2]), warpX);
-    const auto groupCountY = divideRoundUp(static_cast<uint32_t>(dimensions[1]), warpY);
+    const auto totalGroupCountX = divideRoundUp(static_cast<uint32_t>(dimensions[0] * dimensions[2]), warpX);
+    const auto totalGroupCountY = divideRoundUp(static_cast<uint32_t>(dimensions[1]), warpY);
     const auto totalGroupCountZ = divideRoundUp(static_cast<uint32_t>(dimensions[3]), warpZ * 4);
 
-    for (uint32_t groupOffsetZ = 0; groupOffsetZ < totalGroupCountZ;) {
-        const auto groupCountZ = std::min(maxGroupCountZ, totalGroupCountZ - groupOffsetZ);
-        auto dispatchPushConstant = pushConstant;
-        dispatchPushConstant.outputChannelOffset = groupOffsetZ * warpZ * 4;
-        loader->vkCmdPushConstants(commandBuffer, pipelineLayout->getVkPipelineLayout(), VK_SHADER_STAGE_COMPUTE_BIT, 0,
-                                   sizeof(dispatchPushConstant), &dispatchPushConstant);
-        loader->vkCmdDispatch(commandBuffer, groupCountX, groupCountY, groupCountZ);
-        groupOffsetZ += groupCountZ;
+    for (uint32_t groupOffsetX = 0; groupOffsetX < totalGroupCountX; groupOffsetX += maxGroupCount[0]) {
+        const auto groupCountX = std::min(maxGroupCount[0], totalGroupCountX - groupOffsetX);
+        for (uint32_t groupOffsetY = 0; groupOffsetY < totalGroupCountY; groupOffsetY += maxGroupCount[1]) {
+            const auto groupCountY = std::min(maxGroupCount[1], totalGroupCountY - groupOffsetY);
+            for (uint32_t groupOffsetZ = 0; groupOffsetZ < totalGroupCountZ; groupOffsetZ += maxGroupCount[2]) {
+                const auto groupCountZ = std::min(maxGroupCount[2], totalGroupCountZ - groupOffsetZ);
+                auto dispatchPushConstant = pushConstant;
+                dispatchPushConstant.outputPositionOffset[0] = groupOffsetX * warpX;
+                dispatchPushConstant.outputPositionOffset[1] = groupOffsetY * warpY;
+                dispatchPushConstant.outputPositionOffset[2] = groupOffsetZ * warpZ * 4;
+                loader->vkCmdPushConstants(commandBuffer, pipelineLayout->getVkPipelineLayout(),
+                                           VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(dispatchPushConstant),
+                                           &dispatchPushConstant);
+                loader->vkCmdDispatch(commandBuffer, groupCountX, groupCountY, groupCountZ);
+            }
+        }
     }
 }
 
@@ -2374,7 +2382,11 @@ GraphPipeline::GraphPipeline(const std::shared_ptr<VULKAN_HPP_NAMESPACE::detail:
     : loader{_loader}, physicalDevice{_physicalDevice}, device{_device}, pipelineCache{_pipelineCache} {
     VkPhysicalDeviceProperties properties{};
     loader->vkGetPhysicalDeviceProperties(physicalDevice, &properties);
-    maxComputeWorkGroupCountZ = properties.limits.maxComputeWorkGroupCount[2];
+    maxComputeWorkGroupCount = {
+        properties.limits.maxComputeWorkGroupCount[0],
+        properties.limits.maxComputeWorkGroupCount[1],
+        properties.limits.maxComputeWorkGroupCount[2],
+    };
 }
 
 GraphPipeline::~GraphPipeline() {
@@ -2610,7 +2622,7 @@ void GraphPipeline::makeConv2D(const std::shared_ptr<TensorDescriptor> &input,
                                const int8_t inputZeroPoint, const int8_t weightZeroPoint, const uint32_t accType,
                                const std::string &debugName) {
     makePipeline<Conv2D>(input, output, weights, biases, pad, stride, dilation, inputZeroPoint, weightZeroPoint,
-                         accType, maxComputeWorkGroupCountZ, debugName);
+                         accType, maxComputeWorkGroupCount, debugName);
 }
 
 void GraphPipeline::makeConv3D(const std::shared_ptr<TensorDescriptor> &input,

--- a/graph/compute_graph_op.hpp
+++ b/graph/compute_graph_op.hpp
@@ -18,6 +18,7 @@
 #include <spirv-tools/libspirv.hpp>
 #include <vulkan/vulkan.hpp>
 
+#include <array>
 #include <cstdint>
 #include <functional>
 #include <map>
@@ -410,7 +411,8 @@ class Conv2D : public ComputePipeline {
            const std::shared_ptr<TensorDescriptor> &_output, const std::shared_ptr<TensorDescriptor> &_weights,
            const std::shared_ptr<TensorDescriptor> &_biases, const std::vector<int32_t> &_pad,
            const std::vector<int32_t> &_stride, const std::vector<int32_t> &_dilation, int8_t _inputZeroPoint,
-           int8_t _weightZeroPoint, uint32_t _accType, uint32_t _maxGroupCountZ, const std::string &debugName);
+           int8_t _weightZeroPoint, uint32_t _accType, const std::array<uint32_t, 3> &_maxGroupCount,
+           const std::string &debugName);
 
   private:
     struct PushConstant {
@@ -419,7 +421,7 @@ class Conv2D : public ComputePipeline {
         int32_t pad[4];
         int32_t stride[2];
         int32_t dilation[2];
-        uint32_t outputChannelOffset;
+        uint32_t outputPositionOffset[3];
     };
 
     PushConstant createPushConstant(const std::vector<int32_t> &pad, const std::vector<int32_t> &stride,
@@ -439,7 +441,7 @@ class Conv2D : public ComputePipeline {
     void cmdDispatch(VkCommandBuffer commandBuffer) override;
 
     PushConstant pushConstant;
-    uint32_t maxGroupCountZ;
+    std::array<uint32_t, 3> maxGroupCount;
 
     static constexpr std::string_view shaderName = "conv2d";
 
@@ -1516,7 +1518,7 @@ class GraphPipeline {
     std::shared_ptr<VULKAN_HPP_NAMESPACE::detail::DispatchLoaderDynamic> loader;
     VkPhysicalDevice physicalDevice;
     VkDevice device;
-    uint32_t maxComputeWorkGroupCountZ;
+    std::array<uint32_t, 3> maxComputeWorkGroupCount;
 
     std::shared_ptr<PipelineCache> pipelineCache;
     std::vector<std::shared_ptr<ComputePipelineBase>> pipelines;

--- a/graph/shaders/graph_op/tosa/conv2d.comp
+++ b/graph/shaders/graph_op/tosa/conv2d.comp
@@ -29,7 +29,7 @@ layout(push_constant) uniform PushConstants {
     int32_t pad[4];
     int32_t stride[2];
     int32_t dilation[2];
-    uint32_t outputChannelOffset;
+    uint32_t outputPositionOffset[3];
 } pushConstants;
 
 layout(set = 0, binding = 0) uniform tensorARM<OUT_T, 4> outputData;
@@ -40,10 +40,11 @@ layout(set = 3, binding = 0) uniform tensorARM<OUT_T, 1> biasesData;
 void main() {
     ACC_T acc[4] = {ACC_T(0), ACC_T(0), ACC_T(0), ACC_T(0)};
     uint batches = tensorSizeARM(outputData, 0);
-    uint n = gl_GlobalInvocationID.x % batches;
-    uint ox = gl_GlobalInvocationID.x / batches;
-    uint oy = gl_GlobalInvocationID.y;
-    uint oc = pushConstants.outputChannelOffset + gl_GlobalInvocationID.z * 4;
+    uint batchWidth = pushConstants.outputPositionOffset[0] + gl_GlobalInvocationID.x;
+    uint n = batchWidth % batches;
+    uint ox = batchWidth / batches;
+    uint oy = pushConstants.outputPositionOffset[1] + gl_GlobalInvocationID.y;
+    uint oc = pushConstants.outputPositionOffset[2] + gl_GlobalInvocationID.z * 4;
     uint[4] ocs = {oc, oc + 1, oc + 2, oc + 3};
 
     if (oy >= tensorSizeARM(outputData, 1) ||

--- a/tests/shader/conv2d_large_height.spvasm
+++ b/tests/shader/conv2d_large_height.spvasm
@@ -1,0 +1,73 @@
+;
+; SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+; SPDX-License-Identifier: Apache-2.0
+;
+               OpCapability VulkanMemoryModel
+               OpCapability Shader
+               OpCapability Int8
+               OpCapability TensorsARM
+               OpCapability GraphARM
+               OpCapability ReplicatedCompositesEXT
+               OpExtension "SPV_ARM_tensors"
+               OpExtension "SPV_ARM_graph"
+               OpExtension "SPV_EXT_replicated_composites"
+         %45 = OpExtInstImport "TOSA.001000.1"
+               OpMemoryModel Logical Vulkan
+               OpName %conv2d_arg_0 "conv2d_arg_0"
+               OpName %conv2d_arg_1 "conv2d_arg_1"
+               OpName %conv2d_arg_2 "conv2d_arg_2"
+               OpName %conv2d_res_0 "conv2d_res_0"
+               OpDecorate %conv2d_arg_0 Binding 0
+               OpDecorate %conv2d_arg_0 DescriptorSet 0
+               OpDecorate %conv2d_arg_1 Binding 1
+               OpDecorate %conv2d_arg_1 DescriptorSet 0
+               OpDecorate %conv2d_arg_2 Binding 2
+               OpDecorate %conv2d_arg_2 DescriptorSet 0
+               OpDecorate %conv2d_res_0 Binding 3
+               OpDecorate %conv2d_res_0 DescriptorSet 0
+      %uchar = OpTypeInt 8 0
+       %uint = OpTypeInt 32 0
+     %uint_4 = OpConstant %uint 4
+%_arr_uint_uint_4 = OpTypeArray %uint %uint_4
+     %uint_1 = OpConstant %uint 1
+%uint_524281 = OpConstant %uint 524281
+          %7 = OpConstantComposite %_arr_uint_uint_4 %uint_1 %uint_524281 %uint_1 %uint_4
+          %2 = OpTypeTensorARM %uchar %uint_4 %7
+%_ptr_UniformConstant_2 = OpTypePointer UniformConstant %2
+%conv2d_arg_0 = OpVariable %_ptr_UniformConstant_2 UniformConstant
+         %14 = OpConstantComposite %_arr_uint_uint_4 %uint_4 %uint_1 %uint_1 %uint_4
+         %13 = OpTypeTensorARM %uchar %uint_4 %14
+%_ptr_UniformConstant_13 = OpTypePointer UniformConstant %13
+%conv2d_arg_1 = OpVariable %_ptr_UniformConstant_13 UniformConstant
+%_arr_uint_uint_1 = OpTypeArray %uint %uint_1
+         %20 = OpConstantComposite %_arr_uint_uint_1 %uint_4
+         %18 = OpTypeTensorARM %uint %uint_1 %20
+%_ptr_UniformConstant_18 = OpTypePointer UniformConstant %18
+%conv2d_arg_2 = OpVariable %_ptr_UniformConstant_18 UniformConstant
+         %24 = OpConstantComposite %_arr_uint_uint_4 %uint_1 %uint_524281 %uint_1 %uint_4
+         %23 = OpTypeTensorARM %uint %uint_4 %24
+%_ptr_UniformConstant_23 = OpTypePointer UniformConstant %23
+%conv2d_res_0 = OpVariable %_ptr_UniformConstant_23 UniformConstant
+         %27 = OpTypeGraphARM 3 %2 %13 %18 %23
+     %uint_0 = OpConstant %uint 0
+         %33 = OpConstantComposite %_arr_uint_uint_1 %uint_4
+         %32 = OpTypeTensorARM %uint %uint_1 %33
+         %34 = OpConstantNull %32
+     %uint_2 = OpConstant %uint 2
+         %36 = OpConstantComposite %_arr_uint_uint_1 %uint_2
+         %35 = OpTypeTensorARM %uint %uint_1 %36
+         %37 = OpConstantCompositeReplicateEXT %35 %uint_1
+         %38 = OpConstantCompositeReplicateEXT %35 %uint_1
+       %bool = OpTypeBool
+      %false = OpConstantFalse %bool
+         %42 = OpConstantComposite %_arr_uint_uint_1 %uint_1
+         %41 = OpTypeTensorARM %uchar %uint_1 %42
+         %43 = OpConstantNull %41
+               OpGraphEntryPointARM %26 "conv2d" %conv2d_arg_0 %conv2d_arg_1 %conv2d_arg_2 %conv2d_res_0
+         %26 = OpGraphARM %27
+         %28 = OpGraphInputARM %2 %uint_0
+         %30 = OpGraphInputARM %13 %uint_1
+         %31 = OpGraphInputARM %18 %uint_2
+         %44 = OpExtInst %23 %45 CONV2D %34 %37 %38 %uint_1 %false %28 %30 %31 %43 %43
+               OpGraphSetOutputARM %44 %uint_0
+               OpGraphEndARM

--- a/tests/shader/conv2d_large_width.spvasm
+++ b/tests/shader/conv2d_large_width.spvasm
@@ -1,0 +1,73 @@
+;
+; SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+; SPDX-License-Identifier: Apache-2.0
+;
+               OpCapability VulkanMemoryModel
+               OpCapability Shader
+               OpCapability Int8
+               OpCapability TensorsARM
+               OpCapability GraphARM
+               OpCapability ReplicatedCompositesEXT
+               OpExtension "SPV_ARM_tensors"
+               OpExtension "SPV_ARM_graph"
+               OpExtension "SPV_EXT_replicated_composites"
+         %45 = OpExtInstImport "TOSA.001000.1"
+               OpMemoryModel Logical Vulkan
+               OpName %conv2d_arg_0 "conv2d_arg_0"
+               OpName %conv2d_arg_1 "conv2d_arg_1"
+               OpName %conv2d_arg_2 "conv2d_arg_2"
+               OpName %conv2d_res_0 "conv2d_res_0"
+               OpDecorate %conv2d_arg_0 Binding 0
+               OpDecorate %conv2d_arg_0 DescriptorSet 0
+               OpDecorate %conv2d_arg_1 Binding 1
+               OpDecorate %conv2d_arg_1 DescriptorSet 0
+               OpDecorate %conv2d_arg_2 Binding 2
+               OpDecorate %conv2d_arg_2 DescriptorSet 0
+               OpDecorate %conv2d_res_0 Binding 3
+               OpDecorate %conv2d_res_0 DescriptorSet 0
+      %uchar = OpTypeInt 8 0
+       %uint = OpTypeInt 32 0
+     %uint_4 = OpConstant %uint 4
+%_arr_uint_uint_4 = OpTypeArray %uint %uint_4
+     %uint_1 = OpConstant %uint 1
+%uint_524281 = OpConstant %uint 524281
+          %7 = OpConstantComposite %_arr_uint_uint_4 %uint_1 %uint_1 %uint_524281 %uint_4
+          %2 = OpTypeTensorARM %uchar %uint_4 %7
+%_ptr_UniformConstant_2 = OpTypePointer UniformConstant %2
+%conv2d_arg_0 = OpVariable %_ptr_UniformConstant_2 UniformConstant
+         %14 = OpConstantComposite %_arr_uint_uint_4 %uint_4 %uint_1 %uint_1 %uint_4
+         %13 = OpTypeTensorARM %uchar %uint_4 %14
+%_ptr_UniformConstant_13 = OpTypePointer UniformConstant %13
+%conv2d_arg_1 = OpVariable %_ptr_UniformConstant_13 UniformConstant
+%_arr_uint_uint_1 = OpTypeArray %uint %uint_1
+         %20 = OpConstantComposite %_arr_uint_uint_1 %uint_4
+         %18 = OpTypeTensorARM %uint %uint_1 %20
+%_ptr_UniformConstant_18 = OpTypePointer UniformConstant %18
+%conv2d_arg_2 = OpVariable %_ptr_UniformConstant_18 UniformConstant
+         %24 = OpConstantComposite %_arr_uint_uint_4 %uint_1 %uint_1 %uint_524281 %uint_4
+         %23 = OpTypeTensorARM %uint %uint_4 %24
+%_ptr_UniformConstant_23 = OpTypePointer UniformConstant %23
+%conv2d_res_0 = OpVariable %_ptr_UniformConstant_23 UniformConstant
+         %27 = OpTypeGraphARM 3 %2 %13 %18 %23
+     %uint_0 = OpConstant %uint 0
+         %33 = OpConstantComposite %_arr_uint_uint_1 %uint_4
+         %32 = OpTypeTensorARM %uint %uint_1 %33
+         %34 = OpConstantNull %32
+     %uint_2 = OpConstant %uint 2
+         %36 = OpConstantComposite %_arr_uint_uint_1 %uint_2
+         %35 = OpTypeTensorARM %uint %uint_1 %36
+         %37 = OpConstantCompositeReplicateEXT %35 %uint_1
+         %38 = OpConstantCompositeReplicateEXT %35 %uint_1
+       %bool = OpTypeBool
+      %false = OpConstantFalse %bool
+         %42 = OpConstantComposite %_arr_uint_uint_1 %uint_1
+         %41 = OpTypeTensorARM %uchar %uint_1 %42
+         %43 = OpConstantNull %41
+               OpGraphEntryPointARM %26 "conv2d" %conv2d_arg_0 %conv2d_arg_1 %conv2d_arg_2 %conv2d_res_0
+         %26 = OpGraphARM %27
+         %28 = OpGraphInputARM %2 %uint_0
+         %30 = OpGraphInputARM %13 %uint_1
+         %31 = OpGraphInputARM %18 %uint_2
+         %44 = OpExtInst %23 %45 CONV2D %34 %37 %38 %uint_1 %false %28 %30 %31 %43 %43
+               OpGraphSetOutputARM %44 %uint_0
+               OpGraphEndARM

--- a/tests/vulkan.cpp
+++ b/tests/vulkan.cpp
@@ -1118,6 +1118,43 @@ TEST(MLEmulationLayerForVulkan, Conv2DDispatchesBeyondZWorkgroupLimit) {
     ASSERT_TRUE(outputTensor->compare(expected.data(), expected.size() * sizeof(expected[0]))) << "Output mismatch";
 }
 
+class Conv2DLargeSpatialDimension : public testing::TestWithParam<std::tuple<std::string, int64_t, int64_t>> {};
+
+TEST_P(Conv2DLargeSpatialDimension, DispatchesBeyondWorkgroupLimit) {
+    constexpr int64_t channels = 4;
+    const auto &[shaderFile, height, width] = GetParam();
+
+    auto device = createDevice();
+
+    auto inputTensor = std::make_shared<Tensor>(device, Shape{vk::Format::eR8Sint, {1, height, width, channels}});
+    std::fill(inputTensor->data(), inputTensor->data() + inputTensor->size(), 1);
+
+    auto weightTensor = std::make_shared<Tensor>(device, Shape{vk::Format::eR8Sint, {channels, 1, 1, channels}});
+    std::fill(weightTensor->data(), weightTensor->data() + weightTensor->size(), 1);
+
+    auto biasTensor = std::make_shared<Tensor>(device, Shape{vk::Format::eR32Sint, {channels}});
+    std::fill(biasTensor->data(), biasTensor->data() + biasTensor->size(), 0);
+
+    auto outputTensor = std::make_shared<Tensor>(device, Shape{vk::Format::eR32Sint, {1, height, width, channels}});
+    const GraphPipeline::DescriptorMap descriptorMap = {{
+        {0, {inputTensor}},
+        {1, {weightTensor}},
+        {2, {biasTensor}},
+        {3, {outputTensor}},
+    }};
+
+    const auto spirv = assembleSpirv(fileToString(shaderFile));
+    auto graphPipeline = std::make_shared<GraphPipeline>(device, descriptorMap, GraphConstants{}, spirv);
+    graphPipeline->dispatchSubmit();
+
+    const std::vector<int32_t> expected(static_cast<size_t>(height * width * channels), channels);
+    ASSERT_TRUE(outputTensor->compare(expected.data(), expected.size() * sizeof(expected[0]))) << "Output mismatch";
+}
+
+INSTANTIATE_TEST_SUITE_P(MLEmulationLayerForVulkan, Conv2DLargeSpatialDimension,
+                         testing::Values(std::make_tuple("conv2d_large_width.spvasm", 1, 524281),
+                                         std::make_tuple("conv2d_large_height.spvasm", 524281, 1)));
+
 TEST(MLEmulationLayerForVulkan, Conv2DAccumulatorInt64) {
     auto device = createDevice();
 


### PR DESCRIPTION
Respect all three physical-device workgroup count limits and pass invocation offsets to the Conv2D shader for split X, Y, and Z dispatches Add large-width and large-height regression coverage.

Change-Id: I6c273dbc90b7cd2f4bddcd958310340e87e00b14