### PR TITLE
build: Run unit tests in parallel with bounded concurrency

### DIFF
--- a/scripts/build.py
+++ b/scripts/build.py
@@ -315,11 +315,17 @@ class Builder:
                 subprocess.run(cmake_install_cmd, check=True)
 
             if self.run_tests and not self.cross_compile:
+                # Each test process creates a Vulkan device. Three workers perform nearly as
+                # well as four while reducing resource pressure; higher concurrency can
+                # regress performance or cause device initialization failures.
+                test_threads = min(self.threads, 3)
                 test_cmd = [
                     "ctest",
                     "--test-dir",
                     str(self.test_dir),
                     "--output-on-failure",
+                    "--parallel",
+                    str(test_threads),
                 ]
 
                 subprocess.run(test_cmd, check=True)


### PR DESCRIPTION
Pass a capped parallelism level to CTest when running unit tests. Limit concurrency to three workers because each test process creates a device. Measurements show performance comparable to four workers while reducing resource pressure and avoiding device initialization failures at higher concurrency.
